### PR TITLE
Refine browser assistant chat UI

### DIFF
--- a/extensions/dsh-browser/panel/index.html
+++ b/extensions/dsh-browser/panel/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light" />
-    <meta name="theme-color" content="#f7f7f5" />
+    <meta name="theme-color" content="#f4f6fa" />
     <title>dsh 浏览器助手</title>
   </head>
   <body>

--- a/extensions/dsh-browser/src/panel/App.tsx
+++ b/extensions/dsh-browser/src/panel/App.tsx
@@ -33,6 +33,48 @@ const STATE_LABEL: Record<BridgeState, string> = {
   stopped: '未连接',
 }
 
+function SettingsIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 20 20" aria-hidden="true">
+      <path d="M10 7.35A2.65 2.65 0 1 0 10 12.65 2.65 2.65 0 0 0 10 7.35Z" />
+      <path d="M16.15 11.2a6.4 6.4 0 0 0 0-2.4l1.18-.91-1.5-2.6-1.4.57a6.3 6.3 0 0 0-2.08-1.2L12.15 3h-3l-.2 1.66a6.3 6.3 0 0 0-2.08 1.2l-1.4-.57-1.5 2.6 1.18.91a6.4 6.4 0 0 0 0 2.4l-1.18.91 1.5 2.6 1.4-.57a6.3 6.3 0 0 0 2.08 1.2l.2 1.66h3l.2-1.66a6.3 6.3 0 0 0 2.08-1.2l1.4.57 1.5-2.6-1.18-.91Z" />
+    </svg>
+  )
+}
+
+function PageIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 20 20" aria-hidden="true">
+      <path d="M5.25 2.75h6.1l3.4 3.4v11.1h-9.5V2.75Z" />
+      <path d="M11.25 2.9v3.35h3.35M7.7 10h4.6M7.7 13h4.6" />
+    </svg>
+  )
+}
+
+function SendIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 20 20" aria-hidden="true">
+      <path d="M10 15.5v-11M5.5 9 10 4.5 14.5 9" />
+    </svg>
+  )
+}
+
+function ToolIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 20 20" aria-hidden="true">
+      <path d="M12.1 3.35a4 4 0 0 0-4.75 5.27l-4.1 4.1a1.85 1.85 0 1 0 2.62 2.62l4.1-4.1a4 4 0 0 0 5.25-4.78l-2.45 2.45-1.9-.5-.5-1.9 2.45-2.45a4 4 0 0 0-.72-.71Z" />
+    </svg>
+  )
+}
+
+function BackIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 20 20" aria-hidden="true">
+      <path d="m12.5 4.5-5.5 5.5 5.5 5.5" />
+    </svg>
+  )
+}
+
 /**
  * One conversation row body. Memoized: rows are immutable (append/merge copy
  * the array but reuse row objects), so markdown is re-parsed only when a
@@ -45,6 +87,22 @@ const MessageBody = memo(function MessageBody({ row }: { row: Row }): React.JSX.
   return <pre>{row.text}</pre>
 })
 
+const ToolActivity = memo(function ToolActivity({ row }: { row: Row }): React.JSX.Element {
+  const running = row.status === 'running'
+  return (
+    <div className={`tool-activity ${running ? 'running' : 'complete'}`} role="status">
+      <span className="tool-icon"><ToolIcon /></span>
+      <span className="tool-copy">
+        <span className="tool-label">{running ? '正在操作页面' : '页面操作'}</span>
+        <span className="tool-summary">{row.text}</span>
+      </span>
+      <span className="tool-state" aria-label={running ? '进行中' : '已完成'}>
+        {running ? <span className="spinner" /> : '完成'}
+      </span>
+    </div>
+  )
+})
+
 export function App(): React.JSX.Element {
   const [api] = useState<PanelApi>(() => connectPanel())
   const [state, setState] = useState<BridgeState>('stopped')
@@ -54,6 +112,7 @@ export function App(): React.JSX.Element {
   const [rows, setRows] = useState<Row[]>([])
   const [input, setInput] = useState('')
   const [busy, setBusy] = useState(false)
+  const [working, setWorking] = useState(false)
   const [showSettings, setShowSettings] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const seqRef = useRef(0)
@@ -61,7 +120,6 @@ export function App(): React.JSX.Element {
   const scrollRef = useRef<HTMLDivElement | null>(null)
 
   const nextSeq = (): number => { seqRef.current += 1; return seqRef.current }
-
 
   // Settings: seed from storage, then let the panel own the form.
   useEffect(() => {
@@ -89,6 +147,7 @@ export function App(): React.JSX.Element {
       if (previous !== null && next !== previous && next === 'stopped') {
         sessionRef.current = null
         setRows([])
+        setWorking(false)
         setSessionEpoch((epoch) => epoch + 1)
       }
     })
@@ -129,19 +188,25 @@ export function App(): React.JSX.Element {
   // Auto-scroll to the newest row.
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight })
-  }, [rows])
+  }, [rows, working])
 
   /** Live frame handling: session events append rows; turn/end reconciles with history. */
   async function onFrame(frame: ServerFrame): Promise<void> {
     if (frame.t !== 'event') return
     const payload = frame.frame.payload as { sessionId?: string; event?: SessionEventView } | undefined
     if (payload?.sessionId !== sessionRef.current || payload.event === undefined) return
+    if (payload.event.type === 'turn/start') {
+      setWorking(true)
+      return
+    }
     const row = rowFromEvent(payload.event)
     if (row !== null) {
       setRows((prev) => appendLiveRow(prev, row.kind, row.text, nextSeq()))
+      if (row.kind === 'assistant') setWorking(false)
       return
     }
     if (payload.event.type === 'tool/call') {
+      setWorking(true)
       const summary = toolSummary(payload.event.data?.name ?? 'tool', payload.event.data?.arguments)
       setRows((prev) => appendLiveRow(prev, 'tool', summary, nextSeq()))
       return
@@ -151,7 +216,10 @@ export function App(): React.JSX.Element {
       setRows((prev) => completeLastTool(prev, nextSeq()))
       return
     }
-    if (payload.event.type === 'turn/end') await refreshHistory()
+    if (payload.event.type === 'turn/end') {
+      setWorking(false)
+      await refreshHistory()
+    }
   }
 
   async function refreshHistory(): Promise<void> {
@@ -176,12 +244,6 @@ export function App(): React.JSX.Element {
     }
   }
 
-  useEffect(() => {
-    if (state === 'connected' && sessionRef.current === null) {
-      void ensureSession()
-    }
-  }, [state, sessionEpoch])
-
   const sendingRef = useRef(false)
   async function send(textOverride?: string): Promise<void> {
     const text = (textOverride ?? input).trim()
@@ -190,6 +252,7 @@ export function App(): React.JSX.Element {
     sendingRef.current = true
     setInput('')
     setBusy(true)
+    setWorking(true)
     setError(null)
     // 不渲染乐观行：live user/message 事件即时回显，避免同一消息出现两行。
     try {
@@ -200,6 +263,7 @@ export function App(): React.JSX.Element {
       })
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause))
+      setWorking(false)
     } finally {
       setBusy(false)
       sendingRef.current = false
@@ -218,88 +282,126 @@ export function App(): React.JSX.Element {
   if (showSettings) {
     return (
       <div className="settings">
-        <h1>设置</h1>
-        <label>
-          桥地址
-          <input
-            value={settings?.bridgeUrl ?? ''}
-            onChange={(e) => setSettings((prev) => prev === null ? prev : { ...prev, bridgeUrl: e.target.value })}
-            placeholder="留空自动检测本机 dsh（3080/3081/3090）"
-          />
-        </label>
-        <label>
-          Token
-          <input
-            type="password"
-            value={settings?.token ?? ''}
-            onChange={(e) => setSettings((prev) => prev === null ? prev : { ...prev, token: e.target.value })}
-            placeholder="本地回环可留空；远程部署时填写"
-          />
-        </label>
-        <label>
-          页面内容共享
-          <select
-            value={settings?.sharePageContent ?? 'ask'}
-            onChange={(e) => setSettings((prev) => prev === null ? prev : { ...prev, sharePageContent: e.target.value as PanelSettings['sharePageContent'] })}
-          >
-            <option value="ask">每次询问</option>
-            <option value="auto">自动共享</option>
-            <option value="off">关闭</option>
-          </select>
-        </label>
-        <button onClick={saveSettings}>保存并连接</button>
-        <button onClick={() => setShowSettings(false)}>返回</button>
-        <p className="hint">默认零配置：地址留空时扩展自动探测本机 dsh，本地回环连接无需 token。
-          「页面快照」= 模型每次请求能看到的当前页面文字；当前上限 {caps?.snapshotMaxChars ?? 12000} 字符（dsh 插件配置 snapshotMaxChars 可调），超出部分会被截断。</p>
+        <div className="settings-heading">
+          <button className="icon-button" onClick={() => setShowSettings(false)} aria-label="返回对话"><BackIcon /></button>
+          <div>
+            <span className="eyebrow">偏好设置</span>
+            <h1>连接与隐私</h1>
+          </div>
+        </div>
+        <div className="settings-panel">
+          <label>
+            <span>桥地址</span>
+            <small>留空时自动检测本机服务</small>
+            <input
+              value={settings?.bridgeUrl ?? ''}
+              onChange={(e) => setSettings((prev) => prev === null ? prev : { ...prev, bridgeUrl: e.target.value })}
+              placeholder="自动检测 3080 / 3081 / 3090"
+            />
+          </label>
+          <label>
+            <span>Token</span>
+            <small>本地连接无需填写</small>
+            <input
+              type="password"
+              value={settings?.token ?? ''}
+              onChange={(e) => setSettings((prev) => prev === null ? prev : { ...prev, token: e.target.value })}
+              placeholder="远程部署时填写"
+            />
+          </label>
+          <label>
+            <span>页面内容共享</span>
+            <small>控制助手何时可以读取页面文字</small>
+            <select
+              value={settings?.sharePageContent ?? 'ask'}
+              onChange={(e) => setSettings((prev) => prev === null ? prev : { ...prev, sharePageContent: e.target.value as PanelSettings['sharePageContent'] })}
+            >
+              <option value="ask">每次询问</option>
+              <option value="auto">自动共享</option>
+              <option value="off">关闭</option>
+            </select>
+          </label>
+        </div>
+        <div className="settings-actions">
+          <button className="primary" onClick={saveSettings}>保存并连接</button>
+          <button className="secondary" onClick={() => setShowSettings(false)}>取消</button>
+        </div>
+        <p className="hint">页面快照上限为 {caps?.snapshotMaxChars ?? 12000} 字符，超出内容会被截断。可在 dsh 插件中调整 snapshotMaxChars。</p>
       </div>
     )
   }
 
   return (
     <div className="app">
-      <header>
-        <span className={`dot ${state}`} />
-        <span className="status" role="status">{statusText}</span>
-        <button className="ghost" onClick={() => setShowSettings(true)}>设置</button>
+      <header className="topbar">
+        <div className="brand">
+          <span className="brand-mark"><img src={whaleUrl} alt="" /></span>
+          <span className="brand-copy"><strong>浏览助手</strong><small>页面副驾驶</small></span>
+        </div>
+        <span className="connection" role="status"><span className={`dot ${state}`} />{statusText}</span>
+        <button className="icon-button" onClick={() => setShowSettings(true)} aria-label="打开设置" title="设置"><SettingsIcon /></button>
       </header>
-      <div className="page-chip">
-        <span title={pageInfo ?? undefined}>📄 当前页面: {pageInfo ?? '—'}</span>
-        <button className="ghost" disabled={state !== 'connected' || busy}
+      <section className="context-card" aria-label="当前页面">
+        <span className="context-icon"><PageIcon /></span>
+        <span className="context-copy">
+          <small>当前页面</small>
+          <strong title={pageInfo ?? undefined}>{pageInfo ?? '等待浏览器页面'}</strong>
+        </span>
+        <button className="context-action" disabled={state !== 'connected' || busy}
           onClick={() => { void send('请用 browser_snapshot 读取当前页面，然后告诉我页面上有什么，并等待我的指令。') }}>
           读取页面
         </button>
-      </div>
+      </section>
       <div className="messages" ref={scrollRef}>
-        {rows.length === 0 && (
+        {rows.length === 0 && !working && (
           <div className="empty">
-            <img className="empty-logo" src={whaleUrl} alt="DeepSeek" />
-            <p>连接 dsh 后开始对话。模型可读取并操作当前页面（纯文本模式）。</p>
+            <span className="empty-logo"><img src={whaleUrl} alt="" /></span>
+            <div>
+              <h1>把当前页面交给我</h1>
+              <p>我可以阅读页面、查找信息，也可以替你点击、填写和导航。</p>
+            </div>
+            <button disabled={state !== 'connected'}
+              onClick={() => { void send('请先概览当前页面，告诉我最重要的信息，并等待我的下一步指令。') }}>
+              先概览这个页面
+            </button>
           </div>
         )}
         {rows.map((row) => (
           <div key={row.seq} className={`row ${row.kind}`}>
-            <MessageBody row={row} />
+            {row.kind === 'assistant' && <span className="assistant-avatar"><img src={whaleUrl} alt="助手" /></span>}
+            {row.kind === 'tool' ? <ToolActivity row={row} /> : <MessageBody row={row} />}
           </div>
         ))}
-        {busy && <div className="row assistant"><div className="body md">…</div></div>}
+        {working && rows[rows.length - 1]?.status !== 'running' && (
+          <div className="ai-progress" role="status" aria-label="助手正在处理">
+            <span className="assistant-avatar"><img src={whaleUrl} alt="" /></span>
+            <span className="progress-dots" aria-hidden="true"><i /><i /><i /></span>
+            <span>{rows[rows.length - 1]?.kind === 'tool' ? '正在整理结果' : '正在思考'}</span>
+          </div>
+        )}
       </div>
       {error !== null && <div className="error">{error}</div>}
-      <footer>
-        <textarea
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={(e) => {
-            // isComposing：输入法组词中的回车是确认选字，不是发送。
-            if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
-              e.preventDefault()
-              void send()
-            }
-          }}
-          placeholder={state === 'connected' ? '输入消息，Enter 发送' : '请先在设置中配置并连接 dsh'}
-          disabled={state !== 'connected'}
-          rows={3}
-        />
-        <button onClick={() => void send()} disabled={state !== 'connected' || busy || input.trim() === ''}>发送</button>
+      <footer className="composer">
+        <div className="composer-box">
+          <textarea
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              // isComposing：输入法组词中的回车是确认选字，不是发送。
+              if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+                e.preventDefault()
+                void send()
+              }
+            }}
+            placeholder={state === 'connected' ? '告诉我想在这个页面做什么…' : '连接 dsh 后即可开始'}
+            disabled={state !== 'connected'}
+            rows={2}
+          />
+          <div className="composer-actions">
+            <span>Enter 发送 · Shift + Enter 换行</span>
+            <button onClick={() => void send()} disabled={state !== 'connected' || busy || input.trim() === ''} aria-label="发送消息"><SendIcon /></button>
+          </div>
+        </div>
       </footer>
     </div>
   )

--- a/extensions/dsh-browser/src/panel/events.ts
+++ b/extensions/dsh-browser/src/panel/events.ts
@@ -12,6 +12,7 @@ export interface Row {
   seq: number
   kind: 'user' | 'assistant' | 'tool' | 'info'
   text: string
+  status?: 'running' | 'complete'
 }
 
 /** Minimal view of a SessionEvent (payload in `data`). */
@@ -46,18 +47,37 @@ export function rowFromEvent(event: SessionEventView): Row | null {
       // 渲染会污染对话流，必须跳过。
       const source = (event.data as { source?: { kind?: string } } | undefined)?.source
       if (source?.kind !== 'user') return null
-      return { seq: 0, kind: 'user', text: textFromBlocks(event.data?.content) }
+      const text = textFromBlocks(event.data?.content)
+      return text.trim() === '' ? null : { seq: 0, kind: 'user', text }
     }
-    case 'assistant/message':
-      return { seq: 0, kind: 'assistant', text: textFromBlocks(event.data?.message?.content) }
+    case 'assistant/message': {
+      // 工具调用也会产生 assistant/message，但其 content 可能只有 tool_use
+      // 等非文本块。不要为这种中间事件渲染一个空的 AI 气泡。
+      const text = textFromBlocks(event.data?.message?.content)
+      return text.trim() === '' ? null : { seq: 0, kind: 'assistant', text }
+    }
     default:
       return null
   }
 }
 
-/** 工具调用的展示名：带 index 参数时附上（如 browser_click #7）。 */
+const TOOL_LABELS: Record<string, string> = {
+  browser_snapshot: '读取页面',
+  browser_click: '点击元素',
+  browser_type: '填写内容',
+  browser_press: '按下按键',
+  browser_scroll: '滚动页面',
+  browser_navigate: '打开页面',
+  browser_back: '返回上一页',
+  browser_forward: '前进下一页',
+  browser_reload: '刷新页面',
+  browser_get_text: '提取文字',
+  browser_wait: '等待页面',
+}
+
+/** 工具调用的友好展示名：带 index 参数时附上（如「点击元素 #7」）。 */
 export function toolSummary(name: string, argsJson: unknown): string {
-  let summary = `⚙ ${name}`
+  let summary = TOOL_LABELS[name] ?? name
   try {
     const args = JSON.parse(String(argsJson ?? '{}')) as unknown
     if (typeof args === 'object' && args !== null && 'index' in args) {
@@ -74,8 +94,9 @@ export function appendLiveRow(rows: Row[], kind: Row['kind'], text: string, seq:
   if (kind === 'tool') {
     const last = rows[rows.length - 1]
     if (last?.kind === 'tool') {
-      return [...rows.slice(0, -1), { seq, kind: 'tool', text: `${last.text} → ${text}` }]
+      return [...rows.slice(0, -1), { seq, kind: 'tool', text: `${last.text} → ${text}`, status: 'running' }]
     }
+    return [...rows, { seq, kind, text, status: 'running' }]
   }
   return [...rows, { seq, kind, text }]
 }
@@ -84,7 +105,7 @@ export function appendLiveRow(rows: Row[], kind: Row['kind'], text: string, seq:
 export function completeLastTool(rows: Row[], seq: number): Row[] {
   const last = rows[rows.length - 1]
   if (last?.kind === 'tool') {
-    return [...rows.slice(0, -1), { ...last, seq, text: `${last.text} ✓` }]
+    return [...rows.slice(0, -1), { ...last, seq, status: 'complete' }]
   }
   return rows
 }
@@ -99,7 +120,7 @@ export function mergeHistoryRows(events: SessionEventView[], nextSeq: () => numb
     const label = pendingTool.total > shown.length
       ? `${shown.join(' → ')} 等${pendingTool.total}个工具`
       : shown.join(' → ')
-    rows.push({ seq: nextSeq(), kind: 'tool', text: label })
+    rows.push({ seq: nextSeq(), kind: 'tool', text: label, status: 'complete' })
     pendingTool = null
   }
   for (const ev of events) {

--- a/extensions/dsh-browser/src/panel/styles.css
+++ b/extensions/dsh-browser/src/panel/styles.css
@@ -1,32 +1,35 @@
 :root {
   color-scheme: light;
-  --canvas: #f7f7f5;
+  --canvas: #f4f6fa;
+  --canvas-deep: #edf0f6;
   --surface: #ffffff;
-  --surface-subtle: #f1f1ee;
-  --text: #20201f;
-  --text-muted: #6f6f6a;
-  --text-faint: #92928c;
-  --border: #e7e7e2;
-  --border-strong: #d8d8d2;
-  --accent: #10a37f;
-  --accent-hover: #0d8f70;
-  --accent-soft: #e9f7f2;
-  --accent-ink: #0a5d49;
+  --ink: #182033;
+  --ink-strong: #101828;
+  --muted: #667085;
+  --faint: #98a2b3;
+  --line: #dce2ec;
+  --line-strong: #cbd3e1;
+  --blue: #4d6bfe;
+  --blue-hover: #3c57e8;
+  --blue-ink: #2945c7;
+  --blue-soft: #e9eeff;
+  --blue-wash: #f6f8ff;
+  --navy: #172033;
   --danger: #b42318;
-  --danger-soft: #fef3f2;
+  --danger-soft: #fff4f2;
   --danger-border: #fecdca;
-  --warning: #c78a24;
-  --shadow-soft: 0 1px 2px rgba(32, 32, 31, 0.04), 0 4px 16px rgba(32, 32, 31, 0.025);
-  --focus-ring: 0 0 0 3px rgba(16, 163, 127, 0.14);
+  --warning: #d08a17;
+  --shadow: 0 10px 28px rgba(23, 32, 51, 0.08), 0 2px 6px rgba(23, 32, 51, 0.04);
+  --focus-ring: 0 0 0 3px rgba(77, 107, 254, 0.18);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI Variable Text", "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
   font-size: 14px;
-  font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI Variable Text", "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
 }
 
 * {
   box-sizing: border-box;
-  scrollbar-color: #c9c9c3 transparent;
+  scrollbar-color: #bcc4d2 transparent;
   scrollbar-width: thin;
 }
 
@@ -41,7 +44,7 @@ body {
   margin: 0;
   overflow: hidden;
   background: var(--canvas);
-  color: var(--text);
+  color: var(--ink);
   -webkit-font-smoothing: antialiased;
 }
 
@@ -66,7 +69,7 @@ textarea:focus-visible {
 }
 
 ::selection {
-  background: rgba(16, 163, 127, 0.18);
+  background: rgba(77, 107, 254, 0.2);
 }
 
 ::-webkit-scrollbar {
@@ -79,14 +82,9 @@ textarea:focus-visible {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #c9c9c3;
   border: 1px solid transparent;
   border-radius: 999px;
-  background-clip: padding-box;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: #adada6;
+  background: #bcc4d2;
   background-clip: padding-box;
 }
 
@@ -101,123 +99,233 @@ textarea:focus-visible {
   background: var(--canvas);
 }
 
-header {
+.topbar {
   display: flex;
-  min-height: 48px;
+  min-height: 58px;
   flex: 0 0 auto;
   align-items: center;
-  gap: 8px;
-  padding: 9px 12px 9px 14px;
-  background: rgba(255, 255, 255, 0.94);
-  border-bottom: 1px solid var(--border);
+  gap: 10px;
+  padding: 10px 14px;
+  border-bottom: 1px solid rgba(203, 211, 225, 0.72);
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.brand {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  align-items: center;
+  gap: 9px;
+}
+
+.brand-mark {
+  display: grid;
+  width: 31px;
+  height: 31px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid #dbe2ff;
+  border-radius: 10px;
+  background: var(--blue-soft);
+}
+
+.brand-mark img {
+  width: 22px;
+  height: 22px;
+  object-fit: contain;
+}
+
+.brand-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.brand-copy strong,
+.settings h1 {
+  font-family: "Avenir Next", "Segoe UI Variable Display", "PingFang SC", sans-serif;
+}
+
+.brand-copy strong {
+  color: var(--ink-strong);
+  font-size: 13.5px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+
+.brand-copy small {
+  color: var(--faint);
+  font-size: 9.5px;
+  font-weight: 650;
+  letter-spacing: 0.12em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.connection {
+  display: inline-flex;
+  min-height: 26px;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--muted);
+  font-size: 10.5px;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
 }
 
 .dot {
-  width: 7px;
-  height: 7px;
+  width: 6px;
+  height: 6px;
   flex: 0 0 auto;
   border-radius: 50%;
-  background: var(--text-faint);
-  box-shadow: 0 0 0 3px rgba(146, 146, 140, 0.1);
+  background: var(--faint);
   transition: background-color 150ms ease, box-shadow 150ms ease;
 }
 
 .dot.connected {
-  background: var(--accent);
-  box-shadow: 0 0 0 3px rgba(16, 163, 127, 0.12);
+  background: #22a06b;
+  box-shadow: 0 0 0 3px rgba(34, 160, 107, 0.12);
 }
 
 .dot.connecting,
 .dot.reconnecting {
   background: var(--warning);
-  box-shadow: 0 0 0 3px rgba(199, 138, 36, 0.12);
+  box-shadow: 0 0 0 3px rgba(208, 138, 23, 0.12);
   animation: status-pulse 1.8s ease-in-out infinite;
 }
 
-.dot.stopped {
-  background: var(--text-faint);
-}
-
-.status {
-  min-width: 0;
-  flex: 1;
-  overflow: hidden;
-  color: var(--text-muted);
-  font-size: 12px;
-  font-weight: 500;
-  letter-spacing: 0.005em;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-button.ghost {
-  min-height: 30px;
+.icon-button {
+  display: grid;
+  width: 32px;
+  height: 32px;
   flex: 0 0 auto;
-  padding: 5px 9px;
+  padding: 0;
+  place-items: center;
   border: 1px solid transparent;
-  border-radius: 9px;
+  border-radius: 10px;
   background: transparent;
-  color: var(--text-muted);
+  color: var(--muted);
   cursor: pointer;
-  font-size: 12px;
-  font-weight: 550;
-  line-height: 1;
-  transition: background-color 150ms ease, border-color 150ms ease, color 150ms ease, transform 150ms ease;
+  transition: border-color 150ms ease, background-color 150ms ease, color 150ms ease, transform 150ms ease;
 }
 
-button.ghost:hover:not(:disabled) {
-  border-color: var(--border);
-  background: var(--surface-subtle);
-  color: var(--text);
+.icon-button svg {
+  width: 17px;
+  height: 17px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.55;
 }
 
-button.ghost:active:not(:disabled) {
+.icon-button:hover {
+  border-color: var(--line);
+  background: var(--canvas);
+  color: var(--ink);
+}
+
+.icon-button:active {
   transform: translateY(1px);
 }
 
-button.ghost:disabled {
-  color: var(--text-faint);
-  cursor: default;
-  opacity: 0.55;
-}
-
-.page-chip {
+.context-card {
   display: flex;
   min-width: 0;
   flex: 0 0 auto;
   align-items: center;
-  gap: 8px;
-  margin: 10px 12px 0;
-  padding: 6px 7px 6px 10px;
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  background: var(--surface);
-  box-shadow: var(--shadow-soft);
-  color: var(--text-muted);
-  font-size: 12px;
+  gap: 10px;
+  margin: 12px 14px 0;
+  padding: 10px 10px 10px 12px;
+  border: 1px solid #222d43;
+  border-radius: 16px;
+  background: var(--navy);
+  box-shadow: 0 8px 20px rgba(23, 32, 51, 0.14);
+  color: #ffffff;
 }
 
-.page-chip > span {
+.context-icon {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #bac7ff;
+}
+
+.context-icon svg {
+  width: 17px;
+  height: 17px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.45;
+}
+
+.context-copy {
+  display: flex;
   min-width: 0;
   flex: 1;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.context-copy small {
+  color: #8f9bb0;
+  font-size: 9.5px;
+  font-weight: 650;
+  letter-spacing: 0.11em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.context-copy strong {
   overflow: hidden;
-  font-weight: 500;
+  color: #f8faff;
+  font-size: 11.5px;
+  font-weight: 600;
+  line-height: 1.35;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.page-chip .ghost {
-  min-height: 28px;
-  border-color: var(--border);
-  border-radius: 8px;
-  background: var(--canvas);
-  color: var(--accent-ink);
+.context-action {
+  min-height: 30px;
+  flex: 0 0 auto;
+  padding: 6px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.13);
+  border-radius: 9px;
+  background: #ffffff;
+  color: var(--navy);
+  cursor: pointer;
+  font-size: 10.5px;
+  font-weight: 700;
+  line-height: 1;
+  transition: background-color 150ms ease, color 150ms ease, transform 150ms ease;
 }
 
-.page-chip .ghost:hover:not(:disabled) {
-  border-color: rgba(16, 163, 127, 0.28);
-  background: var(--accent-soft);
-  color: var(--accent-ink);
+.context-action:hover:not(:disabled) {
+  background: #dce4ff;
+  color: var(--blue-ink);
+  transform: translateY(-1px);
+}
+
+.context-action:disabled {
+  background: rgba(255, 255, 255, 0.1);
+  color: #738097;
+  cursor: default;
 }
 
 .messages {
@@ -225,49 +333,92 @@ button.ghost:disabled {
   min-height: 0;
   flex: 1;
   flex-direction: column;
-  gap: 14px;
+  gap: 18px;
   overflow-y: auto;
   overscroll-behavior: contain;
-  padding: 18px 12px 22px;
+  padding: 24px 16px 28px;
   scroll-behavior: smooth;
   scrollbar-gutter: stable;
 }
 
 .empty {
   display: flex;
-  max-width: 250px;
+  width: 100%;
+  max-width: 285px;
   flex: 1;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 14px;
+  gap: 18px;
   margin: 0 auto;
-  padding: 32px 4px 56px;
-  color: var(--text-faint);
-  font-size: 12px;
-  line-height: 1.65;
+  padding: 30px 8px 54px;
   text-align: center;
+}
+
+.empty-logo {
+  display: grid;
+  width: 58px;
+  height: 58px;
+  place-items: center;
+  border: 1px solid #d7dfff;
+  border-radius: 19px;
+  background: var(--blue-soft);
+  box-shadow: 0 10px 26px rgba(77, 107, 254, 0.13);
+}
+
+.empty-logo img {
+  width: 42px;
+  height: 42px;
+  object-fit: contain;
+}
+
+.empty h1 {
+  margin: 0 0 7px;
+  color: var(--ink-strong);
+  font-family: "Avenir Next", "Segoe UI Variable Display", "PingFang SC", sans-serif;
+  font-size: 20px;
+  font-weight: 720;
+  letter-spacing: -0.035em;
+  line-height: 1.25;
 }
 
 .empty p {
   margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.65;
 }
 
-.empty-logo {
-  display: block;
-  width: 48px;
-  height: 48px;
-  padding: 7px;
-  border: 1px solid rgba(64, 128, 255, 0.16);
-  border-radius: 15px;
-  background: linear-gradient(160deg, #eef4fe, #e0ecfd);
-  box-shadow: 0 4px 14px rgba(64, 128, 255, 0.16);
-  object-fit: contain;
+.empty button {
+  min-height: 36px;
+  padding: 8px 14px;
+  border: 1px solid #ced8ff;
+  border-radius: 11px;
+  background: var(--surface);
+  color: var(--blue-ink);
+  cursor: pointer;
+  font-size: 11.5px;
+  font-weight: 680;
+  box-shadow: 0 4px 12px rgba(23, 32, 51, 0.05);
+  transition: border-color 150ms ease, background-color 150ms ease, transform 150ms ease;
+}
+
+.empty button:hover:not(:disabled) {
+  border-color: #aebeff;
+  background: var(--blue-wash);
+  transform: translateY(-1px);
+}
+
+.empty button:disabled {
+  border-color: var(--line);
+  color: var(--faint);
+  cursor: default;
 }
 
 .row {
   display: flex;
   width: 100%;
+  min-width: 0;
   flex: 0 0 auto;
   justify-content: flex-start;
 }
@@ -275,13 +426,11 @@ button.ghost:disabled {
 .row pre,
 .row .body {
   width: fit-content;
-  max-width: 85%;
+  max-width: calc(100% - 38px);
   margin: 0;
-  padding: 10px 12px;
-  border-radius: 14px 14px 14px 5px;
   font-family: inherit;
   font-size: 13px;
-  line-height: 1.58;
+  line-height: 1.65;
   overflow-wrap: anywhere;
   word-break: break-word;
 }
@@ -295,33 +444,140 @@ button.ghost:disabled {
 }
 
 .row.user .body {
-  border: 1px solid rgba(16, 163, 127, 0.1);
-  border-radius: 14px 14px 5px 14px;
-  background: var(--accent-soft);
-  color: var(--accent-ink);
+  max-width: 86%;
+  padding: 10px 13px;
+  border: 1px solid #d7dfff;
+  border-radius: 15px 15px 5px 15px;
+  background: var(--blue-soft);
+  color: #24345e;
+  box-shadow: 0 2px 8px rgba(77, 107, 254, 0.05);
+}
+
+.row.assistant {
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.assistant-avatar {
+  display: grid;
+  width: 27px;
+  height: 27px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid #d8e0ff;
+  border-radius: 9px;
+  background: var(--surface);
+  box-shadow: 0 3px 10px rgba(23, 32, 51, 0.06);
+}
+
+.assistant-avatar img {
+  width: 20px;
+  height: 20px;
+  object-fit: contain;
 }
 
 .row.assistant .body {
-  border: 1px solid var(--border);
-  background: var(--surface);
-  box-shadow: 0 1px 2px rgba(32, 32, 31, 0.025);
-  color: var(--text);
+  padding: 2px 2px 0 0;
+  color: var(--ink);
 }
 
 .row.tool {
-  border-left: 2px solid rgba(16, 163, 127, 0.34);
-  margin: 1px 0 1px 4px;
-  padding-left: 7px;
+  position: relative;
+  padding-left: 37px;
 }
 
-.row.tool pre {
-  max-width: calc(100% - 8px);
-  padding: 2px 4px;
-  border-radius: 4px;
-  color: var(--text-faint);
-  font-family: ui-monospace, "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+.row.tool::before {
+  position: absolute;
+  top: -18px;
+  bottom: -18px;
+  left: 13px;
+  width: 1px;
+  background: #d5ddfb;
+  content: "";
+}
+
+.tool-activity {
+  display: flex;
+  width: min(100%, 410px);
+  min-width: 0;
+  align-items: center;
+  gap: 9px;
+  padding: 8px 9px;
+  border: 1px solid #dfe5f5;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.tool-activity.running {
+  border-color: #ccd6ff;
+  background: var(--blue-wash);
+}
+
+.tool-icon {
+  display: grid;
+  width: 26px;
+  height: 26px;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 8px;
+  background: var(--blue-soft);
+  color: var(--blue);
+}
+
+.tool-icon svg {
+  width: 15px;
+  height: 15px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.55;
+}
+
+.tool-copy {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.tool-label {
+  color: var(--faint);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+
+.tool-summary {
+  overflow: hidden;
+  color: #45506a;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
   font-size: 10.5px;
-  line-height: 1.5;
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tool-state {
+  min-width: 26px;
+  flex: 0 0 auto;
+  color: var(--faint);
+  font-size: 9.5px;
+  font-weight: 650;
+  text-align: right;
+}
+
+.spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 1.5px solid #c6d0ff;
+  border-top-color: var(--blue);
+  border-radius: 50%;
+  animation: spin 800ms linear infinite;
 }
 
 .row.info {
@@ -331,17 +587,14 @@ button.ghost:disabled {
 .row.info pre {
   max-width: 92%;
   padding: 3px 8px;
-  color: var(--text-faint);
+  color: var(--faint);
   font-size: 11px;
   line-height: 1.5;
   text-align: center;
 }
 
-.row.assistant:last-child .body:only-child {
-  min-width: 38px;
-}
-
-/* Markdown 内容排版（用户/助手气泡内） */
+/* Markdown content is deliberately open for assistant responses, while user
+   messages inherit their compact command-card container. */
 .row .body.md > :first-child {
   margin-top: 0;
 }
@@ -351,24 +604,27 @@ button.ghost:disabled {
 }
 
 .row .body.md p {
-  margin: 0 0 8px;
+  margin: 0 0 9px;
 }
 
 .row .body.md h1,
 .row .body.md h2,
 .row .body.md h3,
 .row .body.md h4 {
-  margin: 12px 0 6px;
-  font-weight: 680;
+  margin: 14px 0 7px;
+  color: var(--ink-strong);
+  font-family: "Avenir Next", "Segoe UI Variable Display", "PingFang SC", sans-serif;
+  font-weight: 700;
+  letter-spacing: -0.02em;
   line-height: 1.3;
 }
 
 .row .body.md h1 {
-  font-size: 16px;
+  font-size: 17px;
 }
 
 .row .body.md h2 {
-  font-size: 15px;
+  font-size: 15.5px;
 }
 
 .row .body.md h3 {
@@ -381,173 +637,233 @@ button.ghost:disabled {
 
 .row .body.md ul,
 .row .body.md ol {
-  margin: 0 0 8px;
+  margin: 0 0 9px;
   padding-left: 20px;
 }
 
 .row .body.md li {
-  margin: 2px 0;
+  margin: 3px 0;
+  padding-left: 1px;
 }
 
 .row .body.md code {
   padding: 1.5px 5px;
-  border-radius: 6px;
-  background: var(--surface-subtle);
-  font-family: ui-monospace, "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-  font-size: 12px;
+  border: 1px solid #e1e5ed;
+  border-radius: 5px;
+  background: #eef1f6;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 11.5px;
 }
 
 .row .body.md pre {
   max-width: 100%;
-  margin: 8px 0;
-  padding: 10px 12px;
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  background: var(--surface-subtle);
+  margin: 9px 0;
+  padding: 11px 12px;
+  border: 1px solid #2a3448;
+  border-radius: 11px;
+  background: var(--navy);
+  color: #eef2ff;
   overflow-x: auto;
   white-space: pre;
 }
 
 .row .body.md pre code {
   padding: 0;
+  border: 0;
   background: transparent;
-  font-size: 12px;
-  line-height: 1.55;
+  color: inherit;
+  font-size: 11px;
+  line-height: 1.6;
 }
 
 .row .body.md a {
-  color: var(--accent-ink);
+  color: var(--blue-ink);
+  font-weight: 550;
   text-decoration: underline;
-  text-underline-offset: 2px;
+  text-decoration-color: #aebcff;
+  text-underline-offset: 3px;
 }
 
 .row .body.md blockquote {
-  margin: 8px 0;
-  padding: 2px 0 2px 10px;
-  border-left: 3px solid var(--border-strong);
-  color: var(--text-muted);
+  margin: 9px 0;
+  padding: 3px 0 3px 11px;
+  border-left: 3px solid #b8c5ff;
+  color: var(--muted);
 }
 
 .row .body.md table {
   display: block;
-  margin: 8px 0;
+  margin: 9px 0;
   border-collapse: collapse;
   overflow-x: auto;
-  font-size: 12px;
+  font-size: 11.5px;
   white-space: nowrap;
 }
 
 .row .body.md th,
 .row .body.md td {
-  padding: 4px 8px;
-  border: 1px solid var(--border);
+  padding: 5px 8px;
+  border: 1px solid var(--line);
   text-align: left;
 }
 
 .row .body.md th {
-  background: var(--surface-subtle);
-  font-weight: 600;
+  background: var(--canvas-deep);
+  font-weight: 650;
 }
 
 .row .body.md hr {
-  margin: 12px 0;
-  border: none;
-  border-top: 1px solid var(--border);
+  margin: 14px 0;
+  border: 0;
+  border-top: 1px solid var(--line);
+}
+
+.ai-progress {
+  display: flex;
+  min-height: 28px;
+  align-items: center;
+  gap: 9px;
+  color: var(--faint);
+  font-size: 10.5px;
+  line-height: 1;
+}
+
+.progress-dots {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.progress-dots i {
+  display: block;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--blue);
+  animation: thinking 1.15s ease-in-out infinite;
+}
+
+.progress-dots i:nth-child(2) {
+  animation-delay: 130ms;
+}
+
+.progress-dots i:nth-child(3) {
+  animation-delay: 260ms;
 }
 
 .error {
   flex: 0 0 auto;
-  margin: 0 12px 8px;
+  margin: 0 14px 8px;
   padding: 9px 11px;
   border: 1px solid var(--danger-border);
   border-radius: 11px;
   background: var(--danger-soft);
   color: var(--danger);
-  font-size: 12px;
+  font-size: 11.5px;
   line-height: 1.45;
   overflow-wrap: anywhere;
 }
 
-footer {
-  display: flex;
+.composer {
   flex: 0 0 auto;
-  align-items: flex-end;
-  gap: 8px;
-  padding: 10px 12px 12px;
-  border-top: 1px solid var(--border);
-  background: rgba(255, 255, 255, 0.96);
+  padding: 8px 12px 12px;
+  background: var(--canvas);
 }
 
-footer textarea {
-  min-width: 0;
-  min-height: 66px;
-  max-height: 144px;
-  flex: 1;
-  resize: none;
-  padding: 10px 11px;
-  border: 1px solid var(--border-strong);
-  border-radius: 12px;
-  outline: none;
+.composer-box {
+  overflow: hidden;
+  border: 1px solid var(--line-strong);
+  border-radius: 17px;
   background: var(--surface);
-  color: var(--text);
-  font-size: 13px;
-  line-height: 1.45;
-  transition: border-color 150ms ease, box-shadow 150ms ease, background-color 150ms ease;
+  box-shadow: var(--shadow);
+  transition: border-color 150ms ease, box-shadow 150ms ease;
 }
 
-footer textarea::placeholder,
+.composer-box:focus-within {
+  border-color: #aebcff;
+  box-shadow: 0 0 0 3px rgba(77, 107, 254, 0.1), var(--shadow);
+}
+
+.composer textarea {
+  display: block;
+  width: 100%;
+  min-height: 55px;
+  max-height: 150px;
+  padding: 12px 13px 7px;
+  resize: none;
+  border: 0;
+  outline: none;
+  background: transparent;
+  color: var(--ink);
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+
+.composer textarea::placeholder,
 .settings input::placeholder {
-  color: var(--text-faint);
+  color: var(--faint);
   opacity: 1;
 }
 
-footer textarea:hover:not(:disabled) {
-  border-color: #c7c7c0;
-}
-
-footer textarea:focus {
-  border-color: var(--accent);
-  box-shadow: var(--focus-ring);
-}
-
-footer textarea:disabled {
-  border-color: var(--border);
-  background: var(--surface-subtle);
-  color: var(--text-muted);
+.composer textarea:disabled {
+  color: var(--muted);
   cursor: not-allowed;
 }
 
-footer button {
-  min-width: 64px;
-  min-height: 36px;
-  padding: 8px 14px;
-  border: 1px solid var(--accent);
-  border-radius: 999px;
-  background: var(--accent);
-  color: #ffffff;
-  cursor: pointer;
-  font-size: 13px;
-  font-weight: 650;
-  line-height: 1;
-  box-shadow: 0 2px 8px rgba(16, 163, 127, 0.16);
-  transition: background-color 150ms ease, border-color 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+.composer-actions {
+  display: flex;
+  min-height: 37px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 4px 6px 6px 13px;
 }
 
-footer button:hover:not(:disabled) {
-  border-color: var(--accent-hover);
-  background: var(--accent-hover);
-  box-shadow: 0 4px 12px rgba(16, 163, 127, 0.2);
+.composer-actions > span {
+  overflow: hidden;
+  color: var(--faint);
+  font-size: 9.5px;
+  line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.composer-actions button {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  flex: 0 0 auto;
+  padding: 0;
+  place-items: center;
+  border: 1px solid var(--blue);
+  border-radius: 10px;
+  background: var(--blue);
+  color: #ffffff;
+  cursor: pointer;
+  box-shadow: 0 4px 10px rgba(77, 107, 254, 0.22);
+  transition: background-color 150ms ease, border-color 150ms ease, transform 150ms ease;
+}
+
+.composer-actions button svg {
+  width: 16px;
+  height: 16px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+}
+
+.composer-actions button:hover:not(:disabled) {
+  border-color: var(--blue-hover);
+  background: var(--blue-hover);
   transform: translateY(-1px);
 }
 
-footer button:active:not(:disabled) {
-  transform: translateY(0);
-}
-
-footer button:disabled {
-  border-color: var(--border-strong);
-  background: var(--surface-subtle);
-  color: var(--text-faint);
+.composer-actions button:disabled {
+  border-color: #e3e7ee;
+  background: #e8ebf1;
+  color: #aeb6c4;
   cursor: default;
   box-shadow: none;
 }
@@ -558,35 +874,80 @@ footer button:disabled {
   min-height: 100vh;
   min-height: 100dvh;
   flex-direction: column;
-  gap: 12px;
+  gap: 16px;
   overflow-y: auto;
-  padding: 20px 16px 24px;
+  padding: 18px 16px 24px;
   background: var(--canvas);
 }
 
+.settings-heading {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+}
+
+.settings-heading .icon-button {
+  border-color: var(--line);
+  background: var(--surface);
+}
+
+.settings-heading > div {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.eyebrow {
+  color: var(--blue);
+  font-size: 9.5px;
+  font-weight: 750;
+  letter-spacing: 0.12em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
 .settings h1 {
-  margin: 0 0 4px;
-  color: var(--text);
+  margin: 0;
+  color: var(--ink-strong);
   font-size: 19px;
-  font-weight: 680;
-  letter-spacing: -0.025em;
-  line-height: 1.3;
+  font-weight: 720;
+  letter-spacing: -0.035em;
+  line-height: 1.25;
+}
+
+.settings-panel {
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: var(--surface);
+  box-shadow: 0 6px 18px rgba(23, 32, 51, 0.05);
 }
 
 .settings label {
-  display: flex;
+  display: grid;
   min-width: 0;
-  flex-direction: column;
-  gap: 8px;
-  padding: 12px;
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  background: var(--surface);
-  box-shadow: var(--shadow-soft);
-  color: var(--text-muted);
+  grid-template-columns: 1fr auto;
+  gap: 3px 10px;
+  padding: 13px;
+  border-bottom: 1px solid var(--line);
+}
+
+.settings label:last-child {
+  border-bottom: 0;
+}
+
+.settings label > span {
+  color: var(--ink);
   font-size: 12px;
-  font-weight: 600;
+  font-weight: 680;
   line-height: 1.35;
+}
+
+.settings label > small {
+  color: var(--faint);
+  font-size: 9.5px;
+  line-height: 1.4;
+  text-align: right;
 }
 
 .settings input,
@@ -594,110 +955,141 @@ footer button:disabled {
   width: 100%;
   min-width: 0;
   min-height: 38px;
+  grid-column: 1 / -1;
+  margin-top: 7px;
   padding: 8px 10px;
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--line-strong);
   border-radius: 10px;
   outline: none;
-  background: var(--surface);
-  color: var(--text);
-  font-size: 13px;
+  background: var(--canvas);
+  color: var(--ink);
+  font-size: 12px;
   font-weight: 400;
   line-height: 1.3;
   transition: border-color 150ms ease, box-shadow 150ms ease, background-color 150ms ease;
 }
 
-.settings select {
-  cursor: pointer;
-}
-
 .settings input:hover,
 .settings select:hover {
-  border-color: #c7c7c0;
+  border-color: #adb7c7;
 }
 
 .settings input:focus,
 .settings select:focus {
-  border-color: var(--accent);
+  border-color: var(--blue);
+  background: var(--surface);
   box-shadow: var(--focus-ring);
 }
 
-.settings button {
-  min-height: 40px;
-  padding: 9px 14px;
-  border: 1px solid var(--accent);
-  border-radius: 11px;
-  background: var(--accent);
-  color: #ffffff;
-  cursor: pointer;
-  font-size: 13px;
-  font-weight: 650;
-  box-shadow: 0 2px 8px rgba(16, 163, 127, 0.14);
-  transition: background-color 150ms ease, border-color 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+.settings-actions {
+  display: grid;
+  grid-template-columns: 1fr 0.65fr;
+  gap: 9px;
 }
 
-.settings button:hover {
-  border-color: var(--accent-hover);
-  background: var(--accent-hover);
-  box-shadow: 0 4px 12px rgba(16, 163, 127, 0.18);
+.settings-actions button {
+  min-height: 40px;
+  padding: 9px 13px;
+  border-radius: 11px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 680;
+  transition: background-color 150ms ease, border-color 150ms ease, transform 150ms ease;
+}
+
+.settings-actions .primary {
+  border: 1px solid var(--blue);
+  background: var(--blue);
+  color: #ffffff;
+  box-shadow: 0 5px 14px rgba(77, 107, 254, 0.18);
+}
+
+.settings-actions .secondary {
+  border: 1px solid var(--line-strong);
+  background: var(--surface);
+  color: var(--muted);
+}
+
+.settings-actions button:hover {
   transform: translateY(-1px);
 }
 
-.settings button:active {
-  transform: translateY(0);
+.settings-actions .primary:hover {
+  border-color: var(--blue-hover);
+  background: var(--blue-hover);
 }
 
-.settings button + button {
-  border-color: var(--border-strong);
-  background: var(--surface);
-  color: var(--text-muted);
-  box-shadow: none;
-}
-
-.settings button + button:hover {
-  border-color: #c7c7c0;
-  background: var(--surface-subtle);
-  color: var(--text);
-  box-shadow: none;
+.settings-actions .secondary:hover {
+  border-color: #adb7c7;
+  color: var(--ink);
 }
 
 .hint {
-  margin: 2px 2px 0;
-  color: var(--text-faint);
-  font-size: 11px;
+  margin: -3px 2px 0;
+  color: var(--faint);
+  font-size: 10px;
   line-height: 1.55;
 }
 
 @keyframes status-pulse {
   0%,
   100% {
-    box-shadow: 0 0 0 3px rgba(199, 138, 36, 0.1);
+    box-shadow: 0 0 0 3px rgba(208, 138, 23, 0.1);
   }
 
   50% {
-    box-shadow: 0 0 0 5px rgba(199, 138, 36, 0.04);
+    box-shadow: 0 0 0 5px rgba(208, 138, 23, 0.04);
+  }
+}
+
+@keyframes thinking {
+  0%,
+  70%,
+  100% {
+    opacity: 0.3;
+    transform: translateY(0);
+  }
+
+  35% {
+    opacity: 1;
+    transform: translateY(-2px);
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
   }
 }
 
 @media (max-width: 340px) {
-  header {
+  .topbar {
     padding-inline: 10px;
   }
 
-  .page-chip {
+  .brand-copy small,
+  .connection {
+    display: none;
+  }
+
+  .context-card {
     margin-inline: 9px;
   }
 
   .messages {
-    padding-inline: 9px;
+    padding-inline: 10px;
   }
 
-  footer {
-    padding-inline: 9px;
+  .composer {
+    padding-inline: 8px;
   }
 
-  .row pre,
-  .row .body {
-    max-width: 88%;
+  .row.user .body {
+    max-width: 90%;
+  }
+
+  .tool-state {
+    display: none;
   }
 }
 

--- a/extensions/dsh-browser/tests/panel-events.spec.ts
+++ b/extensions/dsh-browser/tests/panel-events.spec.ts
@@ -44,6 +44,15 @@ describe('rowFromEvent', () => {
     expect(row).toEqual({ seq: 0, kind: 'assistant', text: '好的' })
   })
 
+  it('skips assistant events that contain only tool or blank blocks', () => {
+    expect(rowFromEvent(ev('assistant/message', {
+      message: { content: [{ type: 'tool_use', name: 'browser_snapshot' }] },
+    }))).toBeNull()
+    expect(rowFromEvent(ev('assistant/message', {
+      message: { content: [{ type: 'text', text: '   \n' }] },
+    }))).toBeNull()
+  })
+
   it('returns null for non-message events', () => {
     expect(rowFromEvent(ev('turn/start', {}))).toBeNull()
     expect(rowFromEvent(ev('tool/call', { name: 'browser_click' }))).toBeNull()
@@ -52,9 +61,10 @@ describe('rowFromEvent', () => {
 
 describe('toolSummary', () => {
   it('appends the inventory index when present', () => {
-    expect(toolSummary('browser_click', '{"index":7}')).toBe('⚙ browser_click #7')
-    expect(toolSummary('browser_snapshot', '{"delta":true}')).toBe('⚙ browser_snapshot')
-    expect(toolSummary('browser_navigate', 'not-json')).toBe('⚙ browser_navigate')
+    expect(toolSummary('browser_click', '{"index":7}')).toBe('点击元素 #7')
+    expect(toolSummary('browser_snapshot', '{"delta":true}')).toBe('读取页面')
+    expect(toolSummary('browser_navigate', 'not-json')).toBe('打开页面')
+    expect(toolSummary('custom_tool', '{}')).toBe('custom_tool')
   })
 })
 
@@ -62,12 +72,12 @@ describe('appendLiveRow / completeLastTool', () => {
   it('merges consecutive tool rows into one line (no tool spam)', () => {
     let rows: ReturnType<typeof appendLiveRow> = []
     rows = appendLiveRow(rows, 'user', '帮我操作页面', 1)
-    rows = appendLiveRow(rows, 'tool', '⚙ browser_snapshot', 2)
-    rows = appendLiveRow(rows, 'tool', '⚙ browser_click #7', 3)
-    rows = appendLiveRow(rows, 'tool', '⚙ browser_type #9', 4)
+    rows = appendLiveRow(rows, 'tool', '读取页面', 2)
+    rows = appendLiveRow(rows, 'tool', '点击元素 #7', 3)
+    rows = appendLiveRow(rows, 'tool', '填写内容 #9', 4)
     rows = completeLastTool(rows, 5)
     expect(rows.map((r) => r.kind)).toEqual(['user', 'tool'])
-    expect(rows[1]!.text).toBe('⚙ browser_snapshot → ⚙ browser_click #7 → ⚙ browser_type #9 ✓')
+    expect(rows[1]).toMatchObject({ text: '读取页面 → 点击元素 #7 → 填写内容 #9', status: 'complete' })
     rows = appendLiveRow(rows, 'assistant', '完成', 6)
     expect(rows.map((r) => r.kind)).toEqual(['user', 'tool', 'assistant'])
   })
@@ -94,7 +104,17 @@ describe('mergeHistoryRows', () => {
     expect(rows[0]!.text).toBe('操作页面')
     expect(rows[2]!.text).toBe('已点击')
     // 连续工具调用归并一行（不逐条刷屏）
-    expect(rows[1]!.text).toBe('⚙ browser_snapshot → ⚙ browser_click #7 → ⚙ browser_click #8')
+    expect(rows[1]).toMatchObject({ text: '读取页面 → 点击元素 #7 → 点击元素 #8', status: 'complete' })
+  })
+
+  it('does not restore empty assistant rows from history', () => {
+    let seq = 0
+    const rows = mergeHistoryRows([
+      ev('assistant/message', { message: { content: [{ type: 'tool_use', name: 'browser_snapshot' }] } }),
+      ev('tool/call', { name: 'browser_snapshot', arguments: '{}' }),
+      ev('tool/result', {}),
+    ], () => { seq += 1; return seq })
+    expect(rows).toEqual([{ seq: 1, kind: 'tool', text: '读取页面', status: 'complete' }])
   })
 
   it('handles empty history', () => {


### PR DESCRIPTION
## What changed

- redesign the Chrome side-panel as a focused browser-assistant workspace
- distinguish user commands, assistant responses, and browser tool activity
- filter assistant events with no visible text so tool calls no longer create empty chat bubbles
- add friendly localized tool labels and running/completed states
- improve responsive layout, keyboard focus, reduced-motion support, and settings presentation

## Why

Tool-only `assistant/message` events were rendered as ordinary assistant rows even though they contained no text. This produced empty message bubbles and split consecutive tool activity into noisy rows. The new event normalization drops those empty rows and presents tool calls on a dedicated activity track.

## Validation

- `pnpm --filter dsh-browser-extension typecheck`
- `pnpm --filter dsh-browser-extension test` (40 tests)
- `pnpm --filter dsh-browser-extension build`
- visual checks of the main side panel and settings page
