### PR TITLE
fix(extension): clarify approval-denied feedback to the model

### DIFF
--- a/extensions/dsh-browser/src/background/tools.ts
+++ b/extensions/dsh-browser/src/background/tools.ts
@@ -242,7 +242,13 @@ export async function dispatchToolCall(
     const allowed = authorize === undefined ? false : await authorize(approval)
     if (isCancelled(call, signal)) return cancelled()
     if (!allowed) {
-      return { ok: false, error: { code: 'action-failed', message: '用户未批准读取或页面操作' } }
+      return {
+        ok: false,
+        error: {
+          code: 'action-failed',
+          message: '用户未批准或审批等待超时（侧边栏可能未打开）。浏览器操作需要用户在侧边栏确认；请提醒用户打开侧边栏完成审批，或询问用户是否继续此操作后再重试。工具本身工作正常。',
+        },
+      }
     }
   }
   let executionFrames = frames


### PR DESCRIPTION
## Summary

When a browser approval is denied or times out, the tool error now tells the model:

- the browser tool itself is healthy,
- the user may simply have missed the side-panel prompt (or the panel was closed),
- and suggests reminding the user / asking whether to continue, instead of silently giving up on the tool.

## Motivation

Previously the model received only "用户未批准读取或页面操作" (user did not approve), which reads as a deliberate rejection — models would stop trying and sometimes concluded the tool was broken. The clearer message prevents both misreadings.

## Changes

- `extensions/dsh-browser/src/background/tools.ts`: expanded denial/timeout error message

## Validation

- `pnpm --filter dsh-browser-extension run typecheck` clean
- build clean

## Note

Changes were assisted by DeepSeek V4 Flash.

## 中文摘要 🐳

- 审批被拒绝或超时时，返回给模型的错误现在明确说明：工具本身正常、用户可能只是没看到侧边栏审批、请提醒用户或询问是否继续
- 避免模型误判"工具故障"或误以为"用户拒绝"而放弃浏览器工具
- 本改动由 **DeepSeek V4 Flash** 🐳 辅助生成，请审阅