### PR TITLE
feat(panel): answer agent questions and stop active turns

### DIFF
--- a/extensions/dsh-browser/README.md
+++ b/extensions/dsh-browser/README.md
@@ -31,7 +31,7 @@ side panel (React) ◄─port─► background SW ◄─WS─► dsh bridge plug
 
 - **background** (`src/background/`): bridge connection (token auth + exponential-backoff reconnect + keepalive), gateway RPC client, **tool dispatch to the active tab**.
 - **content script** (`src/content/`): text-only snapshot (readability main text + numbered interactive inventory + form fields), **stable element numbers** (`data-dsh-el`), delta changes, click/type/press/scroll/navigate actions, sensitive-field masking.
-- **panel** (`src/panel/`): React conversation UI (isolated session/history/live events/settings); messages render as Markdown (headings/lists/code blocks/tables, sanitized).
+- **panel** (`src/panel/`): React conversation UI (isolated session/history/live events/settings); messages render as sanitized Markdown, `ask_user_question` requests render as answerable cards, and an active turn exposes a standard stop control.
 - **Protocol**: `protocol.ts` in the `@deepseek-ai/dsh-bridge-browser` workspace package is the single source of truth, shared by both ends through the package's source export.
 
 ## Build

--- a/extensions/dsh-browser/README.zh.md
+++ b/extensions/dsh-browser/README.zh.md
@@ -31,7 +31,7 @@ side panel (React) ◄─port─► background SW ◄─WS─► dsh bridge plug
 
 - **background**（`src/background/`）：桥连接（token 认证 + 指数退避重连 + 保活）、网关 RPC 客户端、**工具分发到活动标签页**。
 - **content script**（`src/content/`）：纯文本快照（可读性主文 + 编号交互清单 + 表单字段）、**稳定编号**（`data-dsh-el`）、delta 变化、点击/输入/按键/滚动/导航动作、敏感字段掩码。
-- **panel**（`src/panel/`）：React 对话界面（独立会话/历史/实时事件/设置），消息以 Markdown 渲染（标题/列表/代码块/表格等，已消毒）。
+- **panel**（`src/panel/`）：React 对话界面（独立会话/历史/实时事件/设置），消息以已消毒的 Markdown 渲染；`ask_user_question` 请求会显示成可直接作答的卡片，运行中的回合提供标准停止按钮。
 - **协议**：`@deepseek-ai/dsh-bridge-browser` workspace 包中的 `protocol.ts` 是两端共享的真源，具体通过该包的源码 export 共享。
 
 ## 构建

--- a/extensions/dsh-browser/src/background/index.ts
+++ b/extensions/dsh-browser/src/background/index.ts
@@ -7,10 +7,12 @@
  *
  * Panel port protocol (chrome.runtime.connect, name "dsh-panel"):
  *   panel → bg: { type: 'rpc', id, method, payload }
+ *   panel → bg: { type: 'respond', id, rpcId, result }
  *   panel → bg: { type: 'settings', settings: Partial<Settings> }
  *   panel → bg: { type: 'approval.response', id, decision }
  *   panel → bg: { type: 'request-status' }
  *   bg → panel: { type: 'rpc.result', id, ok, result? | error? }
+ *   bg → panel: { type: 'respond.result', id, ok, result? | error? }
  *   bg → panel: { type: 'status', state: BridgeState, caps? }
  *   bg → panel: { type: 'event', frame: ServerFrame }
  *   bg → panel: { type: 'approval.request', request }
@@ -19,7 +21,7 @@
  * @module
  */
 
-import type { BridgeCaps } from '@deepseek-ai/dsh-bridge-browser/src/protocol.ts'
+import { isRespondResult, type BridgeCaps, type RespondResult } from '@deepseek-ai/dsh-bridge-browser/src/protocol.ts'
 import type { ServerFrame } from '@deepseek-ai/dsh-bridge-browser/src/protocol.ts'
 import { BRIDGE_CONFIG_PATH, BRIDGE_PATH } from '@deepseek-ai/dsh-bridge-browser/src/protocol.ts'
 import { BridgeClient, type BridgeState } from './bridge.ts'
@@ -32,6 +34,7 @@ import {
   type ApprovalRequest,
 } from '../security/approval.ts'
 import { getUiLocale } from '../i18n.ts'
+import { InteractionResponseRouter } from './responses.ts'
 
 /** User settings persisted in chrome.storage.local. */
 export interface Settings {
@@ -96,6 +99,7 @@ let caps: BridgeCaps | null = null
 let bridge: BridgeClient | null = null
 let rpc: ReturnType<typeof createRpc> | null = null
 const panelPorts = new Set<chrome.runtime.Port>()
+const interactionResponses = new InteractionResponseRouter()
 /** Ephemeral allowlist: cleared when the last side panel closes or this worker restarts. */
 const sessionTrustedActionOrigins = new Set<string>()
 /** Tool calls that can still be withdrawn by a bridge `tool.cancel` frame. */
@@ -158,6 +162,22 @@ function broadcastApprovalResolved(id: string): void {
   for (const port of panelPorts) {
     try { port.postMessage({ type: 'approval.resolved', id }) } catch { /* port already closed */ }
   }
+}
+
+function responseMessages(): { unavailable: string; timeout: string; duplicate: string; disconnected: string } {
+  return getUiLocale() === 'zh'
+    ? {
+        unavailable: '未连接 dsh，无法提交回答',
+        timeout: '提交回答超时，请重试',
+        duplicate: '回答请求编号重复，请重试',
+        disconnected: 'dsh 连接已断开，请重新连接后再试',
+      }
+    : {
+        unavailable: 'dsh is not connected, so the answer could not be sent',
+        timeout: 'Sending the answer timed out. Try again.',
+        duplicate: 'The answer request ID was duplicated. Try again.',
+        disconnected: 'The dsh connection was lost. Reconnect and try again.',
+      }
 }
 
 function settleApproval(id: string, decision: ApprovalDecision): void {
@@ -316,13 +336,17 @@ async function startBridge(): Promise<void> {
   if (bridge === null) {
     const client = new BridgeClient({
       onStateChange: (state) => {
-        if (state !== 'connected') cancelAllToolCalls()
+        if (state !== 'connected') {
+          cancelAllToolCalls()
+          interactionResponses.failAll(responseMessages().disconnected)
+        }
         broadcastStatus()
       },
       onFrame: (frame) => {
         if (frame.t === 'event') broadcastEvent(frame)
         else if (frame.t === 'tool.call') routeToolCall(frame)
         else if (frame.t === 'tool.cancel') cancelToolCall(frame.id)
+        else if (frame.t === 'respond.result') interactionResponses.route(frame)
         // rpc.result is settled by the rpc facade (wrapped below).
       },
       onHelloOk: (negotiated) => {
@@ -377,6 +401,23 @@ chrome.runtime.onConnect.addListener((port) => {
         )
         break
       }
+      case 'respond': {
+        const response = message as { id?: unknown; rpcId?: unknown; result?: unknown }
+        if (typeof response.id !== 'string' || typeof response.rpcId !== 'string' || !isRespondResult(response.result)) break
+        const messages = responseMessages()
+        interactionResponses.begin(
+          port,
+          response.id,
+          () => bridge?.send({
+            t: 'respond',
+            id: response.id as string,
+            rpcId: response.rpcId as string,
+            result: response.result as RespondResult,
+          }) === true,
+          messages,
+        )
+        break
+      }
       case 'settings': {
         const settingsMsg = message as { settings: Partial<Settings> }
         void persistSettings(settingsMsg.settings).then(async () => {
@@ -399,6 +440,7 @@ chrome.runtime.onConnect.addListener((port) => {
   })
   port.onDisconnect.addListener(() => {
     panelPorts.delete(port)
+    interactionResponses.removePort(port)
     if (panelPorts.size === 0) {
       sessionTrustedActionOrigins.clear()
       for (const id of [...pendingApprovals.keys()]) settleApproval(id, 'deny')

--- a/extensions/dsh-browser/src/background/responses.ts
+++ b/extensions/dsh-browser/src/background/responses.ts
@@ -1,0 +1,81 @@
+import type { ServerFrame } from '@deepseek-ai/dsh-bridge-browser/src/protocol.ts'
+
+type ResponseReceipt = Extract<ServerFrame, { t: 'respond.result' }>
+
+/** Minimal panel-port surface needed for targeted interaction receipts. */
+export interface ResponsePort {
+  postMessage(message: unknown): void
+}
+
+interface PendingResponse {
+  port: ResponsePort
+  timer: ReturnType<typeof setTimeout>
+}
+
+/**
+ * Correlates one interaction response with the panel that sent it. Receipts
+ * must never be broadcast: separate side panels can answer at the same time.
+ */
+export class InteractionResponseRouter {
+  private readonly pending = new Map<string, PendingResponse>()
+
+  constructor(private readonly timeoutMs = 30_000) {}
+
+  begin(
+    port: ResponsePort,
+    id: string,
+    dispatch: () => boolean,
+    messages: { unavailable: string; timeout: string; duplicate: string },
+  ): void {
+    if (this.pending.has(id)) {
+      this.postError(port, id, 'duplicate-id', messages.duplicate)
+      return
+    }
+    const timer = setTimeout(() => {
+      const entry = this.take(id)
+      if (entry !== undefined) this.postError(entry.port, id, 'timeout', messages.timeout)
+    }, this.timeoutMs)
+    this.pending.set(id, { port, timer })
+    if (!dispatch()) {
+      const entry = this.take(id)
+      if (entry !== undefined) this.postError(entry.port, id, 'bridge-unavailable', messages.unavailable)
+    }
+  }
+
+  route(receipt: ResponseReceipt): void {
+    const entry = this.take(receipt.id)
+    if (entry === undefined) return
+    try {
+      entry.port.postMessage(receipt.ok
+        ? { type: 'respond.result', id: receipt.id, ok: true, result: receipt.result }
+        : { type: 'respond.result', id: receipt.id, ok: false, error: receipt.error })
+    } catch { /* panel already closed */ }
+  }
+
+  failAll(message: string): void {
+    for (const id of [...this.pending.keys()]) {
+      const entry = this.take(id)
+      if (entry !== undefined) this.postError(entry.port, id, 'bridge-disconnected', message)
+    }
+  }
+
+  removePort(port: ResponsePort): void {
+    for (const [id, entry] of this.pending) {
+      if (entry.port !== port) continue
+      clearTimeout(entry.timer)
+      this.pending.delete(id)
+    }
+  }
+
+  private take(id: string): PendingResponse | undefined {
+    const entry = this.pending.get(id)
+    if (entry === undefined) return undefined
+    clearTimeout(entry.timer)
+    this.pending.delete(id)
+    return entry
+  }
+
+  private postError(port: ResponsePort, id: string, code: string, message: string): void {
+    try { port.postMessage({ type: 'respond.result', id, ok: false, error: { code, message } }) } catch { /* panel already closed */ }
+  }
+}

--- a/extensions/dsh-browser/src/panel/App.tsx
+++ b/extensions/dsh-browser/src/panel/App.tsx
@@ -19,6 +19,12 @@ import { getUiLocale } from '../i18n.ts'
 import { PANEL_COPY, type PanelCopy } from './strings.ts'
 import { QuestionCard } from './QuestionCard.tsx'
 import type { QuestionAnswer } from './questions.ts'
+import {
+  hasPendingQuestion,
+  questionReceiptDisposition,
+  removePendingQuestion,
+  upsertPendingQuestion,
+} from './pending-questions.ts'
 
 /** One rendered conversation row. */
 import {
@@ -31,6 +37,7 @@ import {
   toolSummary,
   type Row,
   type PendingQuestion,
+  type ResolvedQuestion,
   type SessionEventView,
 } from './events.ts'
 
@@ -197,26 +204,48 @@ export function App(): React.JSX.Element {
   const [approvalQueue, setApprovalQueue] = useState<ApprovalRequest[]>([])
   const [trustedOriginInput, setTrustedOriginInput] = useState('')
   const [error, setError] = useState<string | null>(null)
-  const [question, setQuestion] = useState<PendingQuestion | null>(null)
-  const [questionSubmitting, setQuestionSubmitting] = useState(false)
-  const questionRef = useRef<PendingQuestion | null>(null)
-  const questionSubmittingRef = useRef(false)
+  const [questions, setQuestions] = useState<PendingQuestion[]>([])
+  const [questionSubmissions, setQuestionSubmissions] = useState<ResolvedQuestion[]>([])
+  const questionsRef = useRef<PendingQuestion[]>([])
+  const questionSubmissionsRef = useRef<ResolvedQuestion[]>([])
   const stoppingRef = useRef(false)
   const seqRef = useRef(0)
   const sessionRef = useRef<string | null>(null)
   const scrollRef = useRef<HTMLDivElement | null>(null)
 
   const nextSeq = (): number => { seqRef.current += 1; return seqRef.current }
+  const question = questions[0] ?? null
+  const questionSubmitting = question !== null && hasPendingQuestion(questionSubmissions, question)
 
-  function replaceQuestion(next: PendingQuestion | null): void {
-    questionRef.current = next
-    setQuestion(next)
-    if (next === null) setQuestionBusy(false)
+  function replaceQuestions(next: PendingQuestion[]): void {
+    questionsRef.current = next
+    setQuestions(next)
   }
 
-  function setQuestionBusy(next: boolean): void {
-    questionSubmittingRef.current = next
-    setQuestionSubmitting(next)
+  function enqueueQuestion(next: PendingQuestion): void {
+    replaceQuestions(upsertPendingQuestion(questionsRef.current, next))
+  }
+
+  function removeQuestion(target: ResolvedQuestion): void {
+    replaceQuestions(removePendingQuestion(questionsRef.current, target))
+    setQuestionBusy(target, false)
+  }
+
+  function clearQuestions(): void {
+    replaceQuestions([])
+    questionSubmissionsRef.current = []
+    setQuestionSubmissions([])
+  }
+
+  function setQuestionBusy(target: PendingQuestion | ResolvedQuestion, next: boolean): void {
+    const current = questionSubmissionsRef.current
+    const updated = next
+      ? hasPendingQuestion(current, target)
+        ? current
+        : [...current, { sessionId: target.sessionId, rpcId: target.rpcId }]
+      : removePendingQuestion(current, target)
+    questionSubmissionsRef.current = updated
+    setQuestionSubmissions(updated)
   }
 
   // Settings: seed from storage, then let the panel own the form.
@@ -249,7 +278,7 @@ export function App(): React.JSX.Element {
         setWorking(false)
         setStopping(false)
         stoppingRef.current = false
-        replaceQuestion(null)
+        clearQuestions()
         setSessionEpoch((epoch) => epoch + 1)
       }
     })
@@ -304,20 +333,15 @@ export function App(): React.JSX.Element {
     const pendingQuestion = pendingQuestionFromFrame(frame.frame)
     if (pendingQuestion !== null) {
       if (pendingQuestion.sessionId === sessionRef.current) {
-        replaceQuestion(pendingQuestion)
-        setQuestionBusy(false)
-        setError(null)
+        const wasEmpty = questionsRef.current.length === 0
+        enqueueQuestion(pendingQuestion)
+        if (wasEmpty) setError(null)
       }
       return
     }
     const resolvedQuestion = resolvedQuestionFromFrame(frame.frame)
     if (resolvedQuestion !== null) {
-      const current = questionRef.current
-      if (current !== null
-        && current.sessionId === resolvedQuestion.sessionId
-        && current.rpcId === resolvedQuestion.rpcId) {
-        replaceQuestion(null)
-      }
+      removeQuestion(resolvedQuestion)
       return
     }
     const payload = frame.frame.payload as { sessionId?: string; event?: SessionEventView } | undefined
@@ -349,47 +373,62 @@ export function App(): React.JSX.Element {
       stoppingRef.current = false
       setStopping(false)
       setWorking(false)
-      replaceQuestion(null)
+      clearQuestions()
       await refreshHistory()
     }
   }
 
   async function answerQuestion(target: PendingQuestion, answers: QuestionAnswer[]): Promise<void> {
-    if (questionSubmittingRef.current || questionRef.current?.rpcId !== target.rpcId) return
-    setQuestionBusy(true)
+    if (hasPendingQuestion(questionSubmissionsRef.current, target)
+      || !hasPendingQuestion(questionsRef.current, target)) return
+    setQuestionBusy(target, true)
     setError(null)
     try {
       const receipt = await api.respond(target.rpcId, {
         ok: true,
         value: { sessionId: target.sessionId, answer: { answers } },
       })
-      if (isRejectedReceipt(receipt)) setError(copy.question.alreadyAnswered)
-      if (questionRef.current?.rpcId === target.rpcId) replaceQuestion(null)
+      settleQuestionReceipt(target, receipt)
     } catch (cause) {
-      if (questionRef.current?.rpcId === target.rpcId) {
+      if (hasPendingQuestion(questionsRef.current, target)) {
         setError(cause instanceof Error ? cause.message : String(cause))
-        setQuestionBusy(false)
       }
+      setQuestionBusy(target, false)
     }
   }
 
   async function dismissQuestion(target: PendingQuestion): Promise<void> {
-    if (questionSubmittingRef.current || questionRef.current?.rpcId !== target.rpcId) return
-    setQuestionBusy(true)
+    if (hasPendingQuestion(questionSubmissionsRef.current, target)
+      || !hasPendingQuestion(questionsRef.current, target)) return
+    setQuestionBusy(target, true)
     setError(null)
     try {
       const receipt = await api.respond(target.rpcId, {
         ok: false,
         error: { code: 'cancelled', message: 'the user dismissed this question request', details: {} },
       })
-      if (isRejectedReceipt(receipt)) setError(copy.question.alreadyAnswered)
-      if (questionRef.current?.rpcId === target.rpcId) replaceQuestion(null)
+      settleQuestionReceipt(target, receipt)
     } catch (cause) {
-      if (questionRef.current?.rpcId === target.rpcId) {
+      if (hasPendingQuestion(questionsRef.current, target)) {
         setError(cause instanceof Error ? cause.message : String(cause))
-        setQuestionBusy(false)
       }
+      setQuestionBusy(target, false)
     }
+  }
+
+  function settleQuestionReceipt(target: PendingQuestion, receipt: unknown): void {
+    const disposition = questionReceiptDisposition(receipt)
+    if (disposition === 'accepted') {
+      removeQuestion(target)
+      return
+    }
+    if (disposition === 'not-pending') {
+      setError(copy.question.alreadyAnswered)
+      removeQuestion(target)
+      return
+    }
+    setError(copy.question.answerRejected)
+    setQuestionBusy(target, false)
   }
 
   async function refreshHistory(): Promise<void> {
@@ -451,7 +490,7 @@ export function App(): React.JSX.Element {
       await api.rpc('session.cancel', { sessionId: id })
       if (sessionRef.current === id) {
         setWorking(false)
-        replaceQuestion(null)
+        clearQuestions()
       }
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause))
@@ -627,7 +666,7 @@ export function App(): React.JSX.Element {
       </div>
       {question !== null && (
         <QuestionCard
-          key={question.rpcId}
+          key={`${question.sessionId}:${question.rpcId}`}
           question={question}
           copy={copy}
           submitting={questionSubmitting}
@@ -672,8 +711,4 @@ export function App(): React.JSX.Element {
       </footer>
     </div>{approvalDialog}</>
   )
-}
-
-function isRejectedReceipt(value: unknown): boolean {
-  return typeof value === 'object' && value !== null && (value as { accepted?: unknown }).accepted === false
 }

--- a/extensions/dsh-browser/src/panel/App.tsx
+++ b/extensions/dsh-browser/src/panel/App.tsx
@@ -17,15 +17,20 @@ import whaleUrl from '../../assets/icons/deepseek-256.png'
 import type { ApprovalDecision, ApprovalRequest } from '../security/approval.ts'
 import { getUiLocale } from '../i18n.ts'
 import { PANEL_COPY, type PanelCopy } from './strings.ts'
+import { QuestionCard } from './QuestionCard.tsx'
+import type { QuestionAnswer } from './questions.ts'
 
 /** One rendered conversation row. */
 import {
   appendLiveRow,
   completeLastTool,
   mergeHistoryRows,
+  pendingQuestionFromFrame,
+  resolvedQuestionFromFrame,
   rowFromEvent,
   toolSummary,
   type Row,
+  type PendingQuestion,
   type SessionEventView,
 } from './events.ts'
 
@@ -191,11 +196,26 @@ export function App(): React.JSX.Element {
   const [approvalQueue, setApprovalQueue] = useState<ApprovalRequest[]>([])
   const [trustedOriginInput, setTrustedOriginInput] = useState('')
   const [error, setError] = useState<string | null>(null)
+  const [question, setQuestion] = useState<PendingQuestion | null>(null)
+  const [questionSubmitting, setQuestionSubmitting] = useState(false)
+  const questionRef = useRef<PendingQuestion | null>(null)
+  const questionSubmittingRef = useRef(false)
   const seqRef = useRef(0)
   const sessionRef = useRef<string | null>(null)
   const scrollRef = useRef<HTMLDivElement | null>(null)
 
   const nextSeq = (): number => { seqRef.current += 1; return seqRef.current }
+
+  function replaceQuestion(next: PendingQuestion | null): void {
+    questionRef.current = next
+    setQuestion(next)
+    if (next === null) setQuestionBusy(false)
+  }
+
+  function setQuestionBusy(next: boolean): void {
+    questionSubmittingRef.current = next
+    setQuestionSubmitting(next)
+  }
 
   // Settings: seed from storage, then let the panel own the form.
   useEffect(() => {
@@ -225,6 +245,7 @@ export function App(): React.JSX.Element {
         sessionRef.current = null
         setRows([])
         setWorking(false)
+        replaceQuestion(null)
         setSessionEpoch((epoch) => epoch + 1)
       }
     })
@@ -276,6 +297,25 @@ export function App(): React.JSX.Element {
   /** Live frame handling: session events append rows; turn/end reconciles with history. */
   async function onFrame(frame: ServerFrame): Promise<void> {
     if (frame.t !== 'event') return
+    const pendingQuestion = pendingQuestionFromFrame(frame.frame)
+    if (pendingQuestion !== null) {
+      if (pendingQuestion.sessionId === sessionRef.current) {
+        replaceQuestion(pendingQuestion)
+        setQuestionBusy(false)
+        setError(null)
+      }
+      return
+    }
+    const resolvedQuestion = resolvedQuestionFromFrame(frame.frame)
+    if (resolvedQuestion !== null) {
+      const current = questionRef.current
+      if (current !== null
+        && current.sessionId === resolvedQuestion.sessionId
+        && current.rpcId === resolvedQuestion.rpcId) {
+        replaceQuestion(null)
+      }
+      return
+    }
     const payload = frame.frame.payload as { sessionId?: string; event?: SessionEventView } | undefined
     if (payload?.sessionId !== sessionRef.current || payload.event === undefined) return
     if (payload.event.type === 'turn/start') {
@@ -301,7 +341,46 @@ export function App(): React.JSX.Element {
     }
     if (payload.event.type === 'turn/end') {
       setWorking(false)
+      replaceQuestion(null)
       await refreshHistory()
+    }
+  }
+
+  async function answerQuestion(target: PendingQuestion, answers: QuestionAnswer[]): Promise<void> {
+    if (questionSubmittingRef.current || questionRef.current?.rpcId !== target.rpcId) return
+    setQuestionBusy(true)
+    setError(null)
+    try {
+      const receipt = await api.respond(target.rpcId, {
+        ok: true,
+        value: { sessionId: target.sessionId, answer: { answers } },
+      })
+      if (isRejectedReceipt(receipt)) setError(copy.question.alreadyAnswered)
+      if (questionRef.current?.rpcId === target.rpcId) replaceQuestion(null)
+    } catch (cause) {
+      if (questionRef.current?.rpcId === target.rpcId) {
+        setError(cause instanceof Error ? cause.message : String(cause))
+        setQuestionBusy(false)
+      }
+    }
+  }
+
+  async function dismissQuestion(target: PendingQuestion): Promise<void> {
+    if (questionSubmittingRef.current || questionRef.current?.rpcId !== target.rpcId) return
+    setQuestionBusy(true)
+    setError(null)
+    try {
+      const receipt = await api.respond(target.rpcId, {
+        ok: false,
+        error: { code: 'cancelled', message: 'the user dismissed this question request' },
+      })
+      if (isRejectedReceipt(receipt)) setError(copy.question.alreadyAnswered)
+      if (questionRef.current?.rpcId === target.rpcId) replaceQuestion(null)
+    } catch (cause) {
+      if (questionRef.current?.rpcId === target.rpcId) {
+        setError(cause instanceof Error ? cause.message : String(cause))
+        setQuestionBusy(false)
+      }
     }
   }
 
@@ -509,7 +588,7 @@ export function App(): React.JSX.Element {
             {row.kind === 'tool' ? <ToolActivity row={row} copy={copy} /> : <MessageBody row={row} />}
           </div>
         ))}
-        {working && rows[rows.length - 1]?.status !== 'running' && (
+        {working && question === null && rows[rows.length - 1]?.status !== 'running' && (
           <div className="ai-progress" role="status" aria-label={copy.app.assistantWorking}>
             <span className="assistant-avatar"><img src={whaleUrl} alt="" /></span>
             <span className="progress-dots" aria-hidden="true"><i /><i /><i /></span>
@@ -517,6 +596,16 @@ export function App(): React.JSX.Element {
           </div>
         )}
       </div>
+      {question !== null && (
+        <QuestionCard
+          key={question.rpcId}
+          question={question}
+          copy={copy}
+          submitting={questionSubmitting}
+          onAnswer={(answers) => { void answerQuestion(question, answers) }}
+          onDismiss={() => { void dismissQuestion(question) }}
+        />
+      )}
       {error !== null && <div className="error">{error}</div>}
       <footer className="composer">
         <div className="composer-box">
@@ -542,4 +631,8 @@ export function App(): React.JSX.Element {
       </footer>
     </div>{approvalDialog}</>
   )
+}
+
+function isRejectedReceipt(value: unknown): boolean {
+  return typeof value === 'object' && value !== null && (value as { accepted?: unknown }).accepted === false
 }

--- a/extensions/dsh-browser/src/panel/App.tsx
+++ b/extensions/dsh-browser/src/panel/App.tsx
@@ -192,6 +192,7 @@ export function App(): React.JSX.Element {
   const [input, setInput] = useState('')
   const [busy, setBusy] = useState(false)
   const [working, setWorking] = useState(false)
+  const [stopping, setStopping] = useState(false)
   const [showSettings, setShowSettings] = useState(false)
   const [approvalQueue, setApprovalQueue] = useState<ApprovalRequest[]>([])
   const [trustedOriginInput, setTrustedOriginInput] = useState('')
@@ -200,6 +201,7 @@ export function App(): React.JSX.Element {
   const [questionSubmitting, setQuestionSubmitting] = useState(false)
   const questionRef = useRef<PendingQuestion | null>(null)
   const questionSubmittingRef = useRef(false)
+  const stoppingRef = useRef(false)
   const seqRef = useRef(0)
   const sessionRef = useRef<string | null>(null)
   const scrollRef = useRef<HTMLDivElement | null>(null)
@@ -245,6 +247,8 @@ export function App(): React.JSX.Element {
         sessionRef.current = null
         setRows([])
         setWorking(false)
+        setStopping(false)
+        stoppingRef.current = false
         replaceQuestion(null)
         setSessionEpoch((epoch) => epoch + 1)
       }
@@ -319,6 +323,8 @@ export function App(): React.JSX.Element {
     const payload = frame.frame.payload as { sessionId?: string; event?: SessionEventView } | undefined
     if (payload?.sessionId !== sessionRef.current || payload.event === undefined) return
     if (payload.event.type === 'turn/start') {
+      stoppingRef.current = false
+      setStopping(false)
       setWorking(true)
       return
     }
@@ -340,6 +346,8 @@ export function App(): React.JSX.Element {
       return
     }
     if (payload.event.type === 'turn/end') {
+      stoppingRef.current = false
+      setStopping(false)
       setWorking(false)
       replaceQuestion(null)
       await refreshHistory()
@@ -429,6 +437,27 @@ export function App(): React.JSX.Element {
     } finally {
       setBusy(false)
       sendingRef.current = false
+    }
+  }
+
+  /** Cancel the active turn while keeping the sidebar session available. */
+  async function stopTurn(): Promise<void> {
+    const id = sessionRef.current
+    if (id === null || stoppingRef.current) return
+    stoppingRef.current = true
+    setStopping(true)
+    setError(null)
+    try {
+      await api.rpc('session.cancel', { sessionId: id })
+      if (sessionRef.current === id) {
+        setWorking(false)
+        replaceQuestion(null)
+      }
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause))
+    } finally {
+      stoppingRef.current = false
+      setStopping(false)
     }
   }
 
@@ -625,7 +654,19 @@ export function App(): React.JSX.Element {
           />
           <div className="composer-actions">
             <span>{copy.app.composerHelp}</span>
-            <button onClick={() => void send()} disabled={state !== 'connected' || busy || input.trim() === ''} aria-label={copy.app.sendMessage}><SendIcon /></button>
+            {working ? (
+              <button
+                className="stop-button"
+                onClick={() => { void stopTurn() }}
+                disabled={state !== 'connected' || stopping}
+                aria-label={stopping ? copy.app.stoppingTurn : copy.app.stopTurn}
+                title={stopping ? copy.app.stoppingTurn : copy.app.stopTurn}
+              >
+                <span className="stop-glyph" aria-hidden="true" />
+              </button>
+            ) : (
+              <button onClick={() => void send()} disabled={state !== 'connected' || busy || input.trim() === ''} aria-label={copy.app.sendMessage}><SendIcon /></button>
+            )}
           </div>
         </div>
       </footer>

--- a/extensions/dsh-browser/src/panel/App.tsx
+++ b/extensions/dsh-browser/src/panel/App.tsx
@@ -380,7 +380,7 @@ export function App(): React.JSX.Element {
     try {
       const receipt = await api.respond(target.rpcId, {
         ok: false,
-        error: { code: 'cancelled', message: 'the user dismissed this question request' },
+        error: { code: 'cancelled', message: 'the user dismissed this question request', details: {} },
       })
       if (isRejectedReceipt(receipt)) setError(copy.question.alreadyAnswered)
       if (questionRef.current?.rpcId === target.rpcId) replaceQuestion(null)

--- a/extensions/dsh-browser/src/panel/QuestionCard.tsx
+++ b/extensions/dsh-browser/src/panel/QuestionCard.tsx
@@ -23,7 +23,7 @@ export function QuestionCard({
   onAnswer: (answers: QuestionAnswer[]) => void
   onDismiss: () => void
 }): React.JSX.Element {
-  const [drafts, setDrafts] = useState<QuestionDrafts>({})
+  const [drafts, setDrafts] = useState<QuestionDrafts>([])
   const answers = answersForQuestion(question, drafts)
 
   return (
@@ -38,15 +38,15 @@ export function QuestionCard({
       <div className="question-list">
         {question.questions.map((item, index) => (
           <QuestionItemView
-            key={item.id}
+            key={index}
             item={item}
             index={index}
             count={question.questions.length}
             drafts={drafts}
             disabled={submitting}
             copy={copy}
-            onToggle={(label, checked) => { setDrafts((current) => toggleQuestionOption(current, item, label, checked)) }}
-            onCustom={(value) => { setDrafts((current) => setQuestionCustomAnswer(current, item, value)) }}
+            onToggle={(label, checked) => { setDrafts((current) => toggleQuestionOption(current, index, item, label, checked)) }}
+            onCustom={(value) => { setDrafts((current) => setQuestionCustomAnswer(current, index, item, value)) }}
           />
         ))}
       </div>
@@ -79,7 +79,7 @@ function QuestionItemView({
   onToggle: (label: string, checked: boolean) => void
   onCustom: (value: string) => void
 }): React.JSX.Element {
-  const draft = draftFor(drafts, item.id)
+  const draft = draftFor(drafts, index)
   const multi = item.multiSelect === true
   return (
     <fieldset className="question-item" disabled={disabled}>
@@ -93,13 +93,13 @@ function QuestionItemView({
       </legend>
       {item.options !== undefined && item.options.length > 0 && (
         <div className="question-options">
-          {item.options.map((option) => {
+          {item.options.map((option, optionIndex) => {
             const checked = draft.selected.includes(option.label)
             return (
-              <label key={option.label} className={`question-option ${checked ? 'checked' : ''}`}>
+              <label key={optionIndex} className={`question-option ${checked ? 'checked' : ''}`}>
                 <input
                   type={multi ? 'checkbox' : 'radio'}
-                  name={`question-${item.id}`}
+                  name={`question-${index}`}
                   checked={checked}
                   onChange={(event) => { onToggle(option.label, event.target.checked) }}
                 />

--- a/extensions/dsh-browser/src/panel/QuestionCard.tsx
+++ b/extensions/dsh-browser/src/panel/QuestionCard.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react'
+import type { PendingQuestion, QuestionItem } from './events.ts'
+import {
+  answersForQuestion,
+  draftFor,
+  setQuestionCustomAnswer,
+  toggleQuestionOption,
+  type QuestionAnswer,
+  type QuestionDrafts,
+} from './questions.ts'
+import type { PanelCopy } from './strings.ts'
+
+export function QuestionCard({
+  question,
+  copy,
+  submitting,
+  onAnswer,
+  onDismiss,
+}: {
+  question: PendingQuestion
+  copy: PanelCopy
+  submitting: boolean
+  onAnswer: (answers: QuestionAnswer[]) => void
+  onDismiss: () => void
+}): React.JSX.Element {
+  const [drafts, setDrafts] = useState<QuestionDrafts>({})
+  const answers = answersForQuestion(question, drafts)
+
+  return (
+    <section className="question-card" aria-labelledby="question-card-title" aria-live="polite">
+      <header className="question-heading">
+        <span className="question-mark" aria-hidden="true">?</span>
+        <div>
+          <span className="eyebrow">{copy.question.eyebrow}</span>
+          <h2 id="question-card-title">{copy.question.title}</h2>
+        </div>
+      </header>
+      <div className="question-list">
+        {question.questions.map((item, index) => (
+          <QuestionItemView
+            key={item.id}
+            item={item}
+            index={index}
+            count={question.questions.length}
+            drafts={drafts}
+            disabled={submitting}
+            copy={copy}
+            onToggle={(label, checked) => { setDrafts((current) => toggleQuestionOption(current, item, label, checked)) }}
+            onCustom={(value) => { setDrafts((current) => setQuestionCustomAnswer(current, item, value)) }}
+          />
+        ))}
+      </div>
+      <div className="question-actions">
+        <button className="secondary" onClick={onDismiss} disabled={submitting}>{copy.question.dismiss}</button>
+        <button className="primary" onClick={() => { if (answers !== null) onAnswer(answers) }} disabled={submitting || answers === null}>
+          {submitting ? copy.question.answering : copy.question.answer}
+        </button>
+      </div>
+    </section>
+  )
+}
+
+function QuestionItemView({
+  item,
+  index,
+  count,
+  drafts,
+  disabled,
+  copy,
+  onToggle,
+  onCustom,
+}: {
+  item: QuestionItem
+  index: number
+  count: number
+  drafts: QuestionDrafts
+  disabled: boolean
+  copy: PanelCopy
+  onToggle: (label: string, checked: boolean) => void
+  onCustom: (value: string) => void
+}): React.JSX.Element {
+  const draft = draftFor(drafts, item.id)
+  const multi = item.multiSelect === true
+  return (
+    <fieldset className="question-item" disabled={disabled}>
+      <legend>
+        {count > 1 && <span className="question-index">{index + 1}</span>}
+        <span className="question-copy">
+          {item.header !== undefined && item.header !== '' && <span className="question-header">{item.header}</span>}
+          <strong>{item.question}</strong>
+          {item.detail !== undefined && item.detail !== '' && <small>{item.detail}</small>}
+        </span>
+      </legend>
+      {item.options !== undefined && item.options.length > 0 && (
+        <div className="question-options">
+          {item.options.map((option) => {
+            const checked = draft.selected.includes(option.label)
+            return (
+              <label key={option.label} className={`question-option ${checked ? 'checked' : ''}`}>
+                <input
+                  type={multi ? 'checkbox' : 'radio'}
+                  name={`question-${item.id}`}
+                  checked={checked}
+                  onChange={(event) => { onToggle(option.label, event.target.checked) }}
+                />
+                <span>
+                  <strong>{option.label}</strong>
+                  {option.description !== undefined && option.description !== '' && <small>{option.description}</small>}
+                </span>
+              </label>
+            )
+          })}
+        </div>
+      )}
+      <input
+        className="question-custom"
+        type="text"
+        value={draft.custom}
+        placeholder={item.options !== undefined && item.options.length > 0 ? copy.question.customAlternative : copy.question.customAnswer}
+        aria-label={copy.question.customAnswer}
+        onChange={(event) => { onCustom(event.target.value) }}
+      />
+    </fieldset>
+  )
+}

--- a/extensions/dsh-browser/src/panel/api.ts
+++ b/extensions/dsh-browser/src/panel/api.ts
@@ -5,7 +5,7 @@
  * @module
  */
 
-import type { BridgeCaps } from '@deepseek-ai/dsh-bridge-browser/src/protocol.ts'
+import type { BridgeCaps, RespondResult } from '@deepseek-ai/dsh-bridge-browser/src/protocol.ts'
 import type { ServerFrame } from '@deepseek-ai/dsh-bridge-browser/src/protocol.ts'
 import type { BridgeState } from '../background/bridge.ts'
 import type { Settings } from '../background/index.ts'
@@ -17,6 +17,14 @@ export type PanelSettings = Settings
 
 interface RpcResultMessage {
   type: 'rpc.result'
+  id: string
+  ok: boolean
+  result?: unknown
+  error?: { code: string; message: string }
+}
+
+interface RespondResultMessage {
+  type: 'respond.result'
   id: string
   ok: boolean
   result?: unknown
@@ -44,11 +52,12 @@ interface ApprovalResolvedMessage {
   id: string
 }
 
-type BackgroundMessage = RpcResultMessage | StatusMessage | EventMessage | ApprovalRequestMessage | ApprovalResolvedMessage
+type BackgroundMessage = RpcResultMessage | RespondResultMessage | StatusMessage | EventMessage | ApprovalRequestMessage | ApprovalResolvedMessage
 
 /** The panel API surface. */
 export interface PanelApi {
   rpc<T = unknown>(method: string, payload?: unknown): Promise<T>
+  respond(rpcId: string, result: RespondResult): Promise<unknown>
   onStatus(callback: (state: BridgeState, caps: BridgeCaps | null) => void): () => void
   onEvent(callback: (frame: ServerFrame) => void): () => void
   onApprovalRequest(callback: (request: ApprovalRequest) => void): () => void
@@ -62,6 +71,11 @@ export interface PanelApi {
 export function connectPanel(): PanelApi {
   const port = chrome.runtime.connect({ name: 'dsh-panel' })
   const pending = new Map<string, { resolve: (value: unknown) => void; reject: (error: Error) => void }>()
+  const pendingResponses = new Map<string, {
+    resolve: (value: unknown) => void
+    reject: (error: Error) => void
+    timer: ReturnType<typeof setTimeout>
+  }>()
   const statusListeners = new Set<(state: BridgeState, caps: BridgeCaps | null) => void>()
   const eventListeners = new Set<(frame: ServerFrame) => void>()
   const approvalListeners = new Set<(request: ApprovalRequest) => void>()
@@ -85,6 +99,16 @@ export function connectPanel(): PanelApi {
           ?? (getUiLocale() === 'zh' ? 'RPC 请求失败' : 'RPC request failed')))
         break
       }
+      case 'respond.result': {
+        const entry = pendingResponses.get(msg.id)
+        if (entry === undefined) return
+        pendingResponses.delete(msg.id)
+        clearTimeout(entry.timer)
+        if (msg.ok) entry.resolve(msg.result)
+        else entry.reject(new Error(msg.error?.message
+          ?? (getUiLocale() === 'zh' ? '回答提交失败' : 'Failed to send the answer')))
+        break
+      }
       case 'status':
         for (const listener of statusListeners) listener(msg.state, msg.caps)
         break
@@ -104,6 +128,11 @@ export function connectPanel(): PanelApi {
     const error = new Error(getUiLocale() === 'zh' ? '后台连接已断开' : 'Background connection lost')
     for (const entry of pending.values()) entry.reject(error)
     pending.clear()
+    for (const entry of pendingResponses.values()) {
+      clearTimeout(entry.timer)
+      entry.reject(error)
+    }
+    pendingResponses.clear()
   })
 
   return {
@@ -112,6 +141,17 @@ export function connectPanel(): PanelApi {
       return new Promise<T>((resolve, reject) => {
         pending.set(id, { resolve: (value) => resolve(value as T), reject })
         port.postMessage({ type: 'rpc', id, method, payload })
+      })
+    },
+    respond(rpcId, result) {
+      const id = crypto.randomUUID()
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          pendingResponses.delete(id)
+          reject(new Error(getUiLocale() === 'zh' ? '回答提交超时，请重试' : 'Sending the answer timed out. Try again.'))
+        }, 35_000)
+        pendingResponses.set(id, { resolve, reject, timer })
+        port.postMessage({ type: 'respond', id, rpcId, result })
       })
     },
     onStatus(callback) {

--- a/extensions/dsh-browser/src/panel/events.ts
+++ b/extensions/dsh-browser/src/panel/events.ts
@@ -71,11 +71,9 @@ export function pendingQuestionFromFrame(frame: EventFrameView): PendingQuestion
   const rawQuestions = frame.payload.questions
   if (typeof sessionId !== 'string' || !Array.isArray(rawQuestions) || rawQuestions.length === 0) return null
   const questions: QuestionItem[] = []
-  const ids = new Set<string>()
   for (const value of rawQuestions) {
     const question = parseQuestionItem(value)
-    if (question === null || ids.has(question.id)) return null
-    ids.add(question.id)
+    if (question === null) return null
     questions.push(question)
   }
   return { rpcId: frame.rpcId, sessionId, questions }
@@ -90,7 +88,6 @@ export function resolvedQuestionFromFrame(frame: EventFrameView): ResolvedQuesti
 
 function parseQuestionItem(value: unknown): QuestionItem | null {
   if (!isRecord(value) || typeof value.id !== 'string' || typeof value.question !== 'string') return null
-  if (value.id.trim() === '' || value.question.trim() === '') return null
   if (value.header !== undefined && typeof value.header !== 'string') return null
   if (value.detail !== undefined && typeof value.detail !== 'string') return null
   if (value.multiSelect !== undefined && typeof value.multiSelect !== 'boolean') return null
@@ -100,7 +97,6 @@ function parseQuestionItem(value: unknown): QuestionItem | null {
     options = []
     for (const rawOption of value.options) {
       if (!isRecord(rawOption) || typeof rawOption.label !== 'string') return null
-      if (rawOption.label.trim() === '') return null
       if (rawOption.description !== undefined && typeof rawOption.description !== 'string') return null
       options.push({
         label: rawOption.label,

--- a/extensions/dsh-browser/src/panel/events.ts
+++ b/extensions/dsh-browser/src/panel/events.ts
@@ -29,6 +29,99 @@ export interface SessionEventView {
   }
 }
 
+/** One user-selectable answer exposed by ask_user_question. */
+export interface QuestionOption {
+  label: string
+  description?: string
+}
+
+/** One item in a question batch. */
+export interface QuestionItem {
+  id: string
+  question: string
+  header?: string
+  detail?: string
+  options?: QuestionOption[]
+  multiSelect?: boolean
+}
+
+/** Pending interaction belonging to one dsh session. */
+export interface PendingQuestion {
+  rpcId: string
+  sessionId: string
+  questions: QuestionItem[]
+}
+
+/** Identity carried by question/resolved; both fields must match before clearing UI. */
+export interface ResolvedQuestion {
+  rpcId: string
+  sessionId: string
+}
+
+/** The gateway mux envelope shape carried inside a bridge event frame. */
+export interface EventFrameView {
+  rpcId: string
+  method: string
+  payload: unknown
+}
+
+export function pendingQuestionFromFrame(frame: EventFrameView): PendingQuestion | null {
+  if (typeof frame.rpcId !== 'string' || frame.method !== 'question/requested' || !isRecord(frame.payload)) return null
+  const sessionId = frame.payload.sessionId
+  const rawQuestions = frame.payload.questions
+  if (typeof sessionId !== 'string' || !Array.isArray(rawQuestions) || rawQuestions.length === 0) return null
+  const questions: QuestionItem[] = []
+  const ids = new Set<string>()
+  for (const value of rawQuestions) {
+    const question = parseQuestionItem(value)
+    if (question === null || ids.has(question.id)) return null
+    ids.add(question.id)
+    questions.push(question)
+  }
+  return { rpcId: frame.rpcId, sessionId, questions }
+}
+
+export function resolvedQuestionFromFrame(frame: EventFrameView): ResolvedQuestion | null {
+  if (frame.method !== 'question/resolved' || !isRecord(frame.payload)) return null
+  const sessionId = frame.payload.sessionId
+  const rpcId = frame.payload.questionRpcId
+  return typeof sessionId === 'string' && typeof rpcId === 'string' ? { sessionId, rpcId } : null
+}
+
+function parseQuestionItem(value: unknown): QuestionItem | null {
+  if (!isRecord(value) || typeof value.id !== 'string' || typeof value.question !== 'string') return null
+  if (value.id.trim() === '' || value.question.trim() === '') return null
+  if (value.header !== undefined && typeof value.header !== 'string') return null
+  if (value.detail !== undefined && typeof value.detail !== 'string') return null
+  if (value.multiSelect !== undefined && typeof value.multiSelect !== 'boolean') return null
+  let options: QuestionOption[] | undefined
+  if (value.options !== undefined) {
+    if (!Array.isArray(value.options)) return null
+    options = []
+    for (const rawOption of value.options) {
+      if (!isRecord(rawOption) || typeof rawOption.label !== 'string') return null
+      if (rawOption.label.trim() === '') return null
+      if (rawOption.description !== undefined && typeof rawOption.description !== 'string') return null
+      options.push({
+        label: rawOption.label,
+        ...(rawOption.description === undefined ? {} : { description: rawOption.description }),
+      })
+    }
+  }
+  return {
+    id: value.id,
+    question: value.question,
+    ...(value.header === undefined ? {} : { header: value.header }),
+    ...(value.detail === undefined ? {} : { detail: value.detail }),
+    ...(options === undefined ? {} : { options }),
+    ...(value.multiSelect === undefined ? {} : { multiSelect: value.multiSelect }),
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
 /** Extract model-visible text from content blocks (defensive: unknown block shapes degrade to markers). */
 export function textFromBlocks(blocks: unknown): string {
   if (!Array.isArray(blocks)) return String(blocks ?? '')

--- a/extensions/dsh-browser/src/panel/pending-questions.ts
+++ b/extensions/dsh-browser/src/panel/pending-questions.ts
@@ -1,0 +1,46 @@
+import type { PendingQuestion, ResolvedQuestion } from './events.ts'
+
+export type QuestionReceiptDisposition = 'accepted' | 'not-pending' | 'retry'
+
+/** Append a new host ask without losing earlier asks; a replay updates in place. */
+export function upsertPendingQuestion(
+  questions: PendingQuestion[],
+  next: PendingQuestion,
+): PendingQuestion[] {
+  const index = questions.findIndex((candidate) => sameQuestion(candidate, next))
+  if (index === -1) return [...questions, next]
+  const updated = questions.slice()
+  updated[index] = next
+  return updated
+}
+
+/** Remove only the host ask named by both session and question RPC id. */
+export function removePendingQuestion<T extends ResolvedQuestion>(
+  questions: T[],
+  resolved: ResolvedQuestion,
+): T[] {
+  return questions.filter((candidate) => !sameQuestion(candidate, resolved))
+}
+
+export function hasPendingQuestion(
+  questions: ResolvedQuestion[],
+  target: ResolvedQuestion,
+): boolean {
+  return questions.some((candidate) => sameQuestion(candidate, target))
+}
+
+/** Interpret /api/respond receipts without discarding a host-pending bad response. */
+export function questionReceiptDisposition(value: unknown): QuestionReceiptDisposition {
+  if (!isRecord(value)) return 'retry'
+  if (value.accepted === true) return 'accepted'
+  if (value.accepted === false && value.reason === 'not-pending') return 'not-pending'
+  return 'retry'
+}
+
+function sameQuestion(left: ResolvedQuestion, right: ResolvedQuestion): boolean {
+  return left.sessionId === right.sessionId && left.rpcId === right.rpcId
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/extensions/dsh-browser/src/panel/questions.ts
+++ b/extensions/dsh-browser/src/panel/questions.ts
@@ -5,7 +5,8 @@ export interface QuestionDraft {
   custom: string
 }
 
-export type QuestionDrafts = Record<string, QuestionDraft>
+/** Drafts are positional because question ids are opaque and may repeat. */
+export type QuestionDrafts = Array<QuestionDraft | undefined>
 
 export interface QuestionAnswer {
   id: string
@@ -13,45 +14,47 @@ export interface QuestionAnswer {
   custom?: string
 }
 
-export function draftFor(drafts: QuestionDrafts, id: string): QuestionDraft {
-  return drafts[id] ?? { selected: [], custom: '' }
+export function draftFor(drafts: QuestionDrafts, index: number): QuestionDraft {
+  return drafts[index] ?? { selected: [], custom: '' }
 }
 
 export function toggleQuestionOption(
   drafts: QuestionDrafts,
+  index: number,
   item: QuestionItem,
   label: string,
   checked: boolean,
 ): QuestionDrafts {
-  const draft = draftFor(drafts, item.id)
+  const draft = draftFor(drafts, index)
   const selected = item.multiSelect === true
     ? checked
       ? [...new Set([...draft.selected, label])]
       : draft.selected.filter((candidate) => candidate !== label)
     : checked ? [label] : []
-  return { ...drafts, [item.id]: { selected, custom: '' } }
+  return replaceDraft(drafts, index, {
+    selected,
+    custom: item.multiSelect === true ? draft.custom : '',
+  })
 }
 
 export function setQuestionCustomAnswer(
   drafts: QuestionDrafts,
+  index: number,
   item: QuestionItem,
   custom: string,
 ): QuestionDrafts {
-  const draft = draftFor(drafts, item.id)
-  return {
-    ...drafts,
-    [item.id]: {
-      selected: item.multiSelect === true ? draft.selected : [],
-      custom,
-    },
-  }
+  const draft = draftFor(drafts, index)
+  return replaceDraft(drafts, index, {
+    selected: item.multiSelect === true ? draft.selected : [],
+    custom,
+  })
 }
 
 /** Return the wire answers only when every question has a non-empty response. */
 export function answersForQuestion(question: PendingQuestion, drafts: QuestionDrafts): QuestionAnswer[] | null {
   const answers: QuestionAnswer[] = []
-  for (const item of question.questions) {
-    const draft = draftFor(drafts, item.id)
+  for (const [index, item] of question.questions.entries()) {
+    const draft = draftFor(drafts, index)
     const custom = draft.custom.trim()
     if (draft.selected.length === 0 && custom === '') return null
     answers.push({
@@ -61,4 +64,10 @@ export function answersForQuestion(question: PendingQuestion, drafts: QuestionDr
     })
   }
   return answers
+}
+
+function replaceDraft(drafts: QuestionDrafts, index: number, draft: QuestionDraft): QuestionDrafts {
+  const next = drafts.slice()
+  next[index] = draft
+  return next
 }

--- a/extensions/dsh-browser/src/panel/questions.ts
+++ b/extensions/dsh-browser/src/panel/questions.ts
@@ -1,0 +1,64 @@
+import type { QuestionItem, PendingQuestion } from './events.ts'
+
+export interface QuestionDraft {
+  selected: string[]
+  custom: string
+}
+
+export type QuestionDrafts = Record<string, QuestionDraft>
+
+export interface QuestionAnswer {
+  id: string
+  selected: string[]
+  custom?: string
+}
+
+export function draftFor(drafts: QuestionDrafts, id: string): QuestionDraft {
+  return drafts[id] ?? { selected: [], custom: '' }
+}
+
+export function toggleQuestionOption(
+  drafts: QuestionDrafts,
+  item: QuestionItem,
+  label: string,
+  checked: boolean,
+): QuestionDrafts {
+  const draft = draftFor(drafts, item.id)
+  const selected = item.multiSelect === true
+    ? checked
+      ? [...new Set([...draft.selected, label])]
+      : draft.selected.filter((candidate) => candidate !== label)
+    : checked ? [label] : []
+  return { ...drafts, [item.id]: { selected, custom: '' } }
+}
+
+export function setQuestionCustomAnswer(
+  drafts: QuestionDrafts,
+  item: QuestionItem,
+  custom: string,
+): QuestionDrafts {
+  const draft = draftFor(drafts, item.id)
+  return {
+    ...drafts,
+    [item.id]: {
+      selected: item.multiSelect === true ? draft.selected : [],
+      custom,
+    },
+  }
+}
+
+/** Return the wire answers only when every question has a non-empty response. */
+export function answersForQuestion(question: PendingQuestion, drafts: QuestionDrafts): QuestionAnswer[] | null {
+  const answers: QuestionAnswer[] = []
+  for (const item of question.questions) {
+    const draft = draftFor(drafts, item.id)
+    const custom = draft.custom.trim()
+    if (draft.selected.length === 0 && custom === '') return null
+    answers.push({
+      id: item.id,
+      selected: draft.selected,
+      ...(custom === '' ? {} : { custom }),
+    })
+  }
+  return answers
+}

--- a/extensions/dsh-browser/src/panel/strings.ts
+++ b/extensions/dsh-browser/src/panel/strings.ts
@@ -84,6 +84,8 @@ export interface PanelCopy {
     disconnectedPlaceholder: string
     composerHelp: string
     sendMessage: string
+    stopTurn: string
+    stoppingTurn: string
   }
 }
 
@@ -187,6 +189,8 @@ const EN: PanelCopy = {
     disconnectedPlaceholder: 'Connect to dsh to get started',
     composerHelp: 'Enter to send · Shift + Enter for a new line',
     sendMessage: 'Send message',
+    stopTurn: 'Stop generating',
+    stoppingTurn: 'Stopping…',
   },
 }
 
@@ -290,6 +294,8 @@ const ZH: PanelCopy = {
     disconnectedPlaceholder: '连接 dsh 后即可开始',
     composerHelp: 'Enter 发送 · Shift + Enter 换行',
     sendMessage: '发送消息',
+    stopTurn: '停止生成',
+    stoppingTurn: '正在停止…',
   },
 }
 

--- a/extensions/dsh-browser/src/panel/strings.ts
+++ b/extensions/dsh-browser/src/panel/strings.ts
@@ -27,6 +27,16 @@ export interface PanelCopy {
     labels: Record<string, string>
     overflow: (shown: string[], total: number) => string
   }
+  question: {
+    eyebrow: string
+    title: string
+    customAlternative: string
+    customAnswer: string
+    dismiss: string
+    answer: string
+    answering: string
+    alreadyAnswered: string
+  }
   settings: {
     back: string
     eyebrow: string
@@ -120,6 +130,16 @@ const EN: PanelCopy = {
     },
     overflow: (shown, total) => `${shown.join(' → ')} → ${total - shown.length} more`,
   },
+  question: {
+    eyebrow: 'Waiting for your answer',
+    title: 'The assistant needs your input',
+    customAlternative: 'Or type a different answer',
+    customAnswer: 'Type your answer',
+    dismiss: 'Dismiss',
+    answer: 'Answer',
+    answering: 'Answering…',
+    alreadyAnswered: 'This question was already handled in another window.',
+  },
   settings: {
     back: 'Back to chat',
     eyebrow: 'Preferences',
@@ -212,6 +232,16 @@ const ZH: PanelCopy = {
       browser_wait: '等待页面',
     },
     overflow: (shown, total) => `${shown.join(' → ')} 等${total}个工具`,
+  },
+  question: {
+    eyebrow: '等待你的回答',
+    title: '助手需要你确认',
+    customAlternative: '或输入其他答案',
+    customAnswer: '输入你的答案',
+    dismiss: '放弃',
+    answer: '回答',
+    answering: '回答中…',
+    alreadyAnswered: '这个问题已在另一个窗口中处理。',
   },
   settings: {
     back: '返回对话',

--- a/extensions/dsh-browser/src/panel/strings.ts
+++ b/extensions/dsh-browser/src/panel/strings.ts
@@ -36,6 +36,7 @@ export interface PanelCopy {
     answer: string
     answering: string
     alreadyAnswered: string
+    answerRejected: string
   }
   settings: {
     back: string
@@ -141,6 +142,7 @@ const EN: PanelCopy = {
     answer: 'Answer',
     answering: 'Answering…',
     alreadyAnswered: 'This question was already handled in another window.',
+    answerRejected: 'The answer was not accepted. Review it and try again.',
   },
   settings: {
     back: 'Back to chat',
@@ -246,6 +248,7 @@ const ZH: PanelCopy = {
     answer: '回答',
     answering: '回答中…',
     alreadyAnswered: '这个问题已在另一个窗口中处理。',
+    answerRejected: '回答未被接受，请检查后重试。',
   },
   settings: {
     back: '返回对话',

--- a/extensions/dsh-browser/src/panel/styles.css
+++ b/extensions/dsh-browser/src/panel/styles.css
@@ -1114,6 +1114,26 @@ textarea:focus-visible {
   transform: translateY(-1px);
 }
 
+.composer-actions button.stop-button {
+  border-color: var(--navy);
+  border-radius: 50%;
+  background: var(--navy);
+  color: #ffffff;
+  box-shadow: 0 4px 10px rgba(24, 32, 51, 0.2);
+}
+
+.composer-actions button.stop-button:hover:not(:disabled) {
+  border-color: #29334a;
+  background: #29334a;
+}
+
+.stop-glyph {
+  width: 8px;
+  height: 8px;
+  border-radius: 1.5px;
+  background: currentColor;
+}
+
 .composer-actions button:disabled {
   border-color: #e3e7ee;
   background: #e8ebf1;

--- a/extensions/dsh-browser/src/panel/styles.css
+++ b/extensions/dsh-browser/src/panel/styles.css
@@ -731,6 +731,257 @@ textarea:focus-visible {
   line-height: 1;
 }
 
+.question-card {
+  max-height: min(52vh, 440px);
+  flex: 0 0 auto;
+  margin: 0 12px 8px;
+  padding: 14px;
+  overflow-y: auto;
+  border: 1px solid #ccd6ff;
+  border-radius: 16px;
+  background: var(--surface);
+  box-shadow: 0 10px 28px rgba(35, 52, 94, 0.12), 0 2px 6px rgba(35, 52, 94, 0.05);
+}
+
+.question-heading {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.question-mark {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid #ced8ff;
+  border-radius: 10px;
+  background: var(--blue-soft);
+  color: var(--blue-ink);
+  font-family: "Avenir Next", "Segoe UI Variable Display", sans-serif;
+  font-size: 16px;
+  font-weight: 760;
+}
+
+.question-heading > div {
+  min-width: 0;
+}
+
+.question-heading h2 {
+  margin: 2px 0 0;
+  color: var(--ink-strong);
+  font-family: "Avenir Next", "Segoe UI Variable Display", "PingFang SC", sans-serif;
+  font-size: 14.5px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.3;
+}
+
+.question-list {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+
+.question-item {
+  min-width: 0;
+  margin: 0;
+  padding: 11px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--canvas);
+}
+
+.question-item legend {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  gap: 8px;
+  padding: 0 0 9px;
+}
+
+.question-index {
+  display: grid;
+  width: 20px;
+  height: 20px;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 7px;
+  background: #e4e9f4;
+  color: var(--muted);
+  font-size: 9.5px;
+  font-weight: 750;
+}
+
+.question-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.question-header {
+  color: var(--blue-ink);
+  font-size: 9.5px;
+  font-weight: 750;
+  letter-spacing: 0.07em;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+
+.question-copy > strong {
+  color: var(--ink-strong);
+  font-size: 12.5px;
+  font-weight: 680;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.question-copy > small {
+  color: var(--muted);
+  font-size: 10.5px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.question-options {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.question-option {
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 9px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--surface);
+  cursor: pointer;
+  transition: border-color 150ms ease, background-color 150ms ease, transform 150ms ease;
+}
+
+.question-option:hover {
+  border-color: #b5c1ed;
+  transform: translateY(-1px);
+}
+
+.question-option.checked {
+  border-color: #aebeff;
+  background: var(--blue-wash);
+}
+
+.question-option input {
+  flex: 0 0 auto;
+  margin: 2px 0 0;
+  accent-color: var(--blue);
+}
+
+.question-option > span {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.question-option strong {
+  color: var(--ink);
+  font-size: 11.5px;
+  font-weight: 620;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.question-option small {
+  color: var(--muted);
+  font-size: 10px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.question-custom {
+  width: 100%;
+  min-height: 36px;
+  margin-top: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--line-strong);
+  border-radius: 10px;
+  outline: none;
+  background: var(--surface);
+  color: var(--ink);
+  font-size: 11.5px;
+  line-height: 1.4;
+}
+
+.question-custom::placeholder {
+  color: var(--faint);
+  opacity: 1;
+}
+
+.question-custom:focus {
+  border-color: var(--blue);
+  box-shadow: var(--focus-ring);
+}
+
+.question-item:disabled,
+.question-item[disabled] {
+  opacity: 0.72;
+}
+
+.question-actions {
+  display: grid;
+  grid-template-columns: 0.72fr 1.28fr;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.question-actions button {
+  min-height: 38px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  cursor: pointer;
+  font-size: 11.5px;
+  font-weight: 680;
+  transition: border-color 150ms ease, background-color 150ms ease, transform 150ms ease;
+}
+
+.question-actions .primary {
+  border: 1px solid var(--blue);
+  background: var(--blue);
+  color: #fff;
+  box-shadow: 0 5px 14px rgba(77, 107, 254, 0.16);
+}
+
+.question-actions .secondary {
+  border: 1px solid var(--line-strong);
+  background: var(--surface);
+  color: var(--muted);
+}
+
+.question-actions button:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.question-actions .primary:hover:not(:disabled) {
+  border-color: var(--blue-hover);
+  background: var(--blue-hover);
+}
+
+.question-actions .secondary:hover:not(:disabled) {
+  border-color: #adb7c7;
+  color: var(--ink);
+}
+
+.question-actions button:disabled {
+  opacity: 0.52;
+  cursor: default;
+  transform: none;
+}
+
 .progress-dots {
   display: inline-flex;
   align-items: center;

--- a/extensions/dsh-browser/tests/panel-api.spec.ts
+++ b/extensions/dsh-browser/tests/panel-api.spec.ts
@@ -93,7 +93,7 @@ describe('panel approval protocol', () => {
     vi.stubGlobal('chrome', { runtime: { connect: vi.fn(() => port) } })
     vi.spyOn(crypto, 'randomUUID').mockReturnValue('12345678-1234-4234-8234-123456789abd')
     const api = connectPanel()
-    const pending = api.respond('question-rpc', { ok: false, error: { code: 'cancelled', message: 'closed' } })
+    const pending = api.respond('question-rpc', { ok: false, error: { code: 'cancelled', message: 'closed', details: {} } })
     receive?.({
       type: 'respond.result',
       id: '12345678-1234-4234-8234-123456789abd',

--- a/extensions/dsh-browser/tests/panel-api.spec.ts
+++ b/extensions/dsh-browser/tests/panel-api.spec.ts
@@ -51,4 +51,55 @@ describe('panel approval protocol', () => {
       decision: 'trust-session',
     })
   })
+
+  it('correlates host-interaction answers with globally unique response ids', async () => {
+    let receive: ((message: unknown) => void) | undefined
+    const postMessage = vi.fn()
+    const port = {
+      postMessage,
+      onMessage: { addListener: vi.fn((listener: (message: unknown) => void) => { receive = listener }) },
+      onDisconnect: { addListener: vi.fn() },
+    }
+    vi.stubGlobal('chrome', { runtime: { connect: vi.fn(() => port) } })
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue('12345678-1234-4234-8234-123456789abc')
+    const api = connectPanel()
+
+    const pending = api.respond('question-rpc', {
+      ok: true,
+      value: { sessionId: 'session-1', answer: { answers: [] } },
+    })
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'respond',
+      id: '12345678-1234-4234-8234-123456789abc',
+      rpcId: 'question-rpc',
+      result: { ok: true, value: { sessionId: 'session-1', answer: { answers: [] } } },
+    })
+    receive?.({
+      type: 'respond.result',
+      id: '12345678-1234-4234-8234-123456789abc',
+      ok: true,
+      result: { accepted: true },
+    })
+    await expect(pending).resolves.toEqual({ accepted: true })
+  })
+
+  it('rejects a pending host-interaction answer when its receipt reports failure', async () => {
+    let receive: ((message: unknown) => void) | undefined
+    const port = {
+      postMessage: vi.fn(),
+      onMessage: { addListener: vi.fn((listener: (message: unknown) => void) => { receive = listener }) },
+      onDisconnect: { addListener: vi.fn() },
+    }
+    vi.stubGlobal('chrome', { runtime: { connect: vi.fn(() => port) } })
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue('12345678-1234-4234-8234-123456789abd')
+    const api = connectPanel()
+    const pending = api.respond('question-rpc', { ok: false, error: { code: 'cancelled', message: 'closed' } })
+    receive?.({
+      type: 'respond.result',
+      id: '12345678-1234-4234-8234-123456789abd',
+      ok: false,
+      error: { code: 'bridge-disconnected', message: 'connection lost' },
+    })
+    await expect(pending).rejects.toThrow('connection lost')
+  })
 })

--- a/extensions/dsh-browser/tests/panel-events.spec.ts
+++ b/extensions/dsh-browser/tests/panel-events.spec.ts
@@ -163,10 +163,26 @@ describe('question mux frames', () => {
       rpcId: 'r', method: 'question/requested',
       payload: { sessionId: 's', questions: [{ id: 'q', question: 'Question?', options: [{ label: 4 }] }] },
     })).toBeNull()
+  })
+
+  it('accepts wire-valid empty strings and repeated question ids', () => {
     expect(pendingQuestionFromFrame({
-      rpcId: 'r', method: 'question/requested',
-      payload: { sessionId: 's', questions: [{ id: 'q', question: 'One?' }, { id: 'q', question: 'Two?' }] },
-    })).toBeNull()
+      rpcId: '', method: 'question/requested',
+      payload: {
+        sessionId: 's',
+        questions: [
+          { id: '', question: '', options: [{ label: '' }] },
+          { id: '', question: 'Repeated id' },
+        ],
+      },
+    })).toEqual({
+      rpcId: '',
+      sessionId: 's',
+      questions: [
+        { id: '', question: '', options: [{ label: '' }] },
+        { id: '', question: 'Repeated id' },
+      ],
+    })
   })
 
   it('extracts both identifiers required to match question/resolved', () => {

--- a/extensions/dsh-browser/tests/panel-events.spec.ts
+++ b/extensions/dsh-browser/tests/panel-events.spec.ts
@@ -4,6 +4,8 @@ import {
   appendLiveRow,
   completeLastTool,
   mergeHistoryRows,
+  pendingQuestionFromFrame,
+  resolvedQuestionFromFrame,
   rowFromEvent,
   textFromBlocks,
   toolSummary,
@@ -120,5 +122,61 @@ describe('mergeHistoryRows', () => {
 
   it('handles empty history', () => {
     expect(mergeHistoryRows([], () => 0)).toEqual([])
+  })
+})
+
+describe('question mux frames', () => {
+  it('parses the full question, compact header, options, and session identity', () => {
+    expect(pendingQuestionFromFrame({
+      rpcId: 'question-rpc',
+      method: 'question/requested',
+      payload: {
+        sessionId: 'session-1',
+        questions: [{
+          id: 'database',
+          header: 'Database',
+          question: 'Which database should we use?',
+          detail: 'Choose the default for local development.',
+          options: [{ label: 'SQLite', description: 'No setup required' }, { label: 'Postgres' }],
+          multiSelect: false,
+        }],
+      },
+    })).toEqual({
+      rpcId: 'question-rpc',
+      sessionId: 'session-1',
+      questions: [{
+        id: 'database',
+        header: 'Database',
+        question: 'Which database should we use?',
+        detail: 'Choose the default for local development.',
+        options: [{ label: 'SQLite', description: 'No setup required' }, { label: 'Postgres' }],
+        multiSelect: false,
+      }],
+    })
+  })
+
+  it('rejects malformed question payloads instead of trusting mux data', () => {
+    expect(pendingQuestionFromFrame({ rpcId: 'r', method: 'session/event', payload: {} })).toBeNull()
+    expect(pendingQuestionFromFrame({ rpcId: 'r', method: 'question/requested', payload: null })).toBeNull()
+    expect(pendingQuestionFromFrame({ rpcId: 'r', method: 'question/requested', payload: { sessionId: 5, questions: [] } })).toBeNull()
+    expect(pendingQuestionFromFrame({
+      rpcId: 'r', method: 'question/requested',
+      payload: { sessionId: 's', questions: [{ id: 'q', question: 'Question?', options: [{ label: 4 }] }] },
+    })).toBeNull()
+    expect(pendingQuestionFromFrame({
+      rpcId: 'r', method: 'question/requested',
+      payload: { sessionId: 's', questions: [{ id: 'q', question: 'One?' }, { id: 'q', question: 'Two?' }] },
+    })).toBeNull()
+  })
+
+  it('extracts both identifiers required to match question/resolved', () => {
+    expect(resolvedQuestionFromFrame({
+      rpcId: 'event-rpc',
+      method: 'question/resolved',
+      payload: { sessionId: 'session-1', questionRpcId: 'question-rpc' },
+    })).toEqual({ sessionId: 'session-1', rpcId: 'question-rpc' })
+    expect(resolvedQuestionFromFrame({
+      rpcId: 'event-rpc', method: 'question/resolved', payload: { sessionId: 'session-1' },
+    })).toBeNull()
   })
 })

--- a/extensions/dsh-browser/tests/pending-questions.spec.ts
+++ b/extensions/dsh-browser/tests/pending-questions.spec.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import type { PendingQuestion } from '../src/panel/events.ts'
+import {
+  hasPendingQuestion,
+  questionReceiptDisposition,
+  removePendingQuestion,
+  upsertPendingQuestion,
+} from '../src/panel/pending-questions.ts'
+
+function pending(rpcId: string, question: string, sessionId = 'session'): PendingQuestion {
+  return { rpcId, sessionId, questions: [{ id: rpcId, question }] }
+}
+
+describe('pending question queue', () => {
+  it('preserves concurrent asks and removes only the matching resolution', () => {
+    const first = pending('first', 'First?')
+    const second = pending('second', 'Second?')
+    const queue = upsertPendingQuestion(upsertPendingQuestion([], first), second)
+    expect(queue).toEqual([first, second])
+    expect(removePendingQuestion(queue, { sessionId: 'session', rpcId: 'second' })).toEqual([first])
+    expect(hasPendingQuestion(queue, { sessionId: 'other-session', rpcId: 'first' })).toBe(false)
+  })
+
+  it('updates a replayed ask in place without duplicating or reordering it', () => {
+    const first = pending('first', 'Old copy')
+    const second = pending('second', 'Second?')
+    const replay = pending('first', 'Fresh copy')
+    expect(upsertPendingQuestion([first, second], replay)).toEqual([replay, second])
+  })
+})
+
+describe('question response receipts', () => {
+  it('clears only accepted and known not-pending questions', () => {
+    expect(questionReceiptDisposition({ accepted: true })).toBe('accepted')
+    expect(questionReceiptDisposition({ accepted: false, reason: 'not-pending' })).toBe('not-pending')
+    expect(questionReceiptDisposition({ accepted: false, reason: 'bad-response' })).toBe('retry')
+    expect(questionReceiptDisposition({ accepted: false, reason: 'future-reason' })).toBe('retry')
+    expect(questionReceiptDisposition('malformed')).toBe('retry')
+  })
+})

--- a/extensions/dsh-browser/tests/questions.spec.ts
+++ b/extensions/dsh-browser/tests/questions.spec.ts
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import type { PendingQuestion } from '../src/panel/events.ts'
+import {
+  answersForQuestion,
+  setQuestionCustomAnswer,
+  toggleQuestionOption,
+  type QuestionDrafts,
+} from '../src/panel/questions.ts'
+
+const QUESTION: PendingQuestion = {
+  rpcId: 'rpc',
+  sessionId: 'session',
+  questions: [
+    { id: 'single', question: 'Pick one', options: [{ label: 'A' }, { label: 'B' }] },
+    { id: 'multi', question: 'Pick several', options: [{ label: 'X' }, { label: 'Y' }], multiSelect: true },
+  ],
+}
+
+describe('question answers', () => {
+  it('requires an answer for every item and serializes selected options', () => {
+    let drafts: QuestionDrafts = {}
+    drafts = toggleQuestionOption(drafts, QUESTION.questions[0]!, 'A', true)
+    expect(answersForQuestion(QUESTION, drafts)).toBeNull()
+    drafts = toggleQuestionOption(drafts, QUESTION.questions[1]!, 'X', true)
+    drafts = toggleQuestionOption(drafts, QUESTION.questions[1]!, 'Y', true)
+    expect(answersForQuestion(QUESTION, drafts)).toEqual([
+      { id: 'single', selected: ['A'] },
+      { id: 'multi', selected: ['X', 'Y'] },
+    ])
+  })
+
+  it('uses custom text for single choice and preserves selections for multi-choice', () => {
+    let drafts: QuestionDrafts = {}
+    drafts = toggleQuestionOption(drafts, QUESTION.questions[0]!, 'A', true)
+    drafts = setQuestionCustomAnswer(drafts, QUESTION.questions[0]!, '  another option  ')
+    drafts = toggleQuestionOption(drafts, QUESTION.questions[1]!, 'X', true)
+    drafts = setQuestionCustomAnswer(drafts, QUESTION.questions[1]!, 'plus this')
+    expect(answersForQuestion(QUESTION, drafts)).toEqual([
+      { id: 'single', selected: [], custom: 'another option' },
+      { id: 'multi', selected: ['X'], custom: 'plus this' },
+    ])
+  })
+})

--- a/extensions/dsh-browser/tests/questions.spec.ts
+++ b/extensions/dsh-browser/tests/questions.spec.ts
@@ -19,11 +19,11 @@ const QUESTION: PendingQuestion = {
 
 describe('question answers', () => {
   it('requires an answer for every item and serializes selected options', () => {
-    let drafts: QuestionDrafts = {}
-    drafts = toggleQuestionOption(drafts, QUESTION.questions[0]!, 'A', true)
+    let drafts: QuestionDrafts = []
+    drafts = toggleQuestionOption(drafts, 0, QUESTION.questions[0]!, 'A', true)
     expect(answersForQuestion(QUESTION, drafts)).toBeNull()
-    drafts = toggleQuestionOption(drafts, QUESTION.questions[1]!, 'X', true)
-    drafts = toggleQuestionOption(drafts, QUESTION.questions[1]!, 'Y', true)
+    drafts = toggleQuestionOption(drafts, 1, QUESTION.questions[1]!, 'X', true)
+    drafts = toggleQuestionOption(drafts, 1, QUESTION.questions[1]!, 'Y', true)
     expect(answersForQuestion(QUESTION, drafts)).toEqual([
       { id: 'single', selected: ['A'] },
       { id: 'multi', selected: ['X', 'Y'] },
@@ -31,14 +31,35 @@ describe('question answers', () => {
   })
 
   it('uses custom text for single choice and preserves selections for multi-choice', () => {
-    let drafts: QuestionDrafts = {}
-    drafts = toggleQuestionOption(drafts, QUESTION.questions[0]!, 'A', true)
-    drafts = setQuestionCustomAnswer(drafts, QUESTION.questions[0]!, '  another option  ')
-    drafts = toggleQuestionOption(drafts, QUESTION.questions[1]!, 'X', true)
-    drafts = setQuestionCustomAnswer(drafts, QUESTION.questions[1]!, 'plus this')
+    let drafts: QuestionDrafts = []
+    drafts = toggleQuestionOption(drafts, 0, QUESTION.questions[0]!, 'A', true)
+    drafts = setQuestionCustomAnswer(drafts, 0, QUESTION.questions[0]!, '  another option  ')
+    drafts = setQuestionCustomAnswer(drafts, 1, QUESTION.questions[1]!, 'plus this')
+    drafts = toggleQuestionOption(drafts, 1, QUESTION.questions[1]!, 'X', true)
     expect(answersForQuestion(QUESTION, drafts)).toEqual([
       { id: 'single', selected: [], custom: 'another option' },
       { id: 'multi', selected: ['X'], custom: 'plus this' },
+    ])
+  })
+
+  it('keeps duplicate and prototype-like ids isolated by question position', () => {
+    const question: PendingQuestion = {
+      rpcId: 'special-ids',
+      sessionId: 'session',
+      questions: [
+        { id: 'constructor', question: '', options: [{ label: '' }] },
+        { id: 'constructor', question: 'Repeated id' },
+        { id: '__proto__', question: 'Prototype id' },
+      ],
+    }
+    let drafts: QuestionDrafts = []
+    drafts = toggleQuestionOption(drafts, 0, question.questions[0]!, '', true)
+    drafts = setQuestionCustomAnswer(drafts, 1, question.questions[1]!, 'second')
+    drafts = setQuestionCustomAnswer(drafts, 2, question.questions[2]!, 'third')
+    expect(answersForQuestion(question, drafts)).toEqual([
+      { id: 'constructor', selected: [''] },
+      { id: 'constructor', selected: [], custom: 'second' },
+      { id: '__proto__', selected: [], custom: 'third' },
     ])
   })
 })

--- a/extensions/dsh-browser/tests/responses.spec.ts
+++ b/extensions/dsh-browser/tests/responses.spec.ts
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { InteractionResponseRouter } from '../src/background/responses.ts'
+
+const MESSAGES = {
+  unavailable: 'unavailable',
+  timeout: 'timed out',
+  duplicate: 'duplicate',
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+function panelPort(): { postMessage: ReturnType<typeof vi.fn<(message: unknown) => void>> } {
+  return { postMessage: vi.fn<(message: unknown) => void>() }
+}
+
+describe('InteractionResponseRouter', () => {
+  it('routes each receipt only to the panel that originated it', () => {
+    const router = new InteractionResponseRouter()
+    const first = panelPort()
+    const second = panelPort()
+    router.begin(first, 'first-id', () => true, MESSAGES)
+    router.begin(second, 'second-id', () => true, MESSAGES)
+
+    router.route({ t: 'respond.result', id: 'second-id', ok: true, result: { accepted: true } })
+
+    expect(first.postMessage).not.toHaveBeenCalled()
+    expect(second.postMessage).toHaveBeenCalledWith({
+      type: 'respond.result', id: 'second-id', ok: true, result: { accepted: true },
+    })
+  })
+
+  it('rejects duplicate ids without replacing the original owner', () => {
+    const router = new InteractionResponseRouter()
+    const first = panelPort()
+    const second = panelPort()
+    router.begin(first, 'same-id', () => true, MESSAGES)
+    router.begin(second, 'same-id', () => true, MESSAGES)
+    router.route({ t: 'respond.result', id: 'same-id', ok: true, result: { accepted: true } })
+
+    expect(second.postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'respond.result', id: 'same-id', ok: false, error: { code: 'duplicate-id', message: 'duplicate' },
+    }))
+    expect(first.postMessage).toHaveBeenCalledWith(expect.objectContaining({ ok: true }))
+  })
+
+  it('settles pending responses when dispatch fails, times out, or the bridge drops', () => {
+    vi.useFakeTimers()
+    const router = new InteractionResponseRouter(100)
+    const port = panelPort()
+    router.begin(port, 'offline', () => false, MESSAGES)
+    router.begin(port, 'timeout', () => true, MESSAGES)
+    vi.advanceTimersByTime(100)
+    router.begin(port, 'disconnect', () => true, MESSAGES)
+    router.failAll('disconnected')
+
+    expect(port.postMessage).toHaveBeenCalledWith(expect.objectContaining({ id: 'offline', error: { code: 'bridge-unavailable', message: 'unavailable' } }))
+    expect(port.postMessage).toHaveBeenCalledWith(expect.objectContaining({ id: 'timeout', error: { code: 'timeout', message: 'timed out' } }))
+    expect(port.postMessage).toHaveBeenCalledWith(expect.objectContaining({ id: 'disconnect', error: { code: 'bridge-disconnected', message: 'disconnected' } }))
+  })
+
+  it('forgets a panel response when that panel closes', () => {
+    const router = new InteractionResponseRouter()
+    const port = panelPort()
+    router.begin(port, 'closed', () => true, MESSAGES)
+    router.removePort(port)
+    router.route({ t: 'respond.result', id: 'closed', ok: true, result: { accepted: true } })
+    expect(port.postMessage).not.toHaveBeenCalled()
+  })
+})

--- a/packages/browser/bridge-browser/README.md
+++ b/packages/browser/bridge-browser/README.md
@@ -50,8 +50,10 @@ The installer copies the unpacked extension to `~/.dsh/browser-extension` and op
 
 Frames are JSON objects discriminated by `t`, defined in [`protocol.ts`](src/protocol.ts) — the single source of truth shared with the extension through the workspace package's `./src/*` export. The built package also publishes `@deepseek-ai/dsh-bridge-browser/protocol` for external consumers.
 
-- Client → server: `hello` (auth + caps), `rpc` (gateway method passthrough), `tool.result`, `pong`.
-- Server → client: `hello.ok` (echoes negotiated caps), `rpc.result`, `event` (gateway event envelope, same shape as `/api/events.mux`), `tool.call`, `ping`, `error`.
+- Client → server: `hello` (auth + caps), `rpc` (gateway method passthrough), `respond` (resolve a host interaction by its RPC id), `tool.result`, `pong`.
+- Server → client: `hello.ok` (echoes negotiated caps), `rpc.result`, `respond.result` (correlated acceptance or error), `event` (gateway event envelope, same shape as `/api/events.mux`), `tool.call`, `ping`, `error`.
+
+Each `respond` carries a globally unique transport id as well as the host interaction's `rpcId`. The extension routes its receipt only to the panel that initiated it and rejects pending responses on timeout, panel closure, or bridge disconnection.
 
 ## Tools
 

--- a/packages/browser/bridge-browser/README.zh.md
+++ b/packages/browser/bridge-browser/README.zh.md
@@ -50,8 +50,10 @@ npx @deepseek-ai/dsh web
 
 帧为按 `t` 判别的 JSON 对象，定义在 [`protocol.ts`](src/protocol.ts)，是通过 workspace 包的 `./src/*` export 与扩展共享的真源。构建后的包还会发布 `@deepseek-ai/dsh-bridge-browser/protocol`，供外部消费方使用。
 
-- 客户端 → 服务端：`hello`（认证+caps）、`rpc`（网关方法透传）、`tool.result`、`pong`。
-- 服务端 → 客户端：`hello.ok`（回显协商后的 caps）、`rpc.result`、`event`（网关事件信封，与 `/api/events.mux` 同形）、`tool.call`、`ping`、`error`。
+- 客户端 → 服务端：`hello`（认证+caps）、`rpc`（网关方法透传）、`respond`（按 RPC id 结算宿主交互）、`tool.result`、`pong`。
+- 服务端 → 客户端：`hello.ok`（回显协商后的 caps）、`rpc.result`、`respond.result`（相关联的受理结果或错误）、`event`（网关事件信封，与 `/api/events.mux` 同形）、`tool.call`、`ping`、`error`。
+
+每个 `respond` 同时携带全局唯一的传输 id 与宿主交互的 `rpcId`。扩展只把回执路由给发起操作的面板，并在超时、面板关闭或桥断线时拒绝尚未完成的响应。
 
 ## 工具
 

--- a/packages/browser/bridge-browser/src/protocol.ts
+++ b/packages/browser/bridge-browser/src/protocol.ts
@@ -46,7 +46,7 @@ export interface ToolError {
 /** Result sent for a pending host interaction such as ask_user_question. */
 export type RespondResult =
   | { ok: true; value?: unknown }
-  | { ok: false; error: { code: string; message: string } }
+  | { ok: false; error: { code: string; message: string; details: Record<string, unknown> } }
 
 /** Capabilities negotiated in `hello`/`hello.ok`. The extension performs its own actions; these bounds shape page snapshots. */
 export interface BridgeCaps {
@@ -230,5 +230,12 @@ export function isRespondResult(value: unknown): value is RespondResult {
   if (typeof value !== 'object' || value === null) return false
   const result = value as Record<string, unknown>
   if (result.ok === true) return result.error === undefined
-  return result.ok === false && isWireError(result.error)
+  return result.ok === false && isRespondError(result.error)
+}
+
+function isRespondError(value: unknown): value is Extract<RespondResult, { ok: false }>['error'] {
+  return isWireError(value)
+    && typeof (value as Record<string, unknown>).details === 'object'
+    && (value as Record<string, unknown>).details !== null
+    && !Array.isArray((value as Record<string, unknown>).details)
 }

--- a/packages/browser/bridge-browser/src/protocol.ts
+++ b/packages/browser/bridge-browser/src/protocol.ts
@@ -43,6 +43,11 @@ export interface ToolError {
   message: string
 }
 
+/** Result sent for a pending host interaction such as ask_user_question. */
+export type RespondResult =
+  | { ok: true; value?: unknown }
+  | { ok: false; error: { code: string; message: string } }
+
 /** Capabilities negotiated in `hello`/`hello.ok`. The extension performs its own actions; these bounds shape page snapshots. */
 export interface BridgeCaps {
   /** The extension renders page state as text only (no screenshots). */
@@ -59,6 +64,8 @@ export type ClientFrame =
   | { t: 'hello'; token: string; caps: BridgeCaps }
   /** Unary gateway RPC passthrough (method names from the apiproxy RpcMethodMap). */
   | { t: 'rpc'; id: string; method: string; payload: unknown }
+  /** Answer or cancel a pending host interaction through /api/respond. */
+  | { t: 'respond'; id: string; rpcId: string; result: RespondResult }
   /** Result of a previously dispatched tool call. */
   | { t: 'tool.result'; id: string; ok: true; result: unknown }
   | { t: 'tool.result'; id: string; ok: false; error: ToolError }
@@ -72,6 +79,9 @@ export type ServerFrame =
   /** Reply to an `rpc` frame; `result` is the apiproxy ServerResponse envelope. */
   | { t: 'rpc.result'; id: string; ok: true; result: unknown }
   | { t: 'rpc.result'; id: string; ok: false; error: { code: string; message: string } }
+  /** Receipt for a `respond` frame (normally `{ accepted: boolean }`). */
+  | { t: 'respond.result'; id: string; ok: true; result: unknown }
+  | { t: 'respond.result'; id: string; ok: false; error: { code: string; message: string } }
   /** One gateway event envelope (the same server-request shape the GUI's /api/events.mux carries). */
   | { t: 'event'; frame: { rpcId: string; method: string; payload: unknown } }
   /** A model-requested browser action to execute in the active tab. */
@@ -96,6 +106,7 @@ export type BridgeFrame = ClientFrame | ServerFrame
 export function isServerFrame(frame: BridgeFrame): frame is ServerFrame {
   return frame.t === 'hello.ok'
     || frame.t === 'rpc.result'
+    || frame.t === 'respond.result'
     || frame.t === 'event'
     || frame.t === 'tool.call'
     || frame.t === 'tool.cancel'
@@ -110,7 +121,7 @@ export function isServerFrame(frame: BridgeFrame): frame is ServerFrame {
  * @returns true for client-sendable frames.
  */
 export function isClientFrame(frame: BridgeFrame): frame is ClientFrame {
-  return frame.t === 'hello' || frame.t === 'rpc' || frame.t === 'tool.result' || frame.t === 'pong'
+  return frame.t === 'hello' || frame.t === 'rpc' || frame.t === 'respond' || frame.t === 'tool.result' || frame.t === 'pong'
 }
 
 /**
@@ -138,6 +149,10 @@ export function parseBridgeFrame(text: string): BridgeFrame | undefined {
       return typeof frame.id === 'string' && typeof frame.method === 'string'
         ? { t: 'rpc', id: frame.id, method: frame.method, payload: frame.payload }
         : undefined
+    case 'respond':
+      return typeof frame.id === 'string' && typeof frame.rpcId === 'string' && isRespondResult(frame.result)
+        ? { t: 'respond', id: frame.id, rpcId: frame.rpcId, result: frame.result }
+        : undefined
     case 'tool.result':
       if (typeof frame.id !== 'string') return undefined
       if (frame.ok === true && 'result' in frame) {
@@ -159,6 +174,14 @@ export function parseBridgeFrame(text: string): BridgeFrame | undefined {
       }
       return typeof frame.error === 'object' && frame.error !== null
         ? { t: 'rpc.result', id: frame.id, ok: false, error: frame.error as { code: string; message: string } }
+        : undefined
+    case 'respond.result':
+      if (typeof frame.id !== 'string') return undefined
+      if (frame.ok === true && 'result' in frame) {
+        return { t: 'respond.result', id: frame.id, ok: true, result: frame.result }
+      }
+      return isWireError(frame.error)
+        ? { t: 'respond.result', id: frame.id, ok: false, error: frame.error }
         : undefined
     case 'event':
       return typeof frame.frame === 'object' && frame.frame !== null
@@ -195,4 +218,17 @@ function isToolError(value: unknown): value is ToolError {
   return typeof value === 'object' && value !== null
     && typeof (value as Record<string, unknown>).code === 'string'
     && typeof (value as Record<string, unknown>).message === 'string'
+}
+
+function isWireError(value: unknown): value is { code: string; message: string } {
+  return typeof value === 'object' && value !== null
+    && typeof (value as Record<string, unknown>).code === 'string'
+    && typeof (value as Record<string, unknown>).message === 'string'
+}
+
+function isRespondResult(value: unknown): value is RespondResult {
+  if (typeof value !== 'object' || value === null) return false
+  const result = value as Record<string, unknown>
+  if (result.ok === true) return result.error === undefined
+  return result.ok === false && isWireError(result.error)
 }

--- a/packages/browser/bridge-browser/src/protocol.ts
+++ b/packages/browser/bridge-browser/src/protocol.ts
@@ -226,7 +226,7 @@ function isWireError(value: unknown): value is { code: string; message: string }
     && typeof (value as Record<string, unknown>).message === 'string'
 }
 
-function isRespondResult(value: unknown): value is RespondResult {
+export function isRespondResult(value: unknown): value is RespondResult {
   if (typeof value !== 'object' || value === null) return false
   const result = value as Record<string, unknown>
   if (result.ok === true) return result.error === undefined

--- a/packages/browser/bridge-browser/src/server.ts
+++ b/packages/browser/bridge-browser/src/server.ts
@@ -54,6 +54,9 @@ const PRIVILEGED_METHODS = new Set([
   'credentials.unset',
 ])
 
+/** Session mutations whose WebSocket arrival order is behaviorally significant. */
+const ORDERED_SESSION_METHODS = new Set(['session.prompt', 'session.cancel'])
+
 /** Loopback IPv4/IPv6 literals (IPv4-mapped included). Exported for tests and reuse. */
 export function isLoopbackAddress(address: string | undefined): boolean {
   return address === '127.0.0.1' || address === '::1' || address === '::ffff:127.0.0.1'
@@ -139,6 +142,7 @@ export class BridgeServer {
   private readonly wss = new WebSocketServer({ noServer: true })
   private current: ReadyConnection | null = null
   private readonly pendingTools = new Map<string, PendingTool>()
+  private readonly orderedSessionRpcs = new Map<string, Promise<void>>()
   private closed = false
 
   constructor(private readonly deps: BridgeServerDeps) {}
@@ -329,7 +333,7 @@ export class BridgeServer {
   private handleReadyFrame(frame: BridgeFrame): void {
     switch (frame.t) {
       case 'rpc':
-        void this.handleRpc(frame)
+        this.routeRpc(frame)
         break
       case 'respond':
         void this.handleRespond(frame)
@@ -351,6 +355,29 @@ export class BridgeServer {
         // the extension is the only sender on this channel.
         break
     }
+  }
+
+  /**
+   * Preserve prompt/cancel arrival order per session. In particular, the
+   * first prompt may still be materializing a provisional session; its cancel
+   * must not reach the gateway until that admission has completed.
+   */
+  private routeRpc(frame: Extract<ClientFrame, { t: 'rpc' }>): void {
+    const sessionId = orderedSessionId(frame)
+    if (sessionId === undefined) {
+      void this.handleRpc(frame)
+      return
+    }
+    const previous = this.orderedSessionRpcs.get(sessionId) ?? Promise.resolve()
+    const task = previous.then(
+      () => this.handleRpc(frame),
+      () => this.handleRpc(frame),
+    )
+    this.orderedSessionRpcs.set(sessionId, task)
+    const clear = (): void => {
+      if (this.orderedSessionRpcs.get(sessionId) === task) this.orderedSessionRpcs.delete(sessionId)
+    }
+    void task.then(clear, clear)
   }
 
   private async handleRpc(frame: Extract<ClientFrame, { t: 'rpc' }>): Promise<void> {
@@ -442,6 +469,13 @@ export class BridgeServer {
       pending.reject(new BridgeToolError('bridge-closed', 'the extension connection was replaced'))
     }
   }
+}
+
+function orderedSessionId(frame: Extract<ClientFrame, { t: 'rpc' }>): string | undefined {
+  if (!ORDERED_SESSION_METHODS.has(frame.method)) return undefined
+  if (typeof frame.payload !== 'object' || frame.payload === null || Array.isArray(frame.payload)) return undefined
+  const sessionId = (frame.payload as Record<string, unknown>).sessionId
+  return typeof sessionId === 'string' ? sessionId : undefined
 }
 
 /**

--- a/packages/browser/bridge-browser/src/server.ts
+++ b/packages/browser/bridge-browser/src/server.ts
@@ -331,6 +331,9 @@ export class BridgeServer {
       case 'rpc':
         void this.handleRpc(frame)
         break
+      case 'respond':
+        void this.handleRespond(frame)
+        break
       case 'tool.result':
         this.settleTool(frame.id, frame.ok, frame.ok ? frame.result : frame.error)
         break
@@ -338,6 +341,7 @@ export class BridgeServer {
       case 'hello':
       case 'hello.ok':
       case 'rpc.result':
+      case 'respond.result':
       case 'event':
       case 'tool.call':
       case 'tool.cancel':
@@ -381,6 +385,35 @@ export class BridgeServer {
       sendFrame(conn.ws, { t: 'rpc.result', id: frame.id, ok: true, result })
     } catch (error: unknown) {
       sendFrame(conn.ws, { t: 'rpc.result', id: frame.id, ok: false, error: { code: 'internal', message: String(error) } })
+    }
+  }
+
+  /** Relay a pending host-interaction response through the GUI's /api/respond channel. */
+  private async handleRespond(frame: Extract<ClientFrame, { t: 'respond' }>): Promise<void> {
+    const conn = this.current
+    /* v8 ignore next -- replacement race; a closed socket simply drops the receipt */
+    if (conn === null) return
+    const request = new Request(new URL('/api/respond', 'http://dsh.internal'), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ type: 'client-response', rpcId: frame.rpcId, result: frame.result }),
+    })
+    try {
+      const response = await this.deps.apiHandler.fetch(request)
+      const text = await response.text()
+      if (!response.ok) {
+        sendFrame(conn.ws, { t: 'respond.result', id: frame.id, ok: false, error: { code: 'http', message: text } })
+        return
+      }
+      let result: unknown
+      try {
+        result = JSON.parse(text)
+      } catch {
+        result = text
+      }
+      sendFrame(conn.ws, { t: 'respond.result', id: frame.id, ok: true, result })
+    } catch (error: unknown) {
+      sendFrame(conn.ws, { t: 'respond.result', id: frame.id, ok: false, error: { code: 'internal', message: String(error) } })
     }
   }
 

--- a/packages/browser/bridge-browser/tests/e2e/bridge-extension.e2e.spec.ts
+++ b/packages/browser/bridge-browser/tests/e2e/bridge-extension.e2e.spec.ts
@@ -384,7 +384,7 @@ describe('extension ↔ bridge e2e', () => {
       agent,
       questions: [
         {
-          id: 'transport',
+          id: 'constructor',
           header: 'Transport',
           question: 'Which transport should the sidebar use?',
           detail: 'Choose the primary connection for this session.',
@@ -394,7 +394,7 @@ describe('extension ↔ bridge e2e', () => {
           ],
         },
         {
-          id: 'extras',
+          id: 'constructor',
           question: 'Which optional capabilities should be enabled?',
           options: [{ label: 'Delta snapshots' }, { label: 'Stable element IDs' }],
           multiSelect: true,
@@ -407,15 +407,41 @@ describe('extension ↔ bridge e2e', () => {
     expect(await questionCard.textContent()).toContain('Which transport should the sidebar use?')
     expect(await questionCard.textContent()).toContain('Choose the primary connection for this session.')
     await questionCard.locator('.question-item').nth(0).locator('.question-option', { hasText: 'WebSocket' }).click()
-    await questionCard.locator('.question-item').nth(1).locator('.question-option', { hasText: 'Delta snapshots' }).click()
     await questionCard.locator('.question-item').nth(1).locator('.question-custom').fill('Session-scoped confirmations')
+    await questionCard.locator('.question-item').nth(1).locator('.question-option', { hasText: 'Delta snapshots' }).click()
     await questionCard.locator('.question-actions .primary').click()
     await expect(answer).resolves.toEqual({
       answers: [
-        { id: 'transport', selected: ['WebSocket'] },
-        { id: 'extras', selected: ['Delta snapshots'], custom: 'Session-scoped confirmations' },
+        { id: 'constructor', selected: ['WebSocket'] },
+        { id: 'constructor', selected: ['Delta snapshots'], custom: 'Session-scoped confirmations' },
       ],
     })
+    await questionCard.waitFor({ state: 'hidden', timeout: 15_000 })
+
+    // Concurrent asks stay queued by rpcId. Resolving the first reveals the
+    // second, and dismissing that second ask must produce a schema-valid
+    // cancelled RpcError that actually rejects the host Promise.
+    const firstConcurrentAnswer = context.userQuestions.ask({
+      agent,
+      questions: [{ id: '__proto__', question: 'Answer the first concurrent question.' }],
+    })
+    const secondConcurrentOutcome = context.userQuestions.ask({
+      agent,
+      questions: [{ id: 'toString', question: 'Dismiss the second concurrent question.' }],
+    }).then(
+      (value) => ({ ok: true as const, value }),
+      (error: unknown) => ({ ok: false as const, error }),
+    )
+    await questionCard.waitFor({ state: 'visible', timeout: 15_000 })
+    await expect.poll(() => questionCard.textContent()).toContain('Answer the first concurrent question.')
+    await questionCard.locator('.question-custom').fill('first answer')
+    await questionCard.locator('.question-actions .primary').click()
+    await expect(firstConcurrentAnswer).resolves.toEqual({
+      answers: [{ id: '__proto__', selected: [], custom: 'first answer' }],
+    })
+    await expect.poll(() => questionCard.textContent()).toContain('Dismiss the second concurrent question.')
+    await questionCard.locator('.question-actions .secondary').click()
+    expect(await secondConcurrentOutcome).toMatchObject({ ok: false, error: { code: 'ASK_CANCELLED' } })
     await questionCard.waitFor({ state: 'hidden', timeout: 15_000 })
 
     expect(statusText).toContain('已连接')

--- a/packages/browser/bridge-browser/tests/e2e/bridge-extension.e2e.spec.ts
+++ b/packages/browser/bridge-browser/tests/e2e/bridge-extension.e2e.spec.ts
@@ -368,10 +368,55 @@ describe('extension ↔ bridge e2e', () => {
     await expect.poll(() => sessions.list().length, { timeout: 30_000 }).toBeGreaterThan(initialSessions.length)
 
     const createdSession = sessions.list().find(session => !initialIds.has(session.id))
+    if (createdSession === undefined) throw new Error('the panel did not materialize its deferred session')
     const workspace = (context.get('workspaceRegistry') as WorkspaceRegistry).list()[0]
     expect(workspace?.path).toBe(await realpath(join(root as string, 'browser-sessions')))
-    expect(workspace?.sessionIds).toContain(createdSession?.id)
-    expect(createdSession?.header.cwd).toBe(workspace?.path)
+    expect(workspace?.sessionIds).toContain(createdSession.id)
+    expect(createdSession.header.cwd).toBe(workspace?.path)
+
+    // A host-side ask_user_question request for this exact live agent must be
+    // rendered and answered by the sidebar. Keep both the short header and the
+    // complete question in the assertion: losing the latter was the original
+    // review regression when a request supplied both fields.
+    const agent = context.agents.get(createdSession.id)
+    if (agent === undefined) throw new Error('the panel session has no live agent')
+    const answer = context.userQuestions.ask({
+      agent,
+      questions: [
+        {
+          id: 'transport',
+          header: 'Transport',
+          question: 'Which transport should the sidebar use?',
+          detail: 'Choose the primary connection for this session.',
+          options: [
+            { label: 'WebSocket', description: 'Keep the live bridge connection.' },
+            { label: 'Polling', description: 'Periodically fetch new events.' },
+          ],
+        },
+        {
+          id: 'extras',
+          question: 'Which optional capabilities should be enabled?',
+          options: [{ label: 'Delta snapshots' }, { label: 'Stable element IDs' }],
+          multiSelect: true,
+        },
+      ],
+    })
+    const questionCard = panel.locator('.question-card')
+    await questionCard.waitFor({ state: 'visible', timeout: 15_000 })
+    expect(await questionCard.locator('.question-header').textContent()).toBe('Transport')
+    expect(await questionCard.textContent()).toContain('Which transport should the sidebar use?')
+    expect(await questionCard.textContent()).toContain('Choose the primary connection for this session.')
+    await questionCard.locator('.question-item').nth(0).locator('.question-option', { hasText: 'WebSocket' }).click()
+    await questionCard.locator('.question-item').nth(1).locator('.question-option', { hasText: 'Delta snapshots' }).click()
+    await questionCard.locator('.question-item').nth(1).locator('.question-custom').fill('Session-scoped confirmations')
+    await questionCard.locator('.question-actions .primary').click()
+    await expect(answer).resolves.toEqual({
+      answers: [
+        { id: 'transport', selected: ['WebSocket'] },
+        { id: 'extras', selected: ['Delta snapshots'], custom: 'Session-scoped confirmations' },
+      ],
+    })
+    await questionCard.waitFor({ state: 'hidden', timeout: 15_000 })
 
     expect(statusText).toContain('已连接')
 

--- a/packages/browser/bridge-browser/tests/protocol.spec.ts
+++ b/packages/browser/bridge-browser/tests/protocol.spec.ts
@@ -54,11 +54,15 @@ describe('parseBridgeFrame', () => {
     })
     expect(parseBridgeFrame(JSON.stringify({
       t: 'respond', id: 'response-2', rpcId: 'question-2',
-      result: { ok: false, error: { code: 'cancelled', message: 'closed' } },
+      result: { ok: false, error: { code: 'cancelled', message: 'closed', details: {} } },
     }))).toEqual({
       t: 'respond', id: 'response-2', rpcId: 'question-2',
-      result: { ok: false, error: { code: 'cancelled', message: 'closed' } },
+      result: { ok: false, error: { code: 'cancelled', message: 'closed', details: {} } },
     })
+    expect(parseBridgeFrame(JSON.stringify({
+      t: 'respond', id: 'x', rpcId: 'q',
+      result: { ok: false, error: { code: 'cancelled', message: 'missing details' } },
+    }))).toBeUndefined()
     expect(parseBridgeFrame(JSON.stringify({ t: 'respond', id: 'x', rpcId: 'q', result: { ok: false } }))).toBeUndefined()
     expect(parseBridgeFrame(JSON.stringify({ t: 'respond', id: 'x', rpcId: 'q', result: { ok: true, error: {} } }))).toBeUndefined()
     expect(parseBridgeFrame(JSON.stringify({ t: 'respond', id: 'x', result: { ok: true } }))).toBeUndefined()

--- a/packages/browser/bridge-browser/tests/protocol.spec.ts
+++ b/packages/browser/bridge-browser/tests/protocol.spec.ts
@@ -44,6 +44,35 @@ describe('parseBridgeFrame', () => {
     expect(parseBridgeFrame(JSON.stringify({ t: 'rpc.result', id: '1', ok: false }))).toBeUndefined()
   })
 
+  it('parses interaction responses and rejects malformed result unions', () => {
+    expect(parseBridgeFrame(JSON.stringify({
+      t: 'respond', id: 'response-1', rpcId: 'question-1',
+      result: { ok: true, value: { answer: { answers: [] } } },
+    }))).toEqual({
+      t: 'respond', id: 'response-1', rpcId: 'question-1',
+      result: { ok: true, value: { answer: { answers: [] } } },
+    })
+    expect(parseBridgeFrame(JSON.stringify({
+      t: 'respond', id: 'response-2', rpcId: 'question-2',
+      result: { ok: false, error: { code: 'cancelled', message: 'closed' } },
+    }))).toEqual({
+      t: 'respond', id: 'response-2', rpcId: 'question-2',
+      result: { ok: false, error: { code: 'cancelled', message: 'closed' } },
+    })
+    expect(parseBridgeFrame(JSON.stringify({ t: 'respond', id: 'x', rpcId: 'q', result: { ok: false } }))).toBeUndefined()
+    expect(parseBridgeFrame(JSON.stringify({ t: 'respond', id: 'x', rpcId: 'q', result: { ok: true, error: {} } }))).toBeUndefined()
+    expect(parseBridgeFrame(JSON.stringify({ t: 'respond', id: 'x', result: { ok: true } }))).toBeUndefined()
+  })
+
+  it('parses interaction response receipts', () => {
+    expect(parseBridgeFrame(JSON.stringify({ t: 'respond.result', id: 'response-1', ok: true, result: { accepted: true } })))
+      .toEqual({ t: 'respond.result', id: 'response-1', ok: true, result: { accepted: true } })
+    expect(parseBridgeFrame(JSON.stringify({ t: 'respond.result', id: 'response-2', ok: false, error: { code: 'http', message: 'failed' } })))
+      .toEqual({ t: 'respond.result', id: 'response-2', ok: false, error: { code: 'http', message: 'failed' } })
+    expect(parseBridgeFrame(JSON.stringify({ t: 'respond.result', id: 'x', ok: true }))).toBeUndefined()
+    expect(parseBridgeFrame(JSON.stringify({ t: 'respond.result', id: 'x', ok: false, error: {} }))).toBeUndefined()
+  })
+
   it('parses ping and error frames', () => {
     expect(parseBridgeFrame(JSON.stringify({ t: 'ping' }))).toEqual({ t: 'ping' })
     expect(parseBridgeFrame(JSON.stringify({ t: 'error', code: 'stream-failed', message: 'x' })))
@@ -64,11 +93,11 @@ describe('parseBridgeFrame', () => {
     expect(isClientFrame(server)).toBe(false)
     expect(isServerFrame(client)).toBe(false)
     expect(isClientFrame(client)).toBe(true)
-    for (const t of ['hello.ok', 'rpc.result', 'event', 'tool.call', 'tool.cancel', 'ping', 'error'] as const) {
+    for (const t of ['hello.ok', 'rpc.result', 'respond.result', 'event', 'tool.call', 'tool.cancel', 'ping', 'error'] as const) {
       const frame = parseBridgeFrame(JSON.stringify(serverShape(t)))!
       expect(isServerFrame(frame)).toBe(true)
     }
-    for (const t of ['hello', 'rpc', 'tool.result', 'pong'] as const) {
+    for (const t of ['hello', 'rpc', 'respond', 'tool.result', 'pong'] as const) {
       const frame = parseBridgeFrame(JSON.stringify(clientShape(t)))!
       expect(isClientFrame(frame)).toBe(true)
     }
@@ -93,10 +122,11 @@ describe('parseBridgeFrame', () => {
 })
 
 /** Minimal valid shape per server-side frame type (for classification tests). */
-function serverShape(t: 'hello.ok' | 'rpc.result' | 'event' | 'tool.call' | 'tool.cancel' | 'ping' | 'error'): Record<string, unknown> {
+function serverShape(t: 'hello.ok' | 'rpc.result' | 'respond.result' | 'event' | 'tool.call' | 'tool.cancel' | 'ping' | 'error'): Record<string, unknown> {
   switch (t) {
     case 'hello.ok': return { t, caps: { textOnly: true, snapshotMaxChars: 100, maxInteractiveItems: 10 } }
     case 'rpc.result': return { t, id: '1', ok: true, result: {} }
+    case 'respond.result': return { t, id: '1', ok: true, result: { accepted: true } }
     case 'event': return { t, frame: { rpcId: 'r', method: 'x', payload: {} } }
     case 'tool.call': return { t, id: '1', name: 'x', args: {}, expiresAt: 123 }
     case 'tool.cancel': return { t, id: '1' }
@@ -106,10 +136,11 @@ function serverShape(t: 'hello.ok' | 'rpc.result' | 'event' | 'tool.call' | 'too
 }
 
 /** Minimal valid shape per client-side frame type (for classification tests). */
-function clientShape(t: 'hello' | 'rpc' | 'tool.result' | 'pong'): Record<string, unknown> {
+function clientShape(t: 'hello' | 'rpc' | 'respond' | 'tool.result' | 'pong'): Record<string, unknown> {
   switch (t) {
     case 'hello': return { t, token: 'x', caps: { textOnly: true, snapshotMaxChars: 100, maxInteractiveItems: 10 } }
     case 'rpc': return { t, id: '1', method: 'x', payload: {} }
+    case 'respond': return { t, id: '1', rpcId: 'q', result: { ok: true, value: {} } }
     case 'tool.result': return { t, id: '1', ok: true, result: {} }
     case 'pong': return { t }
   }

--- a/packages/browser/bridge-browser/tests/server.spec.ts
+++ b/packages/browser/bridge-browser/tests/server.spec.ts
@@ -237,7 +237,7 @@ describe('BridgeServer', () => {
     await waitFor(() => frames.some((frame) => frame.t === 'hello.ok'))
     send(ws, {
       t: 'respond', id: 'response-2', rpcId: 'question-2',
-      result: { ok: false, error: { code: 'cancelled', message: 'user dismissed the question' } },
+      result: { ok: false, error: { code: 'cancelled', message: 'user dismissed the question', details: {} } },
     })
     await waitFor(() => frames.some((frame) => frame.t === 'respond.result' && frame.id === 'response-2'))
     expect(frames).toContainEqual({

--- a/packages/browser/bridge-browser/tests/server.spec.ts
+++ b/packages/browser/bridge-browser/tests/server.spec.ts
@@ -200,6 +200,53 @@ describe('BridgeServer', () => {
     ws.close()
   })
 
+  it('relays interaction responses to /api/respond with the original rpcId', async () => {
+    const h = await startBridge()
+    harnesses.push(h)
+    const { ws, frames } = await connect(h.url)
+    send(ws, { t: 'hello', token: TOKEN, caps: CAPS })
+    await waitFor(() => frames.some((frame) => frame.t === 'hello.ok'))
+    send(ws, {
+      t: 'respond',
+      id: 'response-1',
+      rpcId: 'question-1',
+      result: { ok: true, value: { sessionId: 'session-1', answer: { answers: [{ id: 'db', selected: ['SQLite'] }] } } },
+    })
+    await waitFor(() => frames.some((frame) => frame.t === 'respond.result'))
+
+    expect(frames).toContainEqual(expect.objectContaining({
+      t: 'respond.result', id: 'response-1', ok: true,
+    }))
+    const request = h.fetchMock.mock.calls[0]![0] as Request
+    expect(request.url).toBe('http://dsh.internal/api/respond')
+    expect(request.method).toBe('POST')
+    expect(request.headers.get('content-type')).toBe('application/json')
+    expect(JSON.parse(await request.text())).toEqual({
+      type: 'client-response',
+      rpcId: 'question-1',
+      result: { ok: true, value: { sessionId: 'session-1', answer: { answers: [{ id: 'db', selected: ['SQLite'] }] } } },
+    })
+    ws.close()
+  })
+
+  it('returns gateway response failures to the extension', async () => {
+    const h = await startBridge({ apiHandler: { fetch: async () => new Response('response rejected', { status: 409 }) } })
+    harnesses.push(h)
+    const { ws, frames } = await connect(h.url)
+    send(ws, { t: 'hello', token: TOKEN, caps: CAPS })
+    await waitFor(() => frames.some((frame) => frame.t === 'hello.ok'))
+    send(ws, {
+      t: 'respond', id: 'response-2', rpcId: 'question-2',
+      result: { ok: false, error: { code: 'cancelled', message: 'user dismissed the question' } },
+    })
+    await waitFor(() => frames.some((frame) => frame.t === 'respond.result' && frame.id === 'response-2'))
+    expect(frames).toContainEqual({
+      t: 'respond.result', id: 'response-2', ok: false,
+      error: { code: 'http', message: 'response rejected' },
+    })
+    ws.close()
+  })
+
   it('rejects privileged methods from non-loopback remotes', async () => {
     expect(isLoopbackAddress('127.0.0.1')).toBe(true)
     expect(isLoopbackAddress('::1')).toBe(true)

--- a/packages/browser/bridge-browser/tests/server.spec.ts
+++ b/packages/browser/bridge-browser/tests/server.spec.ts
@@ -200,6 +200,48 @@ describe('BridgeServer', () => {
     ws.close()
   })
 
+  it('orders prompt before cancel for one session without blocking other sessions', async () => {
+    let releasePrompt!: () => void
+    const promptGate = new Promise<void>((resolve) => { releasePrompt = resolve })
+    const calls: Array<{ method: string; sessionId: string }> = []
+    const apiHandler = { fetch: vi.fn(async (request: Request) => {
+      const body = await request.json() as { rpcId: string; method: string; payload: { sessionId: string } }
+      calls.push({ method: body.method, sessionId: body.payload.sessionId })
+      if (body.method === 'session.prompt' && body.payload.sessionId === 'provisional') await promptGate
+      return Response.json({
+        type: 'server-response',
+        rpcId: body.rpcId,
+        result: { ok: true, value: { accepted: true } },
+      })
+    }) }
+    const h = await startBridge({ apiHandler })
+    harnesses.push(h)
+    const { ws, frames } = await connect(h.url)
+    send(ws, { t: 'hello', token: TOKEN, caps: CAPS })
+    await waitFor(() => frames.some((frame) => frame.t === 'hello.ok'))
+
+    send(ws, {
+      t: 'rpc', id: 'prompt', method: 'session.prompt',
+      payload: { sessionId: 'provisional', mode: 'queue', content: [] },
+    })
+    send(ws, { t: 'rpc', id: 'cancel', method: 'session.cancel', payload: { sessionId: 'provisional' } })
+    send(ws, { t: 'rpc', id: 'other-cancel', method: 'session.cancel', payload: { sessionId: 'other' } })
+
+    await waitFor(() => calls.some((call) => call.sessionId === 'other'))
+    expect(calls).toContainEqual({ method: 'session.prompt', sessionId: 'provisional' })
+    expect(calls).toContainEqual({ method: 'session.cancel', sessionId: 'other' })
+    expect(calls).not.toContainEqual({ method: 'session.cancel', sessionId: 'provisional' })
+
+    releasePrompt()
+    await waitFor(() => calls.some((call) => call.method === 'session.cancel' && call.sessionId === 'provisional'))
+    expect(calls.filter((call) => call.sessionId === 'provisional')).toEqual([
+      { method: 'session.prompt', sessionId: 'provisional' },
+      { method: 'session.cancel', sessionId: 'provisional' },
+    ])
+    await waitFor(() => frames.filter((frame) => frame.t === 'rpc.result').length === 3)
+    ws.close()
+  })
+
   it('relays interaction responses to /api/respond with the original rpcId', async () => {
     const h = await startBridge()
     harnesses.push(h)


### PR DESCRIPTION
## Summary

- relay host interaction responses through the browser bridge and return receipts only to the side panel that initiated them
- render bilingual `ask_user_question` cards with full prompts, details, options, multi-select, custom answers, dismissal, and retryable errors
- match resolutions by both session and question RPC id, with UUID correlation plus timeout/disconnect cleanup
- add a conventional circular stop button with a square glyph that calls `session.cancel`
- document the interaction frames and cover the complete flow with a real Chromium extension E2E test

## Why

The dsh main UI could pause for `ask_user_question`, but a turn started from the browser sidebar had no way to display or answer that request and appeared stuck. The sidebar also lacked the familiar stop-generation control.

This builds on the core proposal from #6 by @yeruizhi. Every commit includes them as a co-author, while incorporating the review feedback around full question rendering, exact resolution matching, cross-panel response isolation, and timeout/disconnect handling.

## Safety and behavior

- website-provided question text is rendered as React text, never injected as HTML
- response receipts are targeted to the originating panel instead of broadcast
- pending responses fail closed on timeout, panel closure, bridge loss, or send failure
- concurrent questions are queued by session and RPC id; a rejected response keeps its editor available for retry
- opaque and repeated question ids are stored positionally, avoiding JavaScript prototype-key collisions
- prompt and cancel RPCs preserve WebSocket arrival order per session, so stopping during provisional-session materialization cannot race ahead of the first prompt
- stopping a turn keeps the sidebar session available for the next message

## Validation

- `pnpm run typecheck`
- `pnpm run test` — 86 bridge tests and 94 extension tests
- real Chromium E2E: duplicate/prototype-like ids, multi-select plus custom text, concurrent asks, successful answers, and host-confirmed dismissal
- `pnpm run build`
