### PR TITLE
feat(panel): answer ask_user_question from the side panel and add a stop button

### DIFF
--- a/extensions/dsh-browser/src/background/index.ts
+++ b/extensions/dsh-browser/src/background/index.ts
@@ -7,9 +7,11 @@
  *
  * Panel port protocol (chrome.runtime.connect, name "dsh-panel"):
  *   panel → bg: { type: 'rpc', id, method, payload }
+ *   panel → bg: { type: 'respond', id, rpcId, result }
  *   panel → bg: { type: 'settings', settings: Partial<Settings> }
  *   panel → bg: { type: 'request-status' }
  *   bg → panel: { type: 'rpc.result', id, ok, result? | error? }
+ *   bg → panel: { type: 'respond.result', id, ok, result? | error? }
  *   bg → panel: { type: 'status', state: BridgeState, caps? }
  *   bg → panel: { type: 'event', frame: ServerFrame }
  *
@@ -17,6 +19,7 @@
  */
 
 import type { BridgeCaps } from '@deepseek-ai/dsh-bridge-browser/src/protocol.ts'
+import type { RespondResult } from '@deepseek-ai/dsh-bridge-browser/src/protocol.ts'
 import type { ServerFrame } from '@deepseek-ai/dsh-bridge-browser/src/protocol.ts'
 import { BRIDGE_CONFIG_PATH, BRIDGE_PATH } from '@deepseek-ai/dsh-bridge-browser/src/protocol.ts'
 import { BridgeClient, type BridgeState } from './bridge.ts'
@@ -112,6 +115,15 @@ function broadcastEvent(frame: ServerFrame): void {
   }
 }
 
+/** Relay an interaction-answer receipt from the bridge to every panel port. */
+function broadcastRespondResult(id: string, ok: boolean, result?: unknown, error?: { code: string; message: string }): void {
+  for (const port of panelPorts) {
+    try {
+      port.postMessage({ type: 'respond.result', id, ok, ...(ok ? { result } : { error }) })
+    } catch { /* port already closed */ }
+  }
+}
+
 /** 把协商的快照预算下发到活动标签页的 content script（配置生效）。 */
 async function pushBudgetToActiveTab(negotiated: BridgeCaps): Promise<void> {
   const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true })
@@ -171,6 +183,9 @@ async function startBridge(): Promise<void> {
       onFrame: (frame) => {
         if (frame.t === 'event') broadcastEvent(frame)
         else if (frame.t === 'tool.call') routeToolCall(frame)
+        else if (frame.t === 'respond.result') {
+          broadcastRespondResult(frame.id, frame.ok, frame.ok ? frame.result : undefined, frame.ok ? undefined : frame.error)
+        }
         // rpc.result is settled by the rpc facade (wrapped below).
       },
       onHelloOk: (negotiated) => {
@@ -221,6 +236,22 @@ chrome.runtime.onConnect.addListener((port) => {
             } catch { /* port closed */ }
           },
         )
+        break
+      }
+      case 'respond': {
+        const respondMsg = message as { id: string; rpcId: string; result: RespondResult }
+        if (bridge === null || !bridge.connected) {
+          try {
+            port.postMessage({
+              type: 'respond.result',
+              id: respondMsg.id,
+              ok: false,
+              error: { code: 'bridge-unavailable', message: '未连接 dsh（请检查设置中的地址与 token）' },
+            })
+          } catch { /* port closed */ }
+          break
+        }
+        bridge.send({ t: 'respond', id: respondMsg.id, rpcId: respondMsg.rpcId, result: respondMsg.result })
         break
       }
       case 'settings': {

--- a/extensions/dsh-browser/src/panel/App.tsx
+++ b/extensions/dsh-browser/src/panel/App.tsx
@@ -19,9 +19,14 @@ import whaleUrl from '../../assets/icons/deepseek-256.png'
 import {
   appendLiveRow,
   completeLastTool,
+  isQuestionResolvedFrame,
   mergeHistoryRows,
+  pendingQuestionFromFrame,
   rowFromEvent,
   toolSummary,
+  type EventFrameView,
+  type PendingQuestion,
+  type QuestionItem,
   type Row,
   type SessionEventView,
 } from './events.ts'
@@ -103,6 +108,106 @@ const ToolActivity = memo(function ToolActivity({ row }: { row: Row }): React.JS
   )
 })
 
+/** 单个问题的草稿：已选项 + 自定义答案。 */
+interface QuestionDraft {
+  selected: string[]
+  custom: string
+}
+
+/**
+ * 待回答问题卡片：agent 调用 ask_user_question 后，主界面会弹问题卡片，
+ * 但侧边栏此前看不到也答不了（表现为一直转圈）。这里把问题渲染出来，
+ * 答案通过桥的 /api/respond 通道回传。
+ */
+function QuestionCard({
+  question,
+  drafts,
+  draftOf,
+  onToggleOption,
+  onCustom,
+  onSubmit,
+  onCancel,
+  submitting,
+}: {
+  question: PendingQuestion
+  drafts: Record<string, QuestionDraft>
+  draftOf: (questionId: string) => QuestionDraft
+  onToggleOption: (item: QuestionItem, label: string, checked: boolean) => void
+  onCustom: (item: QuestionItem, value: string) => void
+  onSubmit: () => void
+  onCancel: () => void
+  submitting: boolean
+}): React.JSX.Element {
+  return (
+    <div className="question-card" role="status" aria-label="等待回答">
+      <div className="question-heading">
+        <span className="question-mark">?</span>
+        <div>
+          <span className="eyebrow">等待回答</span>
+          <h1>助手需要你确认</h1>
+        </div>
+      </div>
+      {question.questions.map((item, index) => {
+        const draft = draftOf(item.id)
+        const multi = item.multiSelect === true
+        return (
+          <div className="question-item" key={item.id}>
+            <div className="question-copy">
+              {question.questions.length > 1 && <span className="question-index">{index + 1}.</span>}
+              <strong>{item.header ?? item.question}</strong>
+              {item.detail !== undefined && item.detail !== '' && <small>{item.detail}</small>}
+            </div>
+            {Array.isArray(item.options) && item.options.length > 0 && (
+              <div className="question-options" role={multi ? 'group' : 'radiogroup'}>
+                {item.options.map((option) => {
+                  const checked = draft.selected.includes(option.label)
+                  return (
+                    <label key={option.label} className={`question-option ${checked ? 'checked' : ''}`}>
+                      <input
+                        type={multi ? 'checkbox' : 'radio'}
+                        name={`q-${item.id}`}
+                        checked={checked}
+                        onChange={(e) => onToggleOption(item, option.label, e.target.checked)}
+                      />
+                      <span className="question-option-copy">
+                        <span>{option.label}</span>
+                        {option.description !== undefined && option.description !== '' && <small>{option.description}</small>}
+                      </span>
+                    </label>
+                  )
+                })}
+              </div>
+            )}
+            <label className="question-custom">
+              <input
+                type="text"
+                placeholder="输入你的答案"
+                value={draft.custom}
+                disabled={submitting}
+                onChange={(e) => onCustom(item, e.target.value)}
+              />
+            </label>
+          </div>
+        )
+      })}
+      <div className="question-actions">
+        <button className="primary" onClick={onSubmit} disabled={submitting || !allQuestionsAnswered(question, drafts)}>
+          {submitting ? '提交中…' : '提交'}
+        </button>
+        <button className="secondary" onClick={onCancel} disabled={submitting}>放弃</button>
+      </div>
+    </div>
+  )
+}
+
+/** 提交按钮可用性：每个问题都必须已作答（选项或自定义答案）。 */
+function allQuestionsAnswered(question: PendingQuestion, drafts: Record<string, QuestionDraft>): boolean {
+  return question.questions.every((item) => {
+    const draft = drafts[item.id]
+    return draft !== undefined && (draft.selected.length > 0 || draft.custom.trim() !== '')
+  })
+}
+
 export function App(): React.JSX.Element {
   const [api] = useState<PanelApi>(() => connectPanel())
   const [state, setState] = useState<BridgeState>('stopped')
@@ -115,11 +220,105 @@ export function App(): React.JSX.Element {
   const [working, setWorking] = useState(false)
   const [showSettings, setShowSettings] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [question, setQuestion] = useState<PendingQuestion | null>(null)
+  const [questionDrafts, setQuestionDrafts] = useState<Record<string, QuestionDraft>>({})
+  const [submitting, setSubmitting] = useState(false)
+  const respondSeq = useRef(0)
   const seqRef = useRef(0)
   const sessionRef = useRef<string | null>(null)
   const scrollRef = useRef<HTMLDivElement | null>(null)
 
   const nextSeq = (): number => { seqRef.current += 1; return seqRef.current }
+
+  /** 单个问题的草稿（选项/自定义答案）。 */
+  const draftOf = (questionId: string): QuestionDraft => questionDrafts[questionId] ?? { selected: [], custom: '' }
+
+  const setDraft = (questionId: string, patch: Partial<QuestionDraft>): void => {
+    setQuestionDrafts((prev) => ({
+      ...prev,
+      [questionId]: { ...(prev[questionId] ?? { selected: [], custom: '' }), ...patch },
+    }))
+  }
+
+  const toggleOption = (item: QuestionItem, label: string, checked: boolean): void => {
+    const draft = draftOf(item.id)
+    if (item.multiSelect === true) {
+      const selected = checked
+        ? [...draft.selected, label]
+        : draft.selected.filter((existing) => existing !== label)
+      setDraft(item.id, { selected, custom: '' })
+    } else {
+      setDraft(item.id, { selected: checked ? [label] : [], custom: '' })
+    }
+  }
+
+  const changeCustom = (item: QuestionItem, value: string): void => {
+    const draft = draftOf(item.id)
+    // 自定义答案会清空单选（与主界面行为一致）；多选保留已选项。
+    setDraft(item.id, { selected: item.multiSelect === true ? draft.selected : [], custom: value })
+  }
+
+  /** 把答案回传给桥 /api/respond，解除 agent 的等待。 */
+  async function submitQuestion(): Promise<void> {
+    if (question === null || submitting) return
+    if (!allQuestionsAnswered(question, questionDrafts)) {
+      setError('请先完成这道问题。')
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    const answers = question.questions.map((item) => {
+      const draft = draftOf(item.id)
+      return { id: item.id, selected: draft.selected, ...(draft.custom.trim() !== '' ? { custom: draft.custom.trim() } : {}) }
+    })
+    try {
+      const receipt = await api.respond(`respond-${++respondSeq.current}`, question.rpcId, {
+        ok: true,
+        value: { sessionId: question.sessionId, answer: { answers } },
+      }) as { accepted?: boolean }
+      if (receipt.accepted === false) {
+        setError('问题应答被拒绝，可能已被处理。')
+        return
+      }
+      setQuestion(null)
+      setQuestionDrafts({})
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  /** 放弃整组问题（agent 的 ask_user_question 以 cancelled 结算）。 */
+  async function cancelQuestion(): Promise<void> {
+    if (question === null || submitting) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      await api.respond(`respond-${++respondSeq.current}`, question.rpcId, {
+        ok: false,
+        error: { code: 'cancelled', message: 'the user closed this question request' },
+      })
+      setQuestion(null)
+      setQuestionDrafts({})
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  /** 停止当前正在运行的 turn（等价于主界面的“停止生成”）。 */
+  async function stopTurn(): Promise<void> {
+    const id = sessionRef.current
+    if (id === null) return
+    setError(null)
+    try {
+      await api.rpc('session.cancel', { sessionId: id })
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause))
+    }
+  }
 
   // Settings: seed from storage, then let the panel own the form.
   useEffect(() => {
@@ -193,7 +392,24 @@ export function App(): React.JSX.Element {
   /** Live frame handling: session events append rows; turn/end reconciles with history. */
   async function onFrame(frame: ServerFrame): Promise<void> {
     if (frame.t !== 'event') return
-    const payload = frame.frame.payload as { sessionId?: string; event?: SessionEventView } | undefined
+    const inner = frame.frame as EventFrameView
+    // 待回答的问题：agent 卡在 ask_user_question 上。侧边栏必须能直接应答，
+    // 否则面板会一直显示“正在操作页面 ask_user_question”转圈（假死）。
+    const pending = pendingQuestionFromFrame(inner)
+    if (pending !== null) {
+      if (pending.sessionId === sessionRef.current) {
+        setQuestion(pending)
+        setQuestionDrafts({})
+        setError(null)
+      }
+      return
+    }
+    if (isQuestionResolvedFrame(inner)) {
+      setQuestion(null)
+      setQuestionDrafts({})
+      return
+    }
+    const payload = inner.payload as { sessionId?: string; event?: SessionEventView } | undefined
     if (payload?.sessionId !== sessionRef.current || payload.event === undefined) return
     if (payload.event.type === 'turn/start') {
       setWorking(true)
@@ -372,7 +588,7 @@ export function App(): React.JSX.Element {
             {row.kind === 'tool' ? <ToolActivity row={row} /> : <MessageBody row={row} />}
           </div>
         ))}
-        {working && rows[rows.length - 1]?.status !== 'running' && (
+        {working && question === null && rows[rows.length - 1]?.status !== 'running' && (
           <div className="ai-progress" role="status" aria-label="助手正在处理">
             <span className="assistant-avatar"><img src={whaleUrl} alt="" /></span>
             <span className="progress-dots" aria-hidden="true"><i /><i /><i /></span>
@@ -380,6 +596,18 @@ export function App(): React.JSX.Element {
           </div>
         )}
       </div>
+      {question !== null && (
+        <QuestionCard
+          question={question}
+          drafts={questionDrafts}
+          draftOf={draftOf}
+          onToggleOption={toggleOption}
+          onCustom={changeCustom}
+          onSubmit={() => void submitQuestion()}
+          onCancel={() => void cancelQuestion()}
+          submitting={submitting}
+        />
+      )}
       {error !== null && <div className="error">{error}</div>}
       <footer className="composer">
         <div className="composer-box">
@@ -399,7 +627,13 @@ export function App(): React.JSX.Element {
           />
           <div className="composer-actions">
             <span>Enter 发送 · Shift + Enter 换行</span>
-            <button onClick={() => void send()} disabled={state !== 'connected' || busy || input.trim() === ''} aria-label="发送消息"><SendIcon /></button>
+            {working ? (
+              <button className="stop" onClick={() => void stopTurn()} aria-label="停止生成" title="停止当前回合">
+                停止
+              </button>
+            ) : (
+              <button onClick={() => void send()} disabled={state !== 'connected' || busy || input.trim() === ''} aria-label="发送消息"><SendIcon /></button>
+            )}
           </div>
         </div>
       </footer>

--- a/extensions/dsh-browser/src/panel/api.ts
+++ b/extensions/dsh-browser/src/panel/api.ts
@@ -21,6 +21,14 @@ interface RpcResultMessage {
   error?: { code: string; message: string }
 }
 
+interface RespondResultMessage {
+  type: 'respond.result'
+  id: string
+  ok: boolean
+  result?: unknown
+  error?: { code: string; message: string }
+}
+
 interface StatusMessage {
   type: 'status'
   state: BridgeState
@@ -32,11 +40,16 @@ interface EventMessage {
   frame: ServerFrame
 }
 
-type BackgroundMessage = RpcResultMessage | StatusMessage | EventMessage
+type BackgroundMessage = RpcResultMessage | RespondResultMessage | StatusMessage | EventMessage
 
 /** The panel API surface. */
 export interface PanelApi {
   rpc<T = unknown>(method: string, payload?: unknown): Promise<T>
+  /**
+   * Answer a pending host interaction (user question / approval) by its rpcId.
+   * Resolves with the gateway's receipt ({ accepted }).
+   */
+  respond(id: string, rpcId: string, result: { ok: boolean; value?: unknown; error?: { code: string; message: string } }): Promise<unknown>
   onStatus(callback: (state: BridgeState, caps: BridgeCaps | null) => void): () => void
   onEvent(callback: (frame: ServerFrame) => void): () => void
   updateSettings(settings: Partial<PanelSettings>): void
@@ -47,6 +60,7 @@ export interface PanelApi {
 export function connectPanel(): PanelApi {
   const port = chrome.runtime.connect({ name: 'dsh-panel' })
   const pending = new Map<string, { resolve: (value: unknown) => void; reject: (error: Error) => void }>()
+  const pendingRespond = new Map<string, { resolve: (value: unknown) => void; reject: (error: Error) => void }>()
   const statusListeners = new Set<(state: BridgeState, caps: BridgeCaps | null) => void>()
   const eventListeners = new Set<(frame: ServerFrame) => void>()
 
@@ -70,6 +84,14 @@ export function connectPanel(): PanelApi {
       case 'status':
         for (const listener of statusListeners) listener(msg.state, msg.caps)
         break
+      case 'respond.result': {
+        const entry = pendingRespond.get(msg.id)
+        if (entry === undefined) return
+        pendingRespond.delete(msg.id)
+        if (msg.ok) entry.resolve(msg.result)
+        else entry.reject(new Error(msg.error?.message ?? 'respond failed'))
+        break
+      }
       case 'event':
         for (const listener of eventListeners) listener(msg.frame)
         break
@@ -80,6 +102,8 @@ export function connectPanel(): PanelApi {
     const error = new Error('background disconnected')
     for (const entry of pending.values()) entry.reject(error)
     pending.clear()
+    for (const entry of pendingRespond.values()) entry.reject(error)
+    pendingRespond.clear()
   })
 
   return {
@@ -88,6 +112,12 @@ export function connectPanel(): PanelApi {
       return new Promise<T>((resolve, reject) => {
         pending.set(id, { resolve: (value) => resolve(value as T), reject })
         port.postMessage({ type: 'rpc', id, method, payload })
+      })
+    },
+    respond(id, rpcId, result): Promise<unknown> {
+      return new Promise((resolve, reject) => {
+        pendingRespond.set(id, { resolve, reject })
+        port.postMessage({ type: 'respond', id, rpcId, result })
       })
     },
     onStatus(callback) {

--- a/extensions/dsh-browser/src/panel/events.ts
+++ b/extensions/dsh-browser/src/panel/events.ts
@@ -26,6 +26,58 @@ export interface SessionEventView {
   }
 }
 
+/** One option of a pending question (mirrors askUserQuestionItemSchema). */
+export interface QuestionOption {
+  label: string
+  description?: string
+}
+
+/** One item of a pending question batch. */
+export interface QuestionItem {
+  id: string
+  question: string
+  header?: string
+  detail?: string
+  options?: QuestionOption[]
+  multiSelect?: boolean
+}
+
+/** A pending host interaction rendered as a question card (question/requested). */
+export interface PendingQuestion {
+  /** The mux envelope rpcId, echoed back when answering. */
+  rpcId: string
+  sessionId: string
+  questions: QuestionItem[]
+}
+
+/** The event-frame shape the bridge relays for one mux envelope. */
+export interface EventFrameView {
+  rpcId: string
+  method: string
+  payload: unknown
+}
+
+/** Extract a pending question from a `question/requested` mux frame (or null). */
+export function pendingQuestionFromFrame(frame: EventFrameView): PendingQuestion | null {
+  if (frame.method !== 'question/requested') return null
+  if (typeof frame.payload !== 'object' || frame.payload === null) return null
+  const payload = frame.payload as { sessionId?: unknown; questions?: unknown }
+  if (typeof payload.sessionId !== 'string' || !Array.isArray(payload.questions)) return null
+  return { rpcId: frame.rpcId, sessionId: payload.sessionId, questions: payload.questions as QuestionItem[] }
+}
+
+/** Whether a mux frame marks an earlier question as resolved. */
+export function isQuestionResolvedFrame(frame: EventFrameView): boolean {
+  return frame.method === 'question/resolved'
+}
+
+/** Whether a mux frame is a session event for a given session (session/event). */
+export function isSessionEventFrame(frame: EventFrameView, sessionId: string): boolean {
+  if (typeof frame.payload !== 'object' || frame.payload === null) return false
+  const payload = frame.payload as { sessionId?: unknown; event?: unknown }
+  return payload.sessionId === sessionId && typeof payload.event === 'object' && payload.event !== null
+}
+
 /** Extract model-visible text from content blocks (defensive: unknown block shapes degrade to markers). */
 export function textFromBlocks(blocks: unknown): string {
   if (!Array.isArray(blocks)) return String(blocks ?? '')

--- a/extensions/dsh-browser/src/panel/styles.css
+++ b/extensions/dsh-browser/src/panel/styles.css
@@ -1103,3 +1103,223 @@ textarea:focus-visible {
     animation-iteration-count: 1 !important;
   }
 }
+
+/* ---- 待回答问题卡片（ask_user_question） ---- */
+
+.question-card {
+  flex: 0 0 auto;
+  margin: 0 14px 10px;
+  padding: 13px 14px 14px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.question-heading {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.question-mark {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 9px;
+  background: var(--blue-soft);
+  color: var(--blue-ink);
+  font-weight: 800;
+  font-size: 15px;
+}
+
+.question-heading .eyebrow {
+  display: block;
+  margin: 0;
+  font-size: 10.5px;
+}
+
+.question-heading h1 {
+  margin: 1px 0 0;
+  font-size: 14.5px;
+  font-weight: 680;
+  color: var(--ink-strong);
+}
+
+.question-item {
+  padding: 11px 12px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--canvas);
+}
+
+.question-item + .question-item {
+  margin-top: 8px;
+}
+
+.question-copy {
+  display: flex;
+  gap: 6px;
+  flex-direction: column;
+  margin-bottom: 9px;
+}
+
+.question-copy strong {
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--ink-strong);
+}
+
+.question-index {
+  color: var(--faint);
+  font-weight: 600;
+}
+
+.question-copy small {
+  color: var(--muted);
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.question-options {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.question-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--surface);
+  cursor: pointer;
+  transition: border-color 150ms ease, background-color 150ms ease;
+}
+
+.question-option:hover {
+  border-color: var(--line-strong);
+}
+
+.question-option.checked {
+  border-color: var(--blue);
+  background: var(--blue-wash);
+}
+
+.question-option input {
+  margin: 2px 0 0;
+  accent-color: var(--blue);
+  flex: 0 0 auto;
+}
+
+.question-option-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.question-option-copy span {
+  font-size: 12.5px;
+  line-height: 1.4;
+  color: var(--ink);
+}
+
+.question-option-copy small {
+  font-size: 11px;
+  color: var(--muted);
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.question-custom {
+  display: block;
+  margin-top: 8px;
+}
+
+.question-custom input {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--line-strong);
+  border-radius: 10px;
+  background: var(--surface);
+  font-size: 12.5px;
+  outline: none;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.question-custom input:focus {
+  border-color: var(--blue);
+  box-shadow: var(--focus-ring);
+}
+
+.question-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.question-actions .primary {
+  flex: 1;
+  padding: 8px 14px;
+  border: 1px solid var(--blue);
+  border-radius: 10px;
+  background: var(--blue);
+  color: #ffffff;
+  font-size: 12.5px;
+  font-weight: 650;
+  cursor: pointer;
+  transition: background-color 150ms ease, border-color 150ms ease;
+}
+
+.question-actions .primary:hover:not(:disabled) {
+  background: var(--blue-hover);
+  border-color: var(--blue-hover);
+}
+
+.question-actions .primary:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.question-actions .secondary {
+  padding: 8px 14px;
+  border: 1px solid var(--line-strong);
+  border-radius: 10px;
+  background: var(--surface);
+  color: var(--muted);
+  font-size: 12.5px;
+  cursor: pointer;
+  transition: border-color 150ms ease, color 150ms ease;
+}
+
+.question-actions .secondary:hover:not(:disabled) {
+  color: var(--ink);
+  border-color: var(--faint);
+}
+
+.question-actions .secondary:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+/* ---- 停止按钮（替代发送按钮，运行中显示） ---- */
+
+.composer-actions button.stop {
+  width: auto;
+  padding: 0 12px;
+  border-color: var(--danger);
+  background: var(--danger);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.composer-actions button.stop:hover:not(:disabled) {
+  border-color: #8f2d1f;
+  background: #8f2d1f;
+}

--- a/extensions/dsh-browser/tests/panel-events.spec.ts
+++ b/extensions/dsh-browser/tests/panel-events.spec.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from 'vitest'
 import {
   appendLiveRow,
   completeLastTool,
+  isQuestionResolvedFrame,
+  isSessionEventFrame,
   mergeHistoryRows,
+  pendingQuestionFromFrame,
   rowFromEvent,
   textFromBlocks,
   toolSummary,
@@ -119,5 +122,55 @@ describe('mergeHistoryRows', () => {
 
   it('handles empty history', () => {
     expect(mergeHistoryRows([], () => 0)).toEqual([])
+  })
+})
+
+describe('pendingQuestionFromFrame', () => {
+  it('extracts a pending question from a question/requested mux frame', () => {
+    const pending = pendingQuestionFromFrame({
+      rpcId: 'rpc-1',
+      method: 'question/requested',
+      payload: {
+        type: 'question/requested',
+        sessionId: 's1',
+        questions: [{
+          id: 'mention_target',
+          question: '评论区 @王世楷，指的是哪一位？',
+          header: '确认 @ 目标',
+          options: [{ label: '小鹏内部王世楷', description: '同部门' }, { label: 'Karry' }],
+        }],
+      },
+    })
+    expect(pending).toEqual({
+      rpcId: 'rpc-1',
+      sessionId: 's1',
+      questions: [{
+        id: 'mention_target',
+        question: '评论区 @王世楷，指的是哪一位？',
+        header: '确认 @ 目标',
+        options: [{ label: '小鹏内部王世楷', description: '同部门' }, { label: 'Karry' }],
+      }],
+    })
+  })
+
+  it('rejects non-question frames and malformed payloads', () => {
+    expect(pendingQuestionFromFrame({ rpcId: 'r', method: 'session/event', payload: { sessionId: 's', event: {} } })).toBeNull()
+    expect(pendingQuestionFromFrame({ rpcId: 'r', method: 'question/requested', payload: null })).toBeNull()
+    expect(pendingQuestionFromFrame({ rpcId: 'r', method: 'question/requested', payload: { sessionId: 5, questions: [] } })).toBeNull()
+    expect(pendingQuestionFromFrame({ rpcId: 'r', method: 'question/requested', payload: { sessionId: 's', questions: 'nope' } })).toBeNull()
+  })
+})
+
+describe('isQuestionResolvedFrame / isSessionEventFrame', () => {
+  it('recognizes question/resolved by method', () => {
+    expect(isQuestionResolvedFrame({ rpcId: 'r', method: 'question/resolved', payload: { type: 'question/resolved', sessionId: 's', questionRpcId: 'q' } })).toBe(true)
+    expect(isQuestionResolvedFrame({ rpcId: 'r', method: 'question/requested', payload: {} })).toBe(false)
+  })
+
+  it('recognizes session/event frames for the matching session', () => {
+    const frame = { rpcId: 'r', method: 'session/event', payload: { sessionId: 's1', event: { type: 'turn/start' } } }
+    expect(isSessionEventFrame(frame, 's1')).toBe(true)
+    expect(isSessionEventFrame(frame, 's2')).toBe(false)
+    expect(isSessionEventFrame({ rpcId: 'r', method: 'question/requested', payload: { sessionId: 's1' } }, 's1')).toBe(false)
   })
 })

--- a/packages/browser/bridge-browser/src/protocol.ts
+++ b/packages/browser/bridge-browser/src/protocol.ts
@@ -43,6 +43,15 @@ export interface ToolError {
   message: string
 }
 
+/**
+ * Answer payload for a pending host interaction (user question / approval).
+ * Mirrors the GUI's client-response `result` slot — the bridge adds the
+ * `client-response` envelope when it forwards the frame to `/api/respond`.
+ */
+export type RespondResult =
+  | { ok: true; value?: unknown }
+  | { ok: false; error: { code: string; message: string } }
+
 /** Capabilities negotiated in `hello`/`hello.ok`. The extension performs its own actions; these bounds shape page snapshots. */
 export interface BridgeCaps {
   /** The extension renders page state as text only (no screenshots). */
@@ -59,6 +68,8 @@ export type ClientFrame =
   | { t: 'hello'; token: string; caps: BridgeCaps }
   /** Unary gateway RPC passthrough (method names from the apiproxy RpcMethodMap). */
   | { t: 'rpc'; id: string; method: string; payload: unknown }
+  /** Answer a pending host interaction; the bridge relays it to /api/respond. */
+  | { t: 'respond'; id: string; rpcId: string; result: RespondResult }
   /** Result of a previously dispatched tool call. */
   | { t: 'tool.result'; id: string; ok: true; result: unknown }
   | { t: 'tool.result'; id: string; ok: false; error: ToolError }
@@ -72,6 +83,9 @@ export type ServerFrame =
   /** Reply to an `rpc` frame; `result` is the apiproxy ServerResponse envelope. */
   | { t: 'rpc.result'; id: string; ok: true; result: unknown }
   | { t: 'rpc.result'; id: string; ok: false; error: { code: string; message: string } }
+  /** Reply to a `respond` frame; `result` is the /api/respond receipt ({ accepted }). */
+  | { t: 'respond.result'; id: string; ok: true; result: unknown }
+  | { t: 'respond.result'; id: string; ok: false; error: { code: string; message: string } }
   /** One gateway event envelope (the same server-request shape the GUI's /api/events.mux carries). */
   | { t: 'event'; frame: { rpcId: string; method: string; payload: unknown } }
   /** A model-requested browser action to execute in the active tab. */
@@ -94,6 +108,7 @@ export type BridgeFrame = ClientFrame | ServerFrame
 export function isServerFrame(frame: BridgeFrame): frame is ServerFrame {
   return frame.t === 'hello.ok'
     || frame.t === 'rpc.result'
+    || frame.t === 'respond.result'
     || frame.t === 'event'
     || frame.t === 'tool.call'
     || frame.t === 'ping'
@@ -107,7 +122,7 @@ export function isServerFrame(frame: BridgeFrame): frame is ServerFrame {
  * @returns true for client-sendable frames.
  */
 export function isClientFrame(frame: BridgeFrame): frame is ClientFrame {
-  return frame.t === 'hello' || frame.t === 'rpc' || frame.t === 'tool.result' || frame.t === 'pong'
+  return frame.t === 'hello' || frame.t === 'rpc' || frame.t === 'respond' || frame.t === 'tool.result' || frame.t === 'pong'
 }
 
 /**
@@ -135,6 +150,10 @@ export function parseBridgeFrame(text: string): BridgeFrame | undefined {
       return typeof frame.id === 'string' && typeof frame.method === 'string'
         ? { t: 'rpc', id: frame.id, method: frame.method, payload: frame.payload }
         : undefined
+    case 'respond':
+      return typeof frame.id === 'string' && typeof frame.rpcId === 'string' && isRespondResult(frame.result)
+        ? { t: 'respond', id: frame.id, rpcId: frame.rpcId, result: frame.result }
+        : undefined
     case 'tool.result':
       if (typeof frame.id !== 'string') return undefined
       if (frame.ok === true && 'result' in frame) {
@@ -156,6 +175,14 @@ export function parseBridgeFrame(text: string): BridgeFrame | undefined {
       }
       return typeof frame.error === 'object' && frame.error !== null
         ? { t: 'rpc.result', id: frame.id, ok: false, error: frame.error as { code: string; message: string } }
+        : undefined
+    case 'respond.result':
+      if (typeof frame.id !== 'string') return undefined
+      if (frame.ok === true && 'result' in frame) {
+        return { t: 'respond.result', id: frame.id, ok: true, result: frame.result }
+      }
+      return typeof frame.error === 'object' && frame.error !== null
+        ? { t: 'respond.result', id: frame.id, ok: false, error: frame.error as { code: string; message: string } }
         : undefined
     case 'event':
       return typeof frame.frame === 'object' && frame.frame !== null
@@ -189,4 +216,11 @@ function isToolError(value: unknown): value is ToolError {
   return typeof value === 'object' && value !== null
     && typeof (value as Record<string, unknown>).code === 'string'
     && typeof (value as Record<string, unknown>).message === 'string'
+}
+
+function isRespondResult(value: unknown): value is RespondResult {
+  if (typeof value !== 'object' || value === null) return false
+  const result = value as Record<string, unknown>
+  if (result.ok === true && result.error === undefined) return true
+  return result.ok === false && isToolError(result.error)
 }

--- a/packages/browser/bridge-browser/src/server.ts
+++ b/packages/browser/bridge-browser/src/server.ts
@@ -323,6 +323,9 @@ export class BridgeServer {
       case 'rpc':
         void this.handleRpc(frame)
         break
+      case 'respond':
+        void this.handleRespond(frame)
+        break
       case 'tool.result':
         this.settleTool(frame.id, frame.ok, frame.ok ? frame.result : frame.error)
         break
@@ -330,6 +333,7 @@ export class BridgeServer {
       case 'hello':
       case 'hello.ok':
       case 'rpc.result':
+      case 'respond.result':
       case 'event':
       case 'tool.call':
       case 'ping':
@@ -372,6 +376,44 @@ export class BridgeServer {
       sendFrame(conn.ws, { t: 'rpc.result', id: frame.id, ok: true, result })
     } catch (error: unknown) {
       sendFrame(conn.ws, { t: 'rpc.result', id: frame.id, ok: false, error: { code: 'internal', message: String(error) } })
+    }
+  }
+
+  /**
+   * Relay one client response for a pending host interaction (user question /
+   * approval) to the gateway's /api/respond endpoint. The envelope mirrors the
+   * GUI client's `client-response` full form: the question's own rpcId plus the
+   * result ({ ok: true, value } or { ok: false, error }). The gateway routes
+   * the response through its pending table and settles the blocked tool call.
+   * @param frame - parsed `respond` frame.
+   */
+  private async handleRespond(frame: Extract<ClientFrame, { t: 'respond' }>): Promise<void> {
+    const conn = this.current
+    /* v8 ignore next -- replacement race: a frame can land between a socket
+    replacement and the next promotion; the re-check keeps the handler total */
+    if (conn === null) return
+    const body = JSON.stringify({ type: 'client-response', rpcId: frame.rpcId, result: frame.result })
+    const request = new Request(new URL('/api/respond', 'http://dsh.internal'), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body,
+    })
+    try {
+      const response = await this.deps.apiHandler.fetch(request)
+      const text = await response.text()
+      if (!response.ok) {
+        sendFrame(conn.ws, { t: 'respond.result', id: frame.id, ok: false, error: { code: 'http', message: text } })
+        return
+      }
+      let result: unknown
+      try {
+        result = JSON.parse(text)
+      } catch {
+        result = text
+      }
+      sendFrame(conn.ws, { t: 'respond.result', id: frame.id, ok: true, result })
+    } catch (error: unknown) {
+      sendFrame(conn.ws, { t: 'respond.result', id: frame.id, ok: false, error: { code: 'internal', message: String(error) } })
     }
   }
 

--- a/packages/browser/bridge-browser/tests/protocol.spec.ts
+++ b/packages/browser/bridge-browser/tests/protocol.spec.ts
@@ -42,6 +42,26 @@ describe('parseBridgeFrame', () => {
     expect(parseBridgeFrame(JSON.stringify({ t: 'rpc.result', id: '1', ok: false }))).toBeUndefined()
   })
 
+  it('parses respond (interaction answer) success and error forms', () => {
+    expect(parseBridgeFrame(JSON.stringify({ t: 'respond', id: 'r1', rpcId: 'q1', result: { ok: true, value: { sessionId: 's', answer: { answers: [] } } } })))
+      .toEqual({ t: 'respond', id: 'r1', rpcId: 'q1', result: { ok: true, value: { sessionId: 's', answer: { answers: [] } } } })
+    expect(parseBridgeFrame(JSON.stringify({ t: 'respond', id: 'r2', rpcId: 'q2', result: { ok: false, error: { code: 'cancelled', message: 'closed' } } })))
+      .toEqual({ t: 'respond', id: 'r2', rpcId: 'q2', result: { ok: false, error: { code: 'cancelled', message: 'closed' } } })
+    // ok:false without a well-formed error, or ok:true with an error, are malformed.
+    expect(parseBridgeFrame(JSON.stringify({ t: 'respond', id: 'r3', rpcId: 'q3', result: { ok: false } }))).toBeUndefined()
+    expect(parseBridgeFrame(JSON.stringify({ t: 'respond', id: 'r4', rpcId: 'q4', result: { ok: true, error: { code: 'x', message: 'm' } } }))).toBeUndefined()
+    expect(parseBridgeFrame(JSON.stringify({ t: 'respond', id: 'r5', result: { ok: true } }))).toBeUndefined()
+    expect(parseBridgeFrame(JSON.stringify({ t: 'respond', rpcId: 'q6', result: { ok: true } }))).toBeUndefined()
+  })
+
+  it('parses respond.result success and error forms', () => {
+    expect(parseBridgeFrame(JSON.stringify({ t: 'respond.result', id: 'r1', ok: true, result: { accepted: true } })))
+      .toEqual({ t: 'respond.result', id: 'r1', ok: true, result: { accepted: true } })
+    expect(parseBridgeFrame(JSON.stringify({ t: 'respond.result', id: 'r2', ok: false, error: { code: 'http', message: 'boom' } })))
+      .toEqual({ t: 'respond.result', id: 'r2', ok: false, error: { code: 'http', message: 'boom' } })
+    expect(parseBridgeFrame(JSON.stringify({ t: 'respond.result', id: 'r3', ok: true }))).toBeUndefined()
+  })
+
   it('parses ping and error frames', () => {
     expect(parseBridgeFrame(JSON.stringify({ t: 'ping' }))).toEqual({ t: 'ping' })
     expect(parseBridgeFrame(JSON.stringify({ t: 'error', code: 'stream-failed', message: 'x' })))
@@ -62,11 +82,11 @@ describe('parseBridgeFrame', () => {
     expect(isClientFrame(server)).toBe(false)
     expect(isServerFrame(client)).toBe(false)
     expect(isClientFrame(client)).toBe(true)
-    for (const t of ['hello.ok', 'rpc.result', 'event', 'tool.call', 'ping', 'error'] as const) {
+    for (const t of ['hello.ok', 'rpc.result', 'respond.result', 'event', 'tool.call', 'ping', 'error'] as const) {
       const frame = parseBridgeFrame(JSON.stringify(serverShape(t)))!
       expect(isServerFrame(frame)).toBe(true)
     }
-    for (const t of ['hello', 'rpc', 'tool.result', 'pong'] as const) {
+    for (const t of ['hello', 'rpc', 'respond', 'tool.result', 'pong'] as const) {
       const frame = parseBridgeFrame(JSON.stringify(clientShape(t)))!
       expect(isClientFrame(frame)).toBe(true)
     }
@@ -88,10 +108,11 @@ describe('parseBridgeFrame', () => {
 })
 
 /** Minimal valid shape per server-side frame type (for classification tests). */
-function serverShape(t: 'hello.ok' | 'rpc.result' | 'event' | 'tool.call' | 'ping' | 'error'): Record<string, unknown> {
+function serverShape(t: 'hello.ok' | 'rpc.result' | 'respond.result' | 'event' | 'tool.call' | 'ping' | 'error'): Record<string, unknown> {
   switch (t) {
     case 'hello.ok': return { t, caps: { textOnly: true, snapshotMaxChars: 100, maxInteractiveItems: 10 } }
     case 'rpc.result': return { t, id: '1', ok: true, result: {} }
+    case 'respond.result': return { t, id: '1', ok: true, result: { accepted: true } }
     case 'event': return { t, frame: { rpcId: 'r', method: 'x', payload: {} } }
     case 'tool.call': return { t, id: '1', name: 'x', args: {} }
     case 'ping': return { t }
@@ -100,10 +121,11 @@ function serverShape(t: 'hello.ok' | 'rpc.result' | 'event' | 'tool.call' | 'pin
 }
 
 /** Minimal valid shape per client-side frame type (for classification tests). */
-function clientShape(t: 'hello' | 'rpc' | 'tool.result' | 'pong'): Record<string, unknown> {
+function clientShape(t: 'hello' | 'rpc' | 'respond' | 'tool.result' | 'pong'): Record<string, unknown> {
   switch (t) {
     case 'hello': return { t, token: 'x', caps: { textOnly: true, snapshotMaxChars: 100, maxInteractiveItems: 10 } }
     case 'rpc': return { t, id: '1', method: 'x', payload: {} }
+    case 'respond': return { t, id: '1', rpcId: 'q', result: { ok: true, value: {} } }
     case 'tool.result': return { t, id: '1', ok: true, result: {} }
     case 'pong': return { t }
   }

--- a/packages/browser/bridge-browser/tests/server.spec.ts
+++ b/packages/browser/bridge-browser/tests/server.spec.ts
@@ -200,6 +200,47 @@ describe('BridgeServer', () => {
     ws.close()
   })
 
+  it('relays interaction answers to /api/respond as client-response envelopes', async () => {
+    const h = await startBridge()
+    harnesses.push(h)
+    const { ws, frames } = await connect(h.url)
+    send(ws, { t: 'hello', token: TOKEN, caps: { textOnly: true, snapshotMaxChars: 12000, maxInteractiveItems: 60 } })
+    await waitFor(() => frames.some((f) => f.t === 'hello.ok'))
+    send(ws, {
+      t: 'respond',
+      id: 'ans-1',
+      rpcId: 'q1',
+      result: { ok: true, value: { sessionId: 's1', answer: { answers: [{ id: 'mention_target', selected: ['小鹏内部王世楷'] }] } } },
+    })
+    await waitFor(() => frames.some((f) => f.t === 'respond.result'))
+    const result = frames.find((f) => f.t === 'respond.result')
+    expect(result).toMatchObject({ t: 'respond.result', id: 'ans-1', ok: true })
+    expect(h.fetchMock).toHaveBeenCalledTimes(1)
+    const request = h.fetchMock.mock.calls[0]![0] as Request
+    expect(request.url).toBe('http://dsh.internal/api/respond')
+    expect(request.method).toBe('POST')
+    expect(request.headers.get('content-type')).toBe('application/json')
+    expect(JSON.parse(await request.text())).toEqual({
+      type: 'client-response',
+      rpcId: 'q1',
+      result: { ok: true, value: { sessionId: 's1', answer: { answers: [{ id: 'mention_target', selected: ['小鹏内部王世楷'] }] } } },
+    })
+    ws.close()
+  })
+
+  it('reports /api/respond failures as respond.result errors', async () => {
+    const h = await startBridge({ apiHandler: { fetch: async () => new Response('handler failure: boom', { status: 500 }) } })
+    harnesses.push(h)
+    const { ws, frames } = await connect(h.url)
+    send(ws, { t: 'hello', token: TOKEN, caps: { textOnly: true, snapshotMaxChars: 12000, maxInteractiveItems: 60 } })
+    await waitFor(() => frames.some((f) => f.t === 'hello.ok'))
+    send(ws, { t: 'respond', id: 'ans-2', rpcId: 'q2', result: { ok: false, error: { code: 'cancelled', message: 'closed' } } })
+    await waitFor(() => frames.some((f) => f.t === 'respond.result' && f.id === 'ans-2'))
+    expect(frames.find((f) => f.t === 'respond.result' && f.id === 'ans-2'))
+      .toMatchObject({ t: 'respond.result', id: 'ans-2', ok: false, error: { code: 'http' } })
+    ws.close()
+  })
+
   it('rejects privileged methods from non-loopback remotes', async () => {
     expect(isLoopbackAddress('127.0.0.1')).toBe(true)
     expect(isLoopbackAddress('::1')).toBe(true)


### PR DESCRIPTION
## What & why

When an agent calls `ask_user_question` in a browser-bridge session, the question card is rendered **only in the main dsh web GUI** — the side panel has no question UI and no way to answer or abort. The agent turn blocks forever waiting for an answer:

- the panel shows a perpetual "正在操作页面 ask_user_question" spinner (looks frozen),
- further messages are queued for the next turn and get no response,
- there is no visible way to terminate the action.

This PR fixes both gaps from the side panel itself.

## Changes

### Bridge plugin (`@deepseek-ai/dsh-bridge-browser`)

- **protocol**: new client frame `respond` (interaction `rpcId` + `result`) and server frame `respond.result` (receipt).
- **server**: a `respond` frame is relayed to the gateway's `/api/respond` as a `client-response` envelope — the exact channel the dsh GUI uses — so the blocked `ask_user_question` (or approval) tool call settles from the extension.

### Chrome extension

- **background**: routes panel `respond` messages to the bridge and relays `respond.result` receipts back.
- **panel**: renders a question card on `question/requested` mux frames (options, multi-select, custom answer, 提交/放弃), answers via the bridge, and clears on `question/resolved`.
- **panel**: while a turn is running, the send button is replaced by a **停止** button that calls `session.cancel` — a reliable escape hatch for any stuck action.

### Tests

- bridge: protocol parse/classify for `respond`/`respond.result`; server relay of `/api/respond` including the exact client-response body.
- extension: question extraction from `question/requested` frames, resolved/session-event classification.

Verified against the real failure: after answering through the new flow, the blocked turn resumes and completes. All checks pass (`pnpm run typecheck`, `pnpm run test`, `pnpm run build`).
