### PR TITLE
docs: clarify restart-after-install and add troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ curl -fsSL https://raw.githubusercontent.com/Lum1104/dsh-browser/refs/heads/main
 
 The remote installer downloads `main` into the installer-managed directory `~/.dsh/dsh-browser`, then installs the pinned public npm dependencies from the lockfile, builds the bridge plugin, registers its official bundle in dsh's local `web` profile, builds the extension, copies it to `~/.dsh/browser-extension`, and opens `chrome://extensions`. Enable Developer mode and load the extension directory when prompted. Running the same command again updates the managed installation; keep source edits in a clone instead.
 
+**Already running dsh? Restart it after installing.** The installer registers the bridge bundle in dsh's local `web` profile, and dsh loads its profile only at startup. An instance started before the install keeps running without the bridge, so the side panel reports "Not connected" even though the extension loaded correctly. Stop that instance and start it again (Step 2); the extension then discovers the bridge automatically and needs no reconfiguration.
+
 Developers can clone the repository and run the same installer from any checkout. This mode uses the current branch without downloading or overwriting source files:
 
 ```sh
@@ -83,7 +85,15 @@ Both commands load the same browser bundle from the local `web` profile. Port 30
 
 **Step 3 — use it**: open any normal `http://` or `https://` page and click the DeepSeek whale icon. When the side panel reports "Connected", chat normally or click "Read page" first. A page that was already open before the extension was installed or reloaded is instrumented automatically on the first action; no page refresh is needed. Browser-internal and protected pages such as `chrome://` and the Chrome Web Store cannot be read or operated.
 
-To update a managed installation, run the same `curl | bash` command again. To update a clone, pull or switch to the desired revision and run `./scripts/install.sh`. Then click Reload for "dsh Browser Assistant" in `chrome://extensions` and reopen the side panel. Chrome should load `~/.dsh/browser-extension`; do not load the source directory `extensions/dsh-browser/`.
+To update a managed installation, run the same `curl | bash` command again. To update a clone, pull or switch to the desired revision and run `./scripts/install.sh`. Then click Reload for "dsh Browser Assistant" in `chrome://extensions` and reopen the side panel. Chrome should load `~/.dsh/browser-extension`; do not load the source directory `extensions/dsh-browser/`. If dsh web is already running, restart it too so it reloads the updated `web` profile (see Troubleshooting).
+
+## Troubleshooting
+
+**Side panel stays "Not connected"**
+
+- Make sure dsh web is running locally (default `http://127.0.0.1:3080`).
+- Verify the bridge is loaded: open `http://127.0.0.1:3080/ext/bridge-config`. It should return JSON such as `{"wsUrl":"ws://127.0.0.1:3080/ext/bridge"}`. If it returns a web page instead of JSON, the running dsh predates the bridge registration — restart dsh and refresh the page; the extension reconnects on its own.
+- The extension probes ports 3080, 3081, and 3090 automatically. If dsh runs on another port — or you use a remote `--host 0.0.0.0` deployment — set the address (and bridge token) in the side panel settings.
 
 ## Development
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -53,6 +53,8 @@ curl -fsSL https://raw.githubusercontent.com/Lum1104/dsh-browser/refs/heads/main
 
 远程安装器会把 `main` 下载到脚本托管目录 `~/.dsh/dsh-browser`，然后按锁文件安装固定版本的公共 npm 依赖、构建桥插件、把它的官方 bundle 注册到 dsh 本机的 `web` profile、构建扩展、复制到 `~/.dsh/browser-extension`，并打开 `chrome://extensions`。按提示开启开发者模式并加载扩展目录即可。再次运行同一条命令会更新托管安装；如需修改源码，请使用 clone。
 
+**安装前 dsh 已在运行？装完请重启 dsh。** 安装器把桥接 bundle 注册进 dsh 本机的 `web` profile，而 dsh 只在启动时加载 profile。安装前就已启动的实例不会带上桥接，因此侧边栏会一直显示「未连接」——即使扩展已正确加载。停掉该实例并按第二步重新启动即可；扩展会自动发现桥接，无需重新配置。
+
 开发者也可以 clone 仓库，并在任意 checkout 中运行同一个安装器。该模式直接使用当前分支，不会下载或覆盖源码：
 
 ```sh
@@ -83,7 +85,15 @@ npx @deepseek-ai/dsh web
 
 **第三步：开始使用**：打开任意普通的 `http://` 或 `https://` 页面，点击工具栏的 DeepSeek 鲸鱼图标打开侧边栏；状态显示「已连接」后，可以直接对话，也可以先点「读取页面」。页面即使早于扩展安装或重载就已经打开，也会在第一次操作时自动补加载内容脚本，无需刷新页面。`chrome://`、Chrome Web Store 等浏览器内置或受保护页面不能注入扩展脚本，因此不支持读取和操作。
 
-更新托管安装时，再次运行同一条 `curl | bash` 命令。更新 clone 时，拉取或切换到所需版本，再运行 `./scripts/install.sh`。然后到 `chrome://extensions` 对「dsh 浏览器助手」点一次重新加载并重新打开侧边栏。Chrome 应加载脚本提示的稳定目录 `~/.dsh/browser-extension`；不要加载仓库中的源码目录 `extensions/dsh-browser/`。
+更新托管安装时，再次运行同一条 `curl | bash` 命令。更新 clone 时，拉取或切换到所需版本，再运行 `./scripts/install.sh`。然后到 `chrome://extensions` 对「dsh 浏览器助手」点一次重新加载并重新打开侧边栏。Chrome 应加载脚本提示的稳定目录 `~/.dsh/browser-extension`；不要加载仓库中的源码目录 `extensions/dsh-browser/`。若 dsh web 正在运行，也请重启它，使其重新加载更新后的 `web` profile（见「故障排查」）。
+
+## 故障排查
+
+**侧边栏一直显示「未连接」**
+
+- 确认本机 dsh web 正在运行（默认 `http://127.0.0.1:3080`）。
+- 确认桥接已加载：浏览器打开 `http://127.0.0.1:3080/ext/bridge-config`，应返回类似 `{"wsUrl":"ws://127.0.0.1:3080/ext/bridge"}` 的 JSON。如果返回的是网页而不是 JSON，说明当前运行的 dsh 早于桥接注册——重启 dsh 并刷新页面即可，扩展会自动重连。
+- 扩展会自动探测 3080/3081/3090 端口。若 dsh 运行在其它端口，或使用 `--host 0.0.0.0` 远程部署，请在侧边栏设置中填写地址与桥接 token。
 
 ## 开发
 


### PR DESCRIPTION
## What & why

The current README assumes the user runs the installer and then starts dsh. But when **dsh web is already running** at install time — a very common case for existing users — the freshly registered bridge bundle is **not** loaded, because dsh loads its `web` profile only at startup. The extension then shows **Not connected / 未连接** forever, even though the extension itself is installed and configured correctly.

Diagnosis: `GET http://127.0.0.1:3080/ext/bridge-config` returns the SPA HTML fallback instead of the expected JSON (`{"wsUrl":"ws://127.0.0.1:3080/ext/bridge"}`), so the extension's auto-discovery never finds a bridge. The fix is simply restarting dsh.

## Changes (README.md + README.zh.md)

1. **Step 1 callout**: if dsh was already running when you installed, restart it after installing — otherwise the side panel will keep reporting "Not connected".
2. **New Troubleshooting / 故障排查 section**: the "Not connected" checklist (dsh running? `/ext/bridge-config` returns JSON? port/settings notes), including the key tell — a web page instead of JSON means the running dsh predates the bridge registration.
3. **Update paragraph**: remind to restart dsh after an update as well.

Docs-only change; verified against the exact failure mode reported by a user.
