### PR TITLE
feat(bridge): constrain browser_* usage in system prompt and tool descriptions

### DIFF
--- a/packages/browser/bridge-browser/src/index.ts
+++ b/packages/browser/bridge-browser/src/index.ts
@@ -180,8 +180,20 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
     ctx.effect(() => systemPrompt.section({
       name: 'tool:bridge-browser',
       order: 107,
-      text: 'A browser bridge may be connected. To read or operate the user\'s active browser page, call browser_snapshot '
-        + '(text-only; numbered items are the click/type targets). Never assume page content you have not snapshot.',
+      text: 'A browser bridge may be connected and provides browser_* tools that drive the user\'s real browser tab '
+        + '(preserving login state, cookies and sessions). They are RESTRICTED tools: use them only when one of these '
+        + 'holds — (1) the page needs login state, cookies, or a real browser session; (2) the page is JS-rendered or '
+        + 'dynamic and lightweight tools cannot read its full content; (3) the task requires interaction: clicking, '
+        + 'typing, pressing keys, scrolling, in-page navigation, or extracting text from a specific region; '
+        + '(4) the user explicitly asks to open or operate the browser. '
+        + 'For any other information gathering — searching, looking things up, reading summaries, and the like — '
+        + 'prefer lightweight tools such as web_search, and judge for yourself which tasks do not need the browser: '
+        + 'browser_* is much slower and far more token-expensive than lightweight search, so do not open the browser '
+        + 'for every query. '
+        + 'For research/search tasks, collect candidates with lightweight search first (summaries + links), then open '
+        + 'with browser_navigate only the pages you actually need to read in depth, and snapshot narrowly '
+        + '(region for the content area, delta=true for changes). Never open a browser page just to confirm what a '
+        + 'snippet already tells you. Never assume page content you have not snapshot.',
     }), 'bridge-browser: system prompt section')
   }
 

--- a/packages/browser/bridge-browser/src/tools.ts
+++ b/packages/browser/bridge-browser/src/tools.ts
@@ -115,6 +115,7 @@ function defineTools(call: Call, options: BrowserToolsOptions): ToolDefinition[]
   const snapshot = (): ToolDefinition => ({
     name: 'browser_snapshot',
     description: '读取当前浏览器页面及可访问 iframe 的结构化文本快照（无截图）：标题、URL、正文摘要、带编号的可交互元素清单、表单字段。'
+      + '仅在需要真实浏览器渲染（JS 动态内容）、登录态页面，或要发起交互操作时才使用本工具；普通信息查询应先用 web_search 等轻量方式，不要为每条查询都打开浏览器。'
       + `顶层元素只需 index；iframe 元素使用快照标题中的 frame 与局部稳定 index。页面未变化时设置 delta=true 只返回变化部分，节省上下文。${UNTRUSTED_CONTENT_WARNING}`,
     parameters: {
       ...OBJECT_SCHEMA,
@@ -205,7 +206,7 @@ function defineTools(call: Call, options: BrowserToolsOptions): ToolDefinition[]
 
   const navigate = (): ToolDefinition => ({
     name: 'browser_navigate',
-    description: '在当前标签页导航到指定 URL。保留当前登录状态（cookie/会话）。',
+    description: '在当前标签页导航到指定 URL。保留当前登录状态（cookie/会话）。仅在需要浏览器环境（登录态、JS 渲染）或用户明确要求打开页面时才用；普通信息查询请先用 web_search 等轻量方式。',
     parameters: {
       ...OBJECT_SCHEMA,
       url: { type: 'string', required: true, description: '完整 URL（http/https）。' },


### PR DESCRIPTION
## Summary

The bridge system prompt now treats `browser_*` as **restricted** tools:

- Use them only when one of these holds: (1) the page needs login state / cookies / a real browser session; (2) the page is JS-rendered or dynamic and lightweight tools cannot read it; (3) the task requires interaction (clicking, typing, pressing keys, scrolling, in-page navigation, region text extraction); (4) the user explicitly asks to open or operate the browser.
- For any other information gathering — searching, lookups, summaries, and the like — prefer lightweight tools such as `web_search`, and judge which tasks do not need the browser (browser_* is much slower and far more token-expensive).
- Research/search tasks: collect candidates with lightweight search first, then open only the pages you actually need, keeping snapshots narrow (`region` / `delta=true`); never open a browser page just to confirm what a snippet already says.

Tool descriptions for `browser_snapshot` / `browser_navigate` were updated to state the restricted usage conditions instead of a blanket preference.

## Motivation

Models tended to open the browser for every query (slow, token-heavy), or tried generic scraping first and failed on JS-rendered/login pages. Constraining browser_* to the four cases above gives the model a clear decision boundary while keeping lightweight search as the default for information gathering.

## Changes

- `packages/browser/bridge-browser/src/index.ts`: system-prompt section rework
- `packages/browser/bridge-browser/src/tools.ts`: description updates for `browser_snapshot` / `browser_navigate`

## Validation

- `pnpm --filter @deepseek-ai/dsh-bridge-browser run typecheck` clean
- `pnpm --filter @deepseek-ai/dsh-bridge-browser run build` clean
- Manually verified on Windows/Edge: search tasks use `web_search` first; login/JS pages correctly switch to `browser_*`

## Note

Changes were assisted by DeepSeek V4 Flash.

## 中文摘要 🐳

- 系统提示将 `browser_*` 定义为**受限工具**：仅限登录态 / JS 渲染 / 交互操作 / 用户明确要求四类场景
- 查资料、找信息、看摘要等默认走轻量工具（如 `web_search`），由模型自行判断
- 检索任务：先轻量搜索拿候选，只打开需要深读的页面，快照用 `region`/`delta` 保持最小
- 工具描述同步为约束式措辞
- 本改动由 **DeepSeek V4 Flash** 🐳 辅助生成，请审阅