### PR TITLE
feat: localize sidebar from browser language

### DIFF
--- a/extensions/dsh-browser/_locales/en/messages.json
+++ b/extensions/dsh-browser/_locales/en/messages.json
@@ -1,0 +1,11 @@
+{
+  "extensionName": {
+    "message": "dsh Browser Assistant"
+  },
+  "extensionDescription": {
+    "message": "A Chrome side-panel extension that lets dsh read and operate your browser directly without vision."
+  },
+  "actionTitle": {
+    "message": "Open dsh Browser Assistant"
+  }
+}

--- a/extensions/dsh-browser/_locales/zh_CN/messages.json
+++ b/extensions/dsh-browser/_locales/zh_CN/messages.json
@@ -1,0 +1,11 @@
+{
+  "extensionName": {
+    "message": "dsh 浏览器助手"
+  },
+  "extensionDescription": {
+    "message": "让 dsh 无需视觉能力即可直接读取并操作浏览器的 Chrome 侧边栏扩展。"
+  },
+  "actionTitle": {
+    "message": "打开 dsh 浏览器助手"
+  }
+}

--- a/extensions/dsh-browser/_locales/zh_TW/messages.json
+++ b/extensions/dsh-browser/_locales/zh_TW/messages.json
@@ -1,0 +1,11 @@
+{
+  "extensionName": {
+    "message": "dsh 瀏覽器助手"
+  },
+  "extensionDescription": {
+    "message": "讓 dsh 無需視覺能力即可直接讀取並操作瀏覽器的 Chrome 側邊欄擴充功能。"
+  },
+  "actionTitle": {
+    "message": "開啟 dsh 瀏覽器助手"
+  }
+}

--- a/extensions/dsh-browser/manifest.json
+++ b/extensions/dsh-browser/manifest.json
@@ -1,7 +1,8 @@
 {
   "manifest_version": 3,
-  "name": "dsh 浏览器助手",
-  "description": "Chrome sidebar extension that lets DSH operate your browser directly—no vision capabilities required.",
+  "name": "__MSG_extensionName__",
+  "description": "__MSG_extensionDescription__",
+  "default_locale": "en",
   "version": "0.1.0",
   "minimum_chrome_version": "116",
   "permissions": [
@@ -22,7 +23,7 @@
     "type": "module"
   },
   "action": {
-    "default_title": "打开 dsh 助手",
+    "default_title": "__MSG_actionTitle__",
     "default_icon": {
       "16": "assets/icons/icon16.png",
       "32": "assets/icons/icon32.png"

--- a/extensions/dsh-browser/panel/index.html
+++ b/extensions/dsh-browser/panel/index.html
@@ -1,11 +1,11 @@
 <!doctype html>
-<html lang="zh-CN">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light" />
     <meta name="theme-color" content="#f4f6fa" />
-    <title>dsh 浏览器助手</title>
+    <title>dsh Browser Assistant</title>
   </head>
   <body>
     <div id="root"></div>

--- a/extensions/dsh-browser/src/background/authorization.ts
+++ b/extensions/dsh-browser/src/background/authorization.ts
@@ -3,6 +3,7 @@
 import type { ToolCall } from './tools.ts'
 import type { TabFrame } from './frames.ts'
 import type { ApprovalPrompt } from '../security/approval.ts'
+import { getUiLocale, type UiLocale } from '../i18n.ts'
 
 const PAGE_READS = new Set(['browser_snapshot', 'browser_get_text'])
 const STATE_CHANGING_ACTIONS = new Set([
@@ -20,6 +21,7 @@ export function approvalPromptForCall(
   call: ToolCall,
   sharePageContent: 'ask' | 'auto' | 'off',
   frames: TabFrame[],
+  locale: UiLocale = getUiLocale(),
 ): ApprovalPrompt | undefined {
   if (PAGE_READS.has(call.name)) {
     if (sharePageContent !== 'ask') return undefined
@@ -29,7 +31,9 @@ export function approvalPromptForCall(
     return {
       kind: 'read',
       action: call.name,
-      summary: call.name === 'browser_snapshot' ? '读取当前页面及可访问 iframe' : '读取当前页面的指定文本区域',
+      summary: call.name === 'browser_snapshot'
+        ? localized(locale, 'Read the current page and accessible iframes', '读取当前页面及可访问 iframe')
+        : localized(locale, 'Read text from the specified area of the current page', '读取当前页面的指定文本区域'),
       origins: uniqueOrigins(targetFrames, frames),
       canTrust: false,
     }
@@ -50,7 +54,7 @@ export function approvalPromptForCall(
   return {
     kind: 'action',
     action: call.name,
-    summary: summarizeAction(call),
+    summary: summarizeAction(call, locale),
     origins,
     // Cross-origin/invalid navigation and unknown history destinations always
     // require a fresh decision; they must never expand trust implicitly.
@@ -90,31 +94,49 @@ export function originFromUrl(value: string): string | undefined {
   }
 }
 
-function summarizeAction(call: ToolCall): string {
-  const frame = typeof call.args.frame === 'number' && call.args.frame !== 0 ? `，iframe ${call.args.frame}` : ''
+function summarizeAction(call: ToolCall, locale: UiLocale): string {
+  const frame = typeof call.args.frame === 'number' && call.args.frame !== 0
+    ? localized(locale, `, iframe ${call.args.frame}`, `，iframe ${call.args.frame}`)
+    : ''
   const index = typeof call.args.index === 'number' ? call.args.index : '?'
   switch (call.name) {
-    case 'browser_click': return `点击元素 [${index}]${frame}`
+    case 'browser_click': return localized(locale, `Click element [${index}]${frame}`, `点击元素 [${index}]${frame}`)
     case 'browser_type': {
       const length = typeof call.args.text === 'string' ? call.args.text.length : 0
-      return `向元素 [${index}] 输入 ${length} 个字符${frame}（文本内容不会显示在确认框）`
+      return localized(
+        locale,
+        `Enter ${length} characters in element [${index}]${frame} (the text is not shown in this dialog)`,
+        `向元素 [${index}] 输入 ${length} 个字符${frame}（文本内容不会显示在确认框）`,
+      )
     }
-    case 'browser_press': return `发送按键「${safeInline(typeof call.args.key === 'string' ? call.args.key : '')}」${frame}`
-    case 'browser_navigate': return `导航到 ${displayUrl(typeof call.args.url === 'string' ? call.args.url : '')}`
-    case 'browser_back': return '返回浏览历史上一页（目标域名未知）'
-    case 'browser_forward': return '前进到浏览历史下一页（目标域名未知）'
-    case 'browser_reload': return '重新加载当前页面'
+    case 'browser_press': return localized(
+      locale,
+      `Press “${safeInline(typeof call.args.key === 'string' ? call.args.key : '')}”${frame}`,
+      `发送按键「${safeInline(typeof call.args.key === 'string' ? call.args.key : '')}」${frame}`,
+    )
+    case 'browser_navigate': return localized(
+      locale,
+      `Navigate to ${displayUrl(typeof call.args.url === 'string' ? call.args.url : '', locale)}`,
+      `导航到 ${displayUrl(typeof call.args.url === 'string' ? call.args.url : '', locale)}`,
+    )
+    case 'browser_back': return localized(locale, 'Go back in browser history (destination domain unknown)', '返回浏览历史上一页（目标域名未知）')
+    case 'browser_forward': return localized(locale, 'Go forward in browser history (destination domain unknown)', '前进到浏览历史下一页（目标域名未知）')
+    case 'browser_reload': return localized(locale, 'Reload the current page', '重新加载当前页面')
     default: return call.name
   }
 }
 
-function displayUrl(value: string): string {
+function displayUrl(value: string, locale: UiLocale): string {
   try {
     const url = new URL(value)
     return safeInline(`${url.origin}${url.pathname}`, 160)
   } catch {
-    return '(无效 URL)'
+    return localized(locale, '(invalid URL)', '(无效 URL)')
   }
+}
+
+function localized(locale: UiLocale, english: string, chinese: string): string {
+  return locale === 'zh' ? chinese : english
 }
 
 function safeInline(value: string, maxLength = 40): string {

--- a/extensions/dsh-browser/src/background/index.ts
+++ b/extensions/dsh-browser/src/background/index.ts
@@ -31,6 +31,7 @@ import {
   type ApprovalPrompt,
   type ApprovalRequest,
 } from '../security/approval.ts'
+import { getUiLocale } from '../i18n.ts'
 
 /** User settings persisted in chrome.storage.local. */
 export interface Settings {
@@ -339,7 +340,9 @@ async function startBridge(): Promise<void> {
 /** Gateway RPC with a helpful error when the bridge is down. */
 async function gatewayRpc(method: string, payload: unknown): Promise<unknown> {
   if (rpc === null || bridge === null || !bridge.connected) {
-    throw new Error('未连接 dsh（请检查设置中的地址与 token）')
+    throw new Error(getUiLocale() === 'zh'
+      ? '未连接 dsh（请检查设置中的地址与 token）'
+      : 'dsh is not connected (check the bridge address and token in Settings)')
   }
   return rpc.request(method, payload)
 }

--- a/extensions/dsh-browser/src/i18n.ts
+++ b/extensions/dsh-browser/src/i18n.ts
@@ -1,0 +1,28 @@
+/** Languages supported by the extension UI. */
+export type UiLocale = 'en' | 'zh'
+
+/**
+ * Chinese browser locales use Chinese; every other locale deliberately falls
+ * back to English so an untranslated third language never leaks into the UI.
+ */
+export function localeFromLanguage(language: string | null | undefined): UiLocale {
+  const normalized = language?.trim().toLowerCase() ?? ''
+  return normalized === 'zh' || normalized.startsWith('zh-') ? 'zh' : 'en'
+}
+
+/** Read the browser's first preferred language, with the extension UI locale as a fallback. */
+export function getUiLocale(): UiLocale {
+  let language: string | undefined
+  if (typeof navigator !== 'undefined') {
+    const preferred = navigator.languages?.find((candidate) => candidate.trim() !== '') ?? navigator.language
+    language = preferred.trim() === '' ? undefined : preferred
+  }
+  if (language === undefined && typeof chrome !== 'undefined' && chrome.i18n?.getUILanguage !== undefined) {
+    try {
+      language = chrome.i18n.getUILanguage()
+    } catch {
+      // A partially mocked or stale extension context may expose an unusable API.
+    }
+  }
+  return localeFromLanguage(language)
+}

--- a/extensions/dsh-browser/src/panel/App.tsx
+++ b/extensions/dsh-browser/src/panel/App.tsx
@@ -15,6 +15,8 @@ import { connectPanel, type PanelApi, type PanelSettings } from './api.ts'
 import { renderMarkdown } from './markdown.ts'
 import whaleUrl from '../../assets/icons/deepseek-256.png'
 import type { ApprovalDecision, ApprovalRequest } from '../security/approval.ts'
+import { getUiLocale } from '../i18n.ts'
+import { PANEL_COPY, type PanelCopy } from './strings.ts'
 
 /** One rendered conversation row. */
 import {
@@ -26,13 +28,6 @@ import {
   type Row,
   type SessionEventView,
 } from './events.ts'
-
-const STATE_LABEL: Record<BridgeState, string> = {
-  connected: '已连接',
-  connecting: '连接中…',
-  reconnecting: '重连中…',
-  stopped: '未连接',
-}
 
 function normalizeWebOrigin(value: string): string | null {
   try {
@@ -97,9 +92,11 @@ function ShieldIcon(): React.JSX.Element {
 function ApprovalDialog({
   request,
   onDecision,
+  copy,
 }: {
   request: ApprovalRequest
   onDecision: (decision: ApprovalDecision) => void
+  copy: PanelCopy
 }): React.JSX.Element {
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent): void => {
@@ -116,34 +113,34 @@ function ApprovalDialog({
         <div className="approval-heading">
           <span className="approval-shield"><ShieldIcon /></span>
           <div>
-            <span className="eyebrow">安全检查</span>
-            <h2 id="approval-title">{request.kind === 'read' ? '允许读取页面？' : '允许执行页面操作？'}</h2>
+            <span className="eyebrow">{copy.approval.eyebrow}</span>
+            <h2 id="approval-title">{request.kind === 'read' ? copy.approval.readTitle : copy.approval.actionTitle}</h2>
           </div>
         </div>
         <div className="approval-detail">
-          <span>请求</span>
+          <span>{copy.approval.request}</span>
           <strong>{request.summary}</strong>
         </div>
         <div className="approval-origins">
-          <span>涉及来源</span>
+          <span>{copy.approval.origins}</span>
           {request.origins.length === 0
-            ? <code className="unknown">未知来源</code>
+            ? <code className="unknown">{copy.approval.unknownOrigin}</code>
             : request.origins.map((origin) => <code key={origin}>{origin}</code>)}
         </div>
         <div className="approval-actions">
-          <button className="deny" autoFocus onClick={() => onDecision('deny')}>拒绝</button>
-          <button className="allow" onClick={() => onDecision('allow-once')}>仅允许这一次</button>
+          <button className="deny" autoFocus onClick={() => onDecision('deny')}>{copy.approval.deny}</button>
+          <button className="allow" onClick={() => onDecision('allow-once')}>{copy.approval.allowOnce}</button>
           {request.kind === 'read' && (
-            <button className="read-always" onClick={() => onDecision('always-allow-reads')}>始终允许读取</button>
+            <button className="read-always" onClick={() => onDecision('always-allow-reads')}>{copy.approval.alwaysAllowReads}</button>
           )}
           {request.kind === 'action' && request.canTrust && request.origins.length === 1 && (
-            <button className="session-trust" onClick={() => onDecision('trust-session')}>本次会话信任此域</button>
+            <button className="session-trust" onClick={() => onDecision('trust-session')}>{copy.approval.trustSession}</button>
           )}
         </div>
         <small className="approval-footnote">
           {request.kind === 'read'
-            ? 'Esc 拒绝 · 可随时在设置中关闭自动读取'
-            : 'Esc 拒绝 · 关闭侧栏后临时信任失效 · 输入内容不会显示'}
+            ? copy.approval.readFootnote
+            : copy.approval.actionFootnote}
         </small>
       </section>
     </div>
@@ -162,23 +159,25 @@ const MessageBody = memo(function MessageBody({ row }: { row: Row }): React.JSX.
   return <pre>{row.text}</pre>
 })
 
-const ToolActivity = memo(function ToolActivity({ row }: { row: Row }): React.JSX.Element {
+const ToolActivity = memo(function ToolActivity({ row, copy }: { row: Row; copy: PanelCopy }): React.JSX.Element {
   const running = row.status === 'running'
   return (
     <div className={`tool-activity ${running ? 'running' : 'complete'}`} role="status">
       <span className="tool-icon"><ToolIcon /></span>
       <span className="tool-copy">
-        <span className="tool-label">{running ? '正在操作页面' : '页面操作'}</span>
+        <span className="tool-label">{running ? copy.tool.running : copy.tool.complete}</span>
         <span className="tool-summary">{row.text}</span>
       </span>
-      <span className="tool-state" aria-label={running ? '进行中' : '已完成'}>
-        {running ? <span className="spinner" /> : '完成'}
+      <span className="tool-state" aria-label={running ? copy.tool.inProgress : copy.tool.completed}>
+        {running ? <span className="spinner" /> : copy.tool.done}
       </span>
     </div>
   )
 })
 
 export function App(): React.JSX.Element {
+  const locale = useMemo(() => getUiLocale(), [])
+  const copy = PANEL_COPY[locale]
   const [api] = useState<PanelApi>(() => connectPanel())
   const [state, setState] = useState<BridgeState>('stopped')
   const [caps, setCaps] = useState<BridgeCaps | null>(null)
@@ -291,7 +290,7 @@ export function App(): React.JSX.Element {
     }
     if (payload.event.type === 'tool/call') {
       setWorking(true)
-      const summary = toolSummary(payload.event.data?.name ?? 'tool', payload.event.data?.arguments)
+      const summary = toolSummary(payload.event.data?.name ?? 'tool', payload.event.data?.arguments, locale)
       setRows((prev) => appendLiveRow(prev, 'tool', summary, nextSeq()))
       return
     }
@@ -311,7 +310,7 @@ export function App(): React.JSX.Element {
     if (id === null) return
     try {
       const result = await api.rpc<{ events: { event: SessionEventView }[] }>('session.history', { sessionId: id })
-      setRows(mergeHistoryRows(result.events.map((entry) => entry.event), nextSeq))
+      setRows(mergeHistoryRows(result.events.map((entry) => entry.event), nextSeq, locale))
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause))
     }
@@ -386,85 +385,85 @@ export function App(): React.JSX.Element {
   }
 
   // 状态栏只显示连接状态；快照上限是技术细节，在设置页说明（见 hint）。
-  const statusText = useMemo(() => STATE_LABEL[state], [state])
+  const statusText = copy.status[state]
   const approvalDialog = approvalQueue[0] === undefined
     ? null
-    : <ApprovalDialog request={approvalQueue[0]} onDecision={decideApproval} />
+    : <ApprovalDialog request={approvalQueue[0]} onDecision={decideApproval} copy={copy} />
 
   if (showSettings) {
     return (
       <><div className="settings">
         <div className="settings-heading">
-          <button className="icon-button" onClick={() => setShowSettings(false)} aria-label="返回对话"><BackIcon /></button>
+          <button className="icon-button" onClick={() => setShowSettings(false)} aria-label={copy.settings.back}><BackIcon /></button>
           <div>
-            <span className="eyebrow">偏好设置</span>
-            <h1>连接与隐私</h1>
+            <span className="eyebrow">{copy.settings.eyebrow}</span>
+            <h1>{copy.settings.title}</h1>
           </div>
         </div>
         <div className="settings-panel">
           <label>
-            <span>桥地址</span>
-            <small>留空时自动检测本机服务</small>
+            <span>{copy.settings.bridgeAddress}</span>
+            <small>{copy.settings.bridgeHelp}</small>
             <input
               value={settings?.bridgeUrl ?? ''}
               onChange={(e) => setSettings((prev) => prev === null ? prev : { ...prev, bridgeUrl: e.target.value })}
-              placeholder="自动检测 3080 / 3081 / 3090"
+              placeholder={copy.settings.bridgePlaceholder}
             />
           </label>
           <label>
             <span>Token</span>
-            <small>本地连接无需填写</small>
+            <small>{copy.settings.tokenHelp}</small>
             <input
               type="password"
               value={settings?.token ?? ''}
               onChange={(e) => setSettings((prev) => prev === null ? prev : { ...prev, token: e.target.value })}
-              placeholder="远程部署时填写"
+              placeholder={copy.settings.tokenPlaceholder}
             />
           </label>
           <label>
-            <span>页面内容共享</span>
-            <small>控制助手何时可以读取页面文字</small>
+            <span>{copy.settings.pageSharing}</span>
+            <small>{copy.settings.pageSharingHelp}</small>
             <select
               value={settings?.sharePageContent ?? 'auto'}
               onChange={(e) => setSettings((prev) => prev === null ? prev : { ...prev, sharePageContent: e.target.value as PanelSettings['sharePageContent'] })}
             >
-              <option value="auto">自动共享（默认）</option>
-              <option value="ask">每次询问</option>
-              <option value="off">关闭</option>
+              <option value="auto">{copy.settings.sharingAuto}</option>
+              <option value="ask">{copy.settings.sharingAsk}</option>
+              <option value="off">{copy.settings.sharingOff}</option>
             </select>
           </label>
         </div>
         <section className="trusted-origins" aria-labelledby="trusted-origins-title">
           <div>
-            <span id="trusted-origins-title">永久免确认域名</span>
-            <small>审批框可只信任本次侧栏会话。这里添加的域名会长期免除操作确认；显式跨域导航仍会询问。</small>
+            <span id="trusted-origins-title">{copy.settings.trustedOrigins}</span>
+            <small>{copy.settings.trustedOriginsHelp}</small>
           </div>
           <div className="trusted-origin-add">
             <input
-              aria-label="要永久信任的域名"
+              aria-label={copy.settings.trustedOriginInput}
               value={trustedOriginInput}
               onChange={(event) => setTrustedOriginInput(event.target.value)}
               onKeyDown={(event) => { if (event.key === 'Enter') addTrustedOrigin() }}
               placeholder="https://example.com"
             />
-            <button disabled={normalizeWebOrigin(trustedOriginInput) === null} onClick={addTrustedOrigin}>添加</button>
+            <button disabled={normalizeWebOrigin(trustedOriginInput) === null} onClick={addTrustedOrigin}>{copy.settings.add}</button>
           </div>
           {trustedOriginInput.trim() !== '' && normalizeWebOrigin(trustedOriginInput) === null && (
-            <p className="origin-error">请输入完整的 http:// 或 https:// 地址。</p>
+            <p className="origin-error">{copy.settings.invalidOrigin}</p>
           )}
-          {settings?.trustedActionOrigins.length === 0 && <p>尚未信任任何域名。</p>}
+          {settings?.trustedActionOrigins.length === 0 && <p>{copy.settings.noTrustedOrigins}</p>}
           {settings?.trustedActionOrigins.map((origin) => (
             <div className="trusted-origin" key={origin}>
               <code>{origin}</code>
-              <button onClick={() => removeTrustedOrigin(origin)} aria-label={`移除 ${origin}`}>移除</button>
+              <button onClick={() => removeTrustedOrigin(origin)} aria-label={copy.settings.removeOrigin(origin)}>{copy.settings.remove}</button>
             </div>
           ))}
         </section>
         <div className="settings-actions">
-          <button className="primary" onClick={saveSettings}>保存并连接</button>
-          <button className="secondary" onClick={() => setShowSettings(false)}>取消</button>
+          <button className="primary" onClick={saveSettings}>{copy.settings.save}</button>
+          <button className="secondary" onClick={() => setShowSettings(false)}>{copy.settings.cancel}</button>
         </div>
-        <p className="hint">页面快照上限为 {caps?.snapshotMaxChars ?? 12000} 字符，超出内容会被截断。可在 dsh 插件中调整 snapshotMaxChars。</p>
+        <p className="hint">{copy.settings.snapshotHint(caps?.snapshotMaxChars ?? 12000)}</p>
       </div>{approvalDialog}</>
     )
   }
@@ -474,20 +473,20 @@ export function App(): React.JSX.Element {
       <header className="topbar">
         <div className="brand">
           <span className="brand-mark"><img src={whaleUrl} alt="" /></span>
-          <span className="brand-copy"><strong>浏览助手</strong><small>页面副驾驶</small></span>
+          <span className="brand-copy"><strong>{copy.app.brand}</strong><small>{copy.app.tagline}</small></span>
         </div>
         <span className="connection" role="status"><span className={`dot ${state}`} />{statusText}</span>
-        <button className="icon-button" onClick={() => setShowSettings(true)} aria-label="打开设置" title="设置"><SettingsIcon /></button>
+        <button className="icon-button" onClick={() => setShowSettings(true)} aria-label={copy.app.openSettings} title={copy.app.settings}><SettingsIcon /></button>
       </header>
-      <section className="context-card" aria-label="当前页面">
+      <section className="context-card" aria-label={copy.app.currentPage}>
         <span className="context-icon"><PageIcon /></span>
         <span className="context-copy">
-          <small>当前页面</small>
-          <strong title={pageInfo ?? undefined}>{pageInfo ?? '等待浏览器页面'}</strong>
+          <small>{copy.app.currentPage}</small>
+          <strong title={pageInfo ?? undefined}>{pageInfo ?? copy.app.waitingForPage}</strong>
         </span>
         <button className="context-action" disabled={state !== 'connected' || busy}
-          onClick={() => { void send('请用 browser_snapshot 读取当前页面，然后告诉我页面上有什么，并等待我的指令。') }}>
-          读取页面
+          onClick={() => { void send(copy.app.readPagePrompt) }}>
+          {copy.app.readPage}
         </button>
       </section>
       <div className="messages" ref={scrollRef}>
@@ -495,26 +494,26 @@ export function App(): React.JSX.Element {
           <div className="empty">
             <span className="empty-logo"><img src={whaleUrl} alt="" /></span>
             <div>
-              <h1>把当前页面交给我</h1>
-              <p>我可以阅读页面、查找信息，也可以替你点击、填写和导航。</p>
+              <h1>{copy.app.emptyTitle}</h1>
+              <p>{copy.app.emptyDescription}</p>
             </div>
             <button disabled={state !== 'connected'}
-              onClick={() => { void send('请先概览当前页面，告诉我最重要的信息，并等待我的下一步指令。') }}>
-              先概览这个页面
+              onClick={() => { void send(copy.app.overviewPrompt) }}>
+              {copy.app.overviewPage}
             </button>
           </div>
         )}
         {rows.map((row) => (
           <div key={row.seq} className={`row ${row.kind}`}>
-            {row.kind === 'assistant' && <span className="assistant-avatar"><img src={whaleUrl} alt="助手" /></span>}
-            {row.kind === 'tool' ? <ToolActivity row={row} /> : <MessageBody row={row} />}
+            {row.kind === 'assistant' && <span className="assistant-avatar"><img src={whaleUrl} alt={copy.app.assistant} /></span>}
+            {row.kind === 'tool' ? <ToolActivity row={row} copy={copy} /> : <MessageBody row={row} />}
           </div>
         ))}
         {working && rows[rows.length - 1]?.status !== 'running' && (
-          <div className="ai-progress" role="status" aria-label="助手正在处理">
+          <div className="ai-progress" role="status" aria-label={copy.app.assistantWorking}>
             <span className="assistant-avatar"><img src={whaleUrl} alt="" /></span>
             <span className="progress-dots" aria-hidden="true"><i /><i /><i /></span>
-            <span>{rows[rows.length - 1]?.kind === 'tool' ? '正在整理结果' : '正在思考'}</span>
+            <span>{rows[rows.length - 1]?.kind === 'tool' ? copy.app.organizingResults : copy.app.thinking}</span>
           </div>
         )}
       </div>
@@ -531,13 +530,13 @@ export function App(): React.JSX.Element {
                 void send()
               }
             }}
-            placeholder={state === 'connected' ? '告诉我想在这个页面做什么…' : '连接 dsh 后即可开始'}
+            placeholder={state === 'connected' ? copy.app.connectedPlaceholder : copy.app.disconnectedPlaceholder}
             disabled={state !== 'connected'}
             rows={2}
           />
           <div className="composer-actions">
-            <span>Enter 发送 · Shift + Enter 换行</span>
-            <button onClick={() => void send()} disabled={state !== 'connected' || busy || input.trim() === ''} aria-label="发送消息"><SendIcon /></button>
+            <span>{copy.app.composerHelp}</span>
+            <button onClick={() => void send()} disabled={state !== 'connected' || busy || input.trim() === ''} aria-label={copy.app.sendMessage}><SendIcon /></button>
           </div>
         </div>
       </footer>

--- a/extensions/dsh-browser/src/panel/api.ts
+++ b/extensions/dsh-browser/src/panel/api.ts
@@ -10,6 +10,7 @@ import type { ServerFrame } from '@deepseek-ai/dsh-bridge-browser/src/protocol.t
 import type { BridgeState } from '../background/bridge.ts'
 import type { Settings } from '../background/index.ts'
 import type { ApprovalDecision, ApprovalRequest } from '../security/approval.ts'
+import { getUiLocale } from '../i18n.ts'
 
 /** Panel-side subset of the extension settings. */
 export type PanelSettings = Settings
@@ -80,7 +81,8 @@ export function connectPanel(): PanelApi {
         const envelope = msg.result as { result?: { ok?: boolean; value?: unknown; error?: { message?: string } } } | undefined
         const business = envelope?.result
         if (msg.ok && business?.ok !== false) entry.resolve(business?.value)
-        else entry.reject(new Error(business?.error?.message ?? msg.error?.message ?? 'rpc failed'))
+        else entry.reject(new Error(business?.error?.message ?? msg.error?.message
+          ?? (getUiLocale() === 'zh' ? 'RPC 请求失败' : 'RPC request failed')))
         break
       }
       case 'status':
@@ -99,7 +101,7 @@ export function connectPanel(): PanelApi {
   })
 
   port.onDisconnect.addListener(() => {
-    const error = new Error('background disconnected')
+    const error = new Error(getUiLocale() === 'zh' ? '后台连接已断开' : 'Background connection lost')
     for (const entry of pending.values()) entry.reject(error)
     pending.clear()
   })

--- a/extensions/dsh-browser/src/panel/events.ts
+++ b/extensions/dsh-browser/src/panel/events.ts
@@ -7,6 +7,9 @@
  * @module
  */
 
+import { getUiLocale, type UiLocale } from '../i18n.ts'
+import { PANEL_COPY } from './strings.ts'
+
 /** One rendered conversation row. */
 export interface Row {
   seq: number
@@ -61,23 +64,9 @@ export function rowFromEvent(event: SessionEventView): Row | null {
   }
 }
 
-const TOOL_LABELS: Record<string, string> = {
-  browser_snapshot: '读取页面',
-  browser_click: '点击元素',
-  browser_type: '填写内容',
-  browser_press: '按下按键',
-  browser_scroll: '滚动页面',
-  browser_navigate: '打开页面',
-  browser_back: '返回上一页',
-  browser_forward: '前进下一页',
-  browser_reload: '刷新页面',
-  browser_get_text: '提取文字',
-  browser_wait: '等待页面',
-}
-
 /** 工具调用的友好展示名：带 index 参数时附上（如「点击元素 #7」）。 */
-export function toolSummary(name: string, argsJson: unknown): string {
-  let summary = TOOL_LABELS[name] ?? name
+export function toolSummary(name: string, argsJson: unknown, locale: UiLocale = getUiLocale()): string {
+  let summary = PANEL_COPY[locale].tool.labels[name] ?? name
   try {
     const args = JSON.parse(String(argsJson ?? '{}')) as unknown
     if (typeof args === 'object' && args !== null && 'index' in args) {
@@ -111,21 +100,25 @@ export function completeLastTool(rows: Row[], seq: number): Row[] {
 }
 
 /** 历史渲染：连续工具调用归并成一行（tool/call..result 不逐条刷屏；超 3 个折叠计数）。 */
-export function mergeHistoryRows(events: SessionEventView[], nextSeq: () => number): Row[] {
+export function mergeHistoryRows(
+  events: SessionEventView[],
+  nextSeq: () => number,
+  locale: UiLocale = getUiLocale(),
+): Row[] {
   const rows: Row[] = []
   let pendingTool: { items: string[]; total: number } | null = null
   const flushTool = (): void => {
     if (pendingTool === null) return
     const shown = pendingTool.items.slice(0, 3)
     const label = pendingTool.total > shown.length
-      ? `${shown.join(' → ')} 等${pendingTool.total}个工具`
+      ? PANEL_COPY[locale].tool.overflow(shown, pendingTool.total)
       : shown.join(' → ')
     rows.push({ seq: nextSeq(), kind: 'tool', text: label, status: 'complete' })
     pendingTool = null
   }
   for (const ev of events) {
     if (ev.type === 'tool/call') {
-      const summary = toolSummary(ev.data?.name ?? 'tool', ev.data?.arguments)
+      const summary = toolSummary(ev.data?.name ?? 'tool', ev.data?.arguments, locale)
       if (pendingTool === null) pendingTool = { items: [summary], total: 1 }
       else {
         pendingTool.items.push(summary)

--- a/extensions/dsh-browser/src/panel/main.tsx
+++ b/extensions/dsh-browser/src/panel/main.tsx
@@ -1,6 +1,12 @@
 import { createRoot } from 'react-dom/client'
 import { App } from './App.tsx'
 import './styles.css'
+import { getUiLocale } from '../i18n.ts'
+import { PANEL_COPY } from './strings.ts'
+
+const locale = getUiLocale()
+document.documentElement.lang = locale === 'zh' ? 'zh-CN' : 'en'
+document.title = PANEL_COPY[locale].documentTitle
 
 const root = document.getElementById('root')
 if (root === null) throw new Error('panel root missing')

--- a/extensions/dsh-browser/src/panel/strings.ts
+++ b/extensions/dsh-browser/src/panel/strings.ts
@@ -1,0 +1,266 @@
+import type { BridgeState } from '../background/bridge.ts'
+import type { UiLocale } from '../i18n.ts'
+
+export interface PanelCopy {
+  documentTitle: string
+  status: Record<BridgeState, string>
+  approval: {
+    eyebrow: string
+    readTitle: string
+    actionTitle: string
+    request: string
+    origins: string
+    unknownOrigin: string
+    deny: string
+    allowOnce: string
+    alwaysAllowReads: string
+    trustSession: string
+    readFootnote: string
+    actionFootnote: string
+  }
+  tool: {
+    running: string
+    complete: string
+    inProgress: string
+    completed: string
+    done: string
+    labels: Record<string, string>
+    overflow: (shown: string[], total: number) => string
+  }
+  settings: {
+    back: string
+    eyebrow: string
+    title: string
+    bridgeAddress: string
+    bridgeHelp: string
+    bridgePlaceholder: string
+    tokenHelp: string
+    tokenPlaceholder: string
+    pageSharing: string
+    pageSharingHelp: string
+    sharingAuto: string
+    sharingAsk: string
+    sharingOff: string
+    trustedOrigins: string
+    trustedOriginsHelp: string
+    trustedOriginInput: string
+    add: string
+    invalidOrigin: string
+    noTrustedOrigins: string
+    remove: string
+    removeOrigin: (origin: string) => string
+    save: string
+    cancel: string
+    snapshotHint: (maxChars: number) => string
+  }
+  app: {
+    brand: string
+    tagline: string
+    openSettings: string
+    settings: string
+    currentPage: string
+    waitingForPage: string
+    readPage: string
+    readPagePrompt: string
+    emptyTitle: string
+    emptyDescription: string
+    overviewPage: string
+    overviewPrompt: string
+    assistant: string
+    assistantWorking: string
+    organizingResults: string
+    thinking: string
+    connectedPlaceholder: string
+    disconnectedPlaceholder: string
+    composerHelp: string
+    sendMessage: string
+  }
+}
+
+const EN: PanelCopy = {
+  documentTitle: 'dsh Browser Assistant',
+  status: {
+    connected: 'Connected',
+    connecting: 'Connecting…',
+    reconnecting: 'Reconnecting…',
+    stopped: 'Disconnected',
+  },
+  approval: {
+    eyebrow: 'Security check',
+    readTitle: 'Allow page access?',
+    actionTitle: 'Allow page action?',
+    request: 'Request',
+    origins: 'Origins involved',
+    unknownOrigin: 'Unknown origin',
+    deny: 'Deny',
+    allowOnce: 'Allow once',
+    alwaysAllowReads: 'Always allow reads',
+    trustSession: 'Trust this domain for this session',
+    readFootnote: 'Esc to deny · You can disable automatic reading in Settings at any time',
+    actionFootnote: 'Esc to deny · Temporary trust ends when the side panel closes · Typed content is never shown',
+  },
+  tool: {
+    running: 'Working on page',
+    complete: 'Page action',
+    inProgress: 'In progress',
+    completed: 'Completed',
+    done: 'Done',
+    labels: {
+      browser_snapshot: 'Read page',
+      browser_click: 'Click element',
+      browser_type: 'Enter text',
+      browser_press: 'Press key',
+      browser_scroll: 'Scroll page',
+      browser_navigate: 'Open page',
+      browser_back: 'Go back',
+      browser_forward: 'Go forward',
+      browser_reload: 'Reload page',
+      browser_get_text: 'Extract text',
+      browser_wait: 'Wait for page',
+    },
+    overflow: (shown, total) => `${shown.join(' → ')} → ${total - shown.length} more`,
+  },
+  settings: {
+    back: 'Back to chat',
+    eyebrow: 'Preferences',
+    title: 'Connection & Privacy',
+    bridgeAddress: 'Bridge address',
+    bridgeHelp: 'Leave blank to detect a local service automatically',
+    bridgePlaceholder: 'Auto-detect 3080 / 3081 / 3090',
+    tokenHelp: 'Not required for local connections',
+    tokenPlaceholder: 'Required for remote deployments',
+    pageSharing: 'Page content sharing',
+    pageSharingHelp: 'Control when the assistant can read page text',
+    sharingAuto: 'Share automatically (default)',
+    sharingAsk: 'Ask every time',
+    sharingOff: 'Off',
+    trustedOrigins: 'Always-allowed domains',
+    trustedOriginsHelp: 'The approval dialog can trust a domain for the current side-panel session only. Domains added here permanently skip action confirmation; explicit cross-origin navigation will still ask.',
+    trustedOriginInput: 'Domain to always trust',
+    add: 'Add',
+    invalidOrigin: 'Enter a complete http:// or https:// address.',
+    noTrustedOrigins: 'No domains are currently trusted.',
+    remove: 'Remove',
+    removeOrigin: (origin) => `Remove ${origin}`,
+    save: 'Save & Connect',
+    cancel: 'Cancel',
+    snapshotHint: (maxChars) => `Page snapshots are limited to ${maxChars} characters and longer content is truncated. Change snapshotMaxChars in the dsh plugin to adjust this limit.`,
+  },
+  app: {
+    brand: 'Browser Assistant',
+    tagline: 'Page copilot',
+    openSettings: 'Open settings',
+    settings: 'Settings',
+    currentPage: 'Current page',
+    waitingForPage: 'Waiting for a browser page',
+    readPage: 'Read page',
+    readPagePrompt: 'Use browser_snapshot to read the current page, tell me what is on it, and then wait for my instructions.',
+    emptyTitle: 'Hand me the current page',
+    emptyDescription: 'I can read the page, find information, and click, fill, or navigate for you.',
+    overviewPage: 'Give me an overview',
+    overviewPrompt: 'First give me an overview of the current page, tell me the most important information, and wait for my next instruction.',
+    assistant: 'Assistant',
+    assistantWorking: 'Assistant is working',
+    organizingResults: 'Organizing results',
+    thinking: 'Thinking',
+    connectedPlaceholder: 'Tell me what you want to do on this page…',
+    disconnectedPlaceholder: 'Connect to dsh to get started',
+    composerHelp: 'Enter to send · Shift + Enter for a new line',
+    sendMessage: 'Send message',
+  },
+}
+
+const ZH: PanelCopy = {
+  documentTitle: 'dsh 浏览器助手',
+  status: {
+    connected: '已连接',
+    connecting: '连接中…',
+    reconnecting: '重连中…',
+    stopped: '未连接',
+  },
+  approval: {
+    eyebrow: '安全检查',
+    readTitle: '允许读取页面？',
+    actionTitle: '允许执行页面操作？',
+    request: '请求',
+    origins: '涉及来源',
+    unknownOrigin: '未知来源',
+    deny: '拒绝',
+    allowOnce: '仅允许这一次',
+    alwaysAllowReads: '始终允许读取',
+    trustSession: '本次会话信任此域',
+    readFootnote: 'Esc 拒绝 · 可随时在设置中关闭自动读取',
+    actionFootnote: 'Esc 拒绝 · 关闭侧栏后临时信任失效 · 输入内容不会显示',
+  },
+  tool: {
+    running: '正在操作页面',
+    complete: '页面操作',
+    inProgress: '进行中',
+    completed: '已完成',
+    done: '完成',
+    labels: {
+      browser_snapshot: '读取页面',
+      browser_click: '点击元素',
+      browser_type: '填写内容',
+      browser_press: '按下按键',
+      browser_scroll: '滚动页面',
+      browser_navigate: '打开页面',
+      browser_back: '返回上一页',
+      browser_forward: '前进下一页',
+      browser_reload: '刷新页面',
+      browser_get_text: '提取文字',
+      browser_wait: '等待页面',
+    },
+    overflow: (shown, total) => `${shown.join(' → ')} 等${total}个工具`,
+  },
+  settings: {
+    back: '返回对话',
+    eyebrow: '偏好设置',
+    title: '连接与隐私',
+    bridgeAddress: '桥地址',
+    bridgeHelp: '留空时自动检测本机服务',
+    bridgePlaceholder: '自动检测 3080 / 3081 / 3090',
+    tokenHelp: '本地连接无需填写',
+    tokenPlaceholder: '远程部署时填写',
+    pageSharing: '页面内容共享',
+    pageSharingHelp: '控制助手何时可以读取页面文字',
+    sharingAuto: '自动共享（默认）',
+    sharingAsk: '每次询问',
+    sharingOff: '关闭',
+    trustedOrigins: '永久免确认域名',
+    trustedOriginsHelp: '审批框可只信任本次侧栏会话。这里添加的域名会长期免除操作确认；显式跨域导航仍会询问。',
+    trustedOriginInput: '要永久信任的域名',
+    add: '添加',
+    invalidOrigin: '请输入完整的 http:// 或 https:// 地址。',
+    noTrustedOrigins: '尚未信任任何域名。',
+    remove: '移除',
+    removeOrigin: (origin) => `移除 ${origin}`,
+    save: '保存并连接',
+    cancel: '取消',
+    snapshotHint: (maxChars) => `页面快照上限为 ${maxChars} 字符，超出内容会被截断。可在 dsh 插件中调整 snapshotMaxChars。`,
+  },
+  app: {
+    brand: '浏览助手',
+    tagline: '页面副驾驶',
+    openSettings: '打开设置',
+    settings: '设置',
+    currentPage: '当前页面',
+    waitingForPage: '等待浏览器页面',
+    readPage: '读取页面',
+    readPagePrompt: '请用 browser_snapshot 读取当前页面，然后告诉我页面上有什么，并等待我的指令。',
+    emptyTitle: '把当前页面交给我',
+    emptyDescription: '我可以阅读页面、查找信息，也可以替你点击、填写和导航。',
+    overviewPage: '先概览这个页面',
+    overviewPrompt: '请先概览当前页面，告诉我最重要的信息，并等待我的下一步指令。',
+    assistant: '助手',
+    assistantWorking: '助手正在处理',
+    organizingResults: '正在整理结果',
+    thinking: '正在思考',
+    connectedPlaceholder: '告诉我想在这个页面做什么…',
+    disconnectedPlaceholder: '连接 dsh 后即可开始',
+    composerHelp: 'Enter 发送 · Shift + Enter 换行',
+    sendMessage: '发送消息',
+  },
+}
+
+export const PANEL_COPY: Record<UiLocale, PanelCopy> = { en: EN, zh: ZH }

--- a/extensions/dsh-browser/tests/authorization.spec.ts
+++ b/extensions/dsh-browser/tests/authorization.spec.ts
@@ -16,12 +16,12 @@ function call(name: string, args: Record<string, unknown> = {}): ToolCall {
 
 describe('approvalPromptForCall', () => {
   it('asks before reading and names every effective frame origin', () => {
-    expect(approvalPromptForCall(call('browser_snapshot'), 'ask', FRAMES)).toMatchObject({
+    expect(approvalPromptForCall(call('browser_snapshot'), 'ask', FRAMES, 'zh')).toMatchObject({
       kind: 'read',
       origins: ['https://app.example', 'https://login.example.net'],
       canTrust: false,
     })
-    expect(approvalPromptForCall(call('browser_snapshot'), 'auto', FRAMES)).toBeUndefined()
+    expect(approvalPromptForCall(call('browser_snapshot'), 'auto', FRAMES, 'zh')).toBeUndefined()
   })
 
   it('scopes a frame-local action to the frame origin and redacts typed text', () => {
@@ -29,7 +29,7 @@ describe('approvalPromptForCall', () => {
       frame: 4,
       index: 7,
       text: 'my-password-must-not-appear',
-    }), 'auto', FRAMES)
+    }), 'auto', FRAMES, 'zh')
 
     expect(prompt).toMatchObject({
       kind: 'action',
@@ -43,7 +43,7 @@ describe('approvalPromptForCall', () => {
   it('never offers persistent trust for cross-origin navigation', () => {
     const prompt = approvalPromptForCall(call('browser_navigate', {
       url: 'https://bank.example/transfer?token=secret#confirm',
-    }), 'auto', FRAMES)
+    }), 'auto', FRAMES, 'zh')
 
     expect(prompt).toMatchObject({
       origins: ['https://app.example', 'https://bank.example'],
@@ -54,17 +54,28 @@ describe('approvalPromptForCall', () => {
   })
 
   it('does not offer trust for invalid navigation and keeps key summaries on one bounded line', () => {
-    expect(approvalPromptForCall(call('browser_navigate', { url: 'javascript:alert(1)' }), 'auto', FRAMES))
+    expect(approvalPromptForCall(call('browser_navigate', { url: 'javascript:alert(1)' }), 'auto', FRAMES, 'zh'))
       .toMatchObject({ canTrust: false })
 
-    const prompt = approvalPromptForCall(call('browser_press', { key: `Enter\n${'x'.repeat(100)}` }), 'auto', FRAMES)
+    const prompt = approvalPromptForCall(call('browser_press', { key: `Enter\n${'x'.repeat(100)}` }), 'auto', FRAMES, 'zh')
     expect(prompt?.summary).not.toContain('\n')
     expect(prompt?.summary.length).toBeLessThan(70)
   })
 
   it('keeps read-only viewport tools outside the approval path', () => {
-    expect(approvalPromptForCall(call('browser_scroll', { direction: 'down' }), 'auto', FRAMES)).toBeUndefined()
-    expect(approvalPromptForCall(call('browser_wait'), 'auto', FRAMES)).toBeUndefined()
+    expect(approvalPromptForCall(call('browser_scroll', { direction: 'down' }), 'auto', FRAMES, 'zh')).toBeUndefined()
+    expect(approvalPromptForCall(call('browser_wait'), 'auto', FRAMES, 'zh')).toBeUndefined()
+  })
+
+  it('renders approval summaries in English for non-Chinese browsers', () => {
+    expect(approvalPromptForCall(call('browser_type', {
+      index: 3,
+      text: 'secret',
+    }), 'auto', FRAMES, 'en')?.summary).toBe(
+      'Enter 6 characters in element [3] (the text is not shown in this dialog)',
+    )
+    expect(approvalPromptForCall(call('browser_snapshot'), 'ask', FRAMES, 'en')?.summary)
+      .toBe('Read the current page and accessible iframes')
   })
 })
 

--- a/extensions/dsh-browser/tests/i18n.spec.ts
+++ b/extensions/dsh-browser/tests/i18n.spec.ts
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getUiLocale, localeFromLanguage } from '../src/i18n.ts'
+import { PANEL_COPY } from '../src/panel/strings.ts'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('browser locale selection', () => {
+  it('uses Chinese for every zh locale variant', () => {
+    expect(localeFromLanguage('zh')).toBe('zh')
+    expect(localeFromLanguage('zh-CN')).toBe('zh')
+    expect(localeFromLanguage('zh-TW')).toBe('zh')
+    expect(localeFromLanguage('ZH-hant-HK')).toBe('zh')
+  })
+
+  it('defaults every non-Chinese or missing locale to English', () => {
+    expect(localeFromLanguage('en-US')).toBe('en')
+    expect(localeFromLanguage('ja-JP')).toBe('en')
+    expect(localeFromLanguage('fr')).toBe('en')
+    expect(localeFromLanguage(undefined)).toBe('en')
+  })
+
+  it('uses the browser\'s first preferred language', () => {
+    vi.stubGlobal('navigator', { languages: ['zh-Hant', 'en-US'], language: 'en-US' })
+    expect(getUiLocale()).toBe('zh')
+
+    vi.stubGlobal('navigator', { languages: ['de-DE', 'zh-CN'], language: 'de-DE' })
+    expect(getUiLocale()).toBe('en')
+  })
+
+  it('provides localized panel and prompt copy in both languages', () => {
+    expect(PANEL_COPY.en.app.readPage).toBe('Read page')
+    expect(PANEL_COPY.en.approval.allowOnce).toBe('Allow once')
+    expect(PANEL_COPY.en.app.readPagePrompt).toMatch(/^Use browser_snapshot/)
+    expect(PANEL_COPY.zh.app.readPage).toBe('读取页面')
+    expect(PANEL_COPY.zh.approval.allowOnce).toBe('仅允许这一次')
+  })
+})

--- a/extensions/dsh-browser/tests/panel-events.spec.ts
+++ b/extensions/dsh-browser/tests/panel-events.spec.ts
@@ -61,10 +61,11 @@ describe('rowFromEvent', () => {
 
 describe('toolSummary', () => {
   it('appends the inventory index when present', () => {
-    expect(toolSummary('browser_click', '{"index":7}')).toBe('点击元素 #7')
-    expect(toolSummary('browser_snapshot', '{"delta":true}')).toBe('读取页面')
-    expect(toolSummary('browser_navigate', 'not-json')).toBe('打开页面')
-    expect(toolSummary('custom_tool', '{}')).toBe('custom_tool')
+    expect(toolSummary('browser_click', '{"index":7}', 'zh')).toBe('点击元素 #7')
+    expect(toolSummary('browser_snapshot', '{"delta":true}', 'zh')).toBe('读取页面')
+    expect(toolSummary('browser_navigate', 'not-json', 'zh')).toBe('打开页面')
+    expect(toolSummary('custom_tool', '{}', 'zh')).toBe('custom_tool')
+    expect(toolSummary('browser_click', '{"index":7}', 'en')).toBe('Click element #7')
   })
 })
 
@@ -99,7 +100,7 @@ describe('mergeHistoryRows', () => {
       ev('assistant/message', { message: { content: [{ type: 'text', text: '已点击' }] } }),
       ev('turn/end', {}),
     ]
-    const rows = mergeHistoryRows(events, nextSeq)
+    const rows = mergeHistoryRows(events, nextSeq, 'zh')
     expect(rows.map((r) => r.kind)).toEqual(['user', 'tool', 'assistant'])
     expect(rows[0]!.text).toBe('操作页面')
     expect(rows[2]!.text).toBe('已点击')
@@ -113,7 +114,7 @@ describe('mergeHistoryRows', () => {
       ev('assistant/message', { message: { content: [{ type: 'tool_use', name: 'browser_snapshot' }] } }),
       ev('tool/call', { name: 'browser_snapshot', arguments: '{}' }),
       ev('tool/result', {}),
-    ], () => { seq += 1; return seq })
+    ], () => { seq += 1; return seq }, 'zh')
     expect(rows).toEqual([{ seq: 1, kind: 'tool', text: '读取页面', status: 'complete' }])
   })
 

--- a/extensions/dsh-browser/vite.shared.ts
+++ b/extensions/dsh-browser/vite.shared.ts
@@ -11,12 +11,13 @@ import { defineConfig } from 'vite'
 
 export const outDir = resolve(import.meta.dirname, 'dist')
 
-/** Copy manifest.json into dist after each target build (Chrome loads dist/). */
+/** Copy manifest, locale catalogs, and icons into dist (Chrome loads dist/). */
 export const copyManifest = {
   name: 'copy-manifest',
   closeBundle(): void {
     mkdirSync(outDir, { recursive: true })
     copyFileSync(resolve(import.meta.dirname, 'manifest.json'), resolve(outDir, 'manifest.json'))
+    cpSync(resolve(import.meta.dirname, '_locales'), resolve(outDir, '_locales'), { recursive: true })
     cpSync(resolve(import.meta.dirname, 'assets'), resolve(outDir, 'assets'), { recursive: true })
   },
 }


### PR DESCRIPTION
## Summary

- select Chinese when the browser's first preferred language is `zh` or `zh-*`, and English for every other language
- localize the complete side-panel UI, settings, approval dialogs, tool activity, accessibility labels, built-in prompts, and connection errors
- localize the Chrome extension name, description, and action title through `_locales/en`, `_locales/zh_CN`, and `_locales/zh_TW`
- package locale catalogs into the production extension build

## User impact

The extension now opens in the user's browser language without requiring a setting. Existing connection, page-sharing, and trusted-origin preferences are unchanged. English quick actions also send English prompts, so the initial assistant response follows the English experience.

## Validation

- `pnpm run typecheck`
- `pnpm run test` — 159 tests passed (81 bridge + 78 extension)
- `pnpm run build`
