### PR TITLE
feat(extension): approval notifications, session resume, and queued approvals

### DIFF
--- a/extensions/dsh-browser/manifest.json
+++ b/extensions/dsh-browser/manifest.json
@@ -12,7 +12,8 @@
     "activeTab",
     "scripting",
     "webNavigation",
-    "alarms"
+    "alarms",
+    "notifications"
   ],
   "host_permissions": [
     "http://*/*",

--- a/extensions/dsh-browser/src/background/index.ts
+++ b/extensions/dsh-browser/src/background/index.ts
@@ -48,6 +48,10 @@ export interface Settings {
   sharePageContent: 'ask' | 'auto' | 'off'
   /** Origins whose state-changing actions may run without another prompt. */
   trustedActionOrigins: string[]
+  /** Auto-open the side panel when a browser action needs approval while it is closed. */
+  autoOpenSidePanel: boolean
+  /** Auto-resume the most recent session when the panel connects. */
+  autoResumeSession: boolean
 }
 
 const SETTINGS_DEFAULTS: Settings = {
@@ -56,6 +60,8 @@ const SETTINGS_DEFAULTS: Settings = {
   token: '',
   sharePageContent: 'auto',
   trustedActionOrigins: [],
+  autoOpenSidePanel: true,
+  autoResumeSession: true,
 }
 
 /** 自动探测的候选端口（dsh web 默认 3080；--port 覆盖的常见值）。 */
@@ -103,6 +109,8 @@ let settings: Settings = { ...SETTINGS_DEFAULTS }
 let caps: BridgeCaps | null = null
 let bridge: BridgeClient | null = null
 let rpc: ReturnType<typeof createRpc> | null = null
+/** Most recently observed session id from the event stream (the session that triggered the last browser action). */
+let lastActiveSessionId: string | null = null
 const panelPorts = new Set<chrome.runtime.Port>()
 const interactionResponses = new InteractionResponseRouter()
 const transientEvents = new TransientEventCache()
@@ -114,7 +122,7 @@ const pendingApprovals = new Map<string, {
   resolve: (decision: ApprovalDecision) => void
   timer: ReturnType<typeof setTimeout>
 }>()
-const APPROVAL_TIMEOUT_MS = 30_000
+const APPROVAL_TIMEOUT_MS = 60_000
 
 async function loadSettings(): Promise<Settings> {
   const stored = await chrome.storage.local.get(STORAGE_KEY)
@@ -138,7 +146,13 @@ function normalizeSettings(candidate: Settings): Settings {
   const sharePageContent = candidate.sharePageContent === 'auto' || candidate.sharePageContent === 'off'
     ? candidate.sharePageContent
     : candidate.sharePageContent === 'ask' ? 'ask' : 'auto'
-  return { ...candidate, sharePageContent, trustedActionOrigins: trusted }
+  return {
+    ...candidate,
+    sharePageContent,
+    trustedActionOrigins: trusted,
+    autoOpenSidePanel: candidate.autoOpenSidePanel !== false,
+    autoResumeSession: candidate.autoResumeSession !== false,
+  }
 }
 
 function broadcastStatus(): void {
@@ -185,8 +199,30 @@ function settleApproval(id: string, decision: ApprovalDecision): void {
   broadcastApprovalResolved(id)
 }
 
+/** Auto-open the side panel (setting-gated). Falls back to a notification when the browser rejects the call. */
+async function ensureSidePanelOpen(): Promise<void> {
+  if (settings.autoOpenSidePanel !== true) return
+  const zh = getUiLocale() === 'zh'
+  try {
+    const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true })
+    const windowId = tab?.windowId ?? (await chrome.windows.getLastFocused()).id
+    if (windowId !== undefined) await chrome.sidePanel.open({ windowId })
+  } catch {
+    try {
+      await chrome.notifications.create('dsh-browser-approval', {
+        type: 'basic',
+        iconUrl: chrome.runtime.getURL('assets/icons/icon128.png'),
+        title: zh ? 'dsh 浏览器助手' : 'dsh Browser Assistant',
+        message: zh
+          ? '侧边栏有浏览器操作待审批，请点击工具栏鲸鱼图标打开侧边栏（审批会等待 60 秒）。'
+          : 'A browser action is waiting for approval. Click the whale icon in the toolbar to open the side panel (the request waits 60s).',
+      })
+    } catch { /* notifications unavailable */ }
+  }
+}
+
 function requestApproval(prompt: ApprovalPrompt, signal: AbortSignal): Promise<ApprovalDecision> {
-  if (panelPorts.size === 0 || signal.aborted) return Promise.resolve('deny')
+  if (signal.aborted) return Promise.resolve('deny')
   const request: ApprovalRequest = { ...prompt, id: crypto.randomUUID() }
   return new Promise((resolve) => {
     const onAbort = (): void => { settleApproval(request.id, 'deny') }
@@ -202,14 +238,29 @@ function requestApproval(prompt: ApprovalPrompt, signal: AbortSignal): Promise<A
       settleApproval(request.id, 'deny')
       return
     }
+    // 侧边栏未打开时不再立即拒绝：自动弹出（受设置开关控制），并在超时窗口内
+    // 轮询等待面板端口出现后再送达审批；超时仍 fail-closed 拒绝。
+    if (panelPorts.size === 0) void ensureSidePanelOpen()
     let delivered = false
-    for (const port of panelPorts) {
-      try {
-        port.postMessage({ type: 'approval.request', request })
-        delivered = true
-      } catch { /* port already closed */ }
+    let poll: ReturnType<typeof setInterval> | undefined
+    const tryDeliver = (): void => {
+      if (delivered) return
+      if (pendingApprovals.get(request.id) === undefined) {
+        // 已被 settle（超时/abort）：停止轮询。
+        if (poll !== undefined) clearInterval(poll)
+        return
+      }
+      for (const port of panelPorts) {
+        try {
+          port.postMessage({ type: 'approval.request', request })
+          delivered = true
+          if (poll !== undefined) clearInterval(poll)
+          return
+        } catch { /* port already closed */ }
+      }
     }
-    if (!delivered) settleApproval(request.id, 'deny')
+    tryDeliver()
+    if (!delivered) poll = setInterval(tryDeliver, 500)
   })
 }
 
@@ -345,6 +396,8 @@ async function startBridge(): Promise<void> {
         if (frame.t === 'event') {
           transientEvents.ingest(frame)
           broadcastEvent(frame)
+          const payload = frame.frame.payload as { sessionId?: string } | undefined
+          if (typeof payload?.sessionId === 'string') lastActiveSessionId = payload.sessionId
         }
         else if (frame.t === 'tool.call') routeToolCall(frame)
         else if (frame.t === 'tool.cancel') cancelToolCall(frame.id)
@@ -380,6 +433,9 @@ chrome.runtime.onConnect.addListener((port) => {
   panelPorts.add(port)
   if (bridge === null) void startBridge()
   try { port.postMessage({ type: 'status', state: bridge?.state ?? ('stopped' as BridgeState), caps }) } catch { /* port closed */ }
+  try {
+    port.postMessage({ type: 'resume-hint', sessionId: lastActiveSessionId })
+  } catch { /* port closed */ }
   port.onMessage.addListener((message: unknown) => {
     if (typeof message !== 'object' || message === null) return
     const msg = message as { type?: string }

--- a/extensions/dsh-browser/src/panel/App.tsx
+++ b/extensions/dsh-browser/src/panel/App.tsx
@@ -206,6 +206,7 @@ export function App(): React.JSX.Element {
   const [stopping, setStopping] = useState(false)
   const [showSettings, setShowSettings] = useState(false)
   const [approvalQueue, setApprovalQueue] = useState<ApprovalRequest[]>([])
+  const [pendingApprovals, setPendingApprovals] = useState<ApprovalRequest[]>([])
   const [trustedOriginInput, setTrustedOriginInput] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [showSessionPicker, setShowSessionPicker] = useState(false)
@@ -223,6 +224,7 @@ export function App(): React.JSX.Element {
   const sessionRuntimeRef = useRef(new SessionRuntimeCache())
   const seqRef = useRef(0)
   const sessionRef = useRef<string | null>(null)
+  const resumeHintRef = useRef<string | null>(null)
   const scrollRef = useRef<HTMLDivElement | null>(null)
 
   const nextSeq = (): number => { seqRef.current += 1; return seqRef.current }
@@ -273,6 +275,8 @@ export function App(): React.JSX.Element {
         token: raw?.token ?? '',
         sharePageContent: raw?.sharePageContent ?? 'auto',
         trustedActionOrigins: raw?.trustedActionOrigins ?? [],
+        autoOpenSidePanel: raw?.autoOpenSidePanel ?? true,
+        autoResumeSession: raw?.autoResumeSession ?? true,
       })
     })
   }, [])
@@ -305,21 +309,45 @@ export function App(): React.JSX.Element {
       }
     })
     const offEvent = api.onEvent((frame) => { void onFrame(frame) })
+    const offResumeHint = api.onResumeHint((sessionId) => { resumeHintRef.current = sessionId })
     const offApproval = api.onApprovalRequest((request) => {
+      if (sessionChangingRef.current) {
+        setPendingApprovals((current) => current.some((entry) => entry.id === request.id) ? current : [...current, request])
+        return
+      }
       setApprovalQueue((current) => current.some((entry) => entry.id === request.id) ? current : [...current, request])
     })
     const offApprovalResolved = api.onApprovalResolved((id) => {
       setApprovalQueue((current) => current.filter((request) => request.id !== id))
+      setPendingApprovals((current) => current.filter((request) => request.id !== id))
     })
     api.requestStatus()
-    return () => { offStatus(); offEvent(); offApproval(); offApprovalResolved() }
+    return () => { offStatus(); offEvent(); offResumeHint(); offApproval(); offApprovalResolved() }
   }, [api])
+
+  // 会话切换完成后，把等待中的审批请求并入显示队列。
+  useEffect(() => {
+    if (sessionChanging) return
+    if (pendingApprovals.length === 0) return
+    setApprovalQueue((current) => {
+      const merged = [...current]
+      for (const request of pendingApprovals) {
+        if (!merged.some((entry) => entry.id === request.id)) merged.push(request)
+      }
+      return merged
+    })
+    setPendingApprovals([])
+  }, [sessionChanging, pendingApprovals])
 
   useEffect(() => {
     if (state === 'connected' && sessionRef.current === null) {
-      void ensureSession()
+      if (settings?.autoResumeSession !== false) {
+        void resumeMostRecentSession()
+      } else {
+        void ensureSession()
+      }
     }
-  }, [state, sessionEpoch])
+  }, [state, sessionEpoch, settings?.autoResumeSession])
 
   // Auto-scroll to the newest row.
   useEffect(() => {
@@ -454,6 +482,27 @@ export function App(): React.JSX.Element {
     } catch (cause) {
       if (sessionRef.current === id) setError(cause instanceof Error ? cause.message : String(cause))
     }
+  }
+
+  /** 连接后优先续接当前会话：resume-hint 指定 → 最近非空白会话 → 新建。 */
+  async function resumeMostRecentSession(): Promise<void> {
+    const hinted = resumeHintRef.current
+    try {
+      const result = await api.rpc<{ items: SessionPickerEntry[] }>('session.list', {})
+      for (const entry of result.items ?? []) {
+        sessionRuntimeRef.current.seedRunning(entry.sessionId, entry.running)
+      }
+      const items = resumableSessions(result.items ?? [])
+      const target = (hinted !== null ? items.find((entry) => entry.sessionId === hinted) : undefined)
+        ?? items[0]
+      if (target !== undefined && !sessionChangingRef.current) {
+        await resumeSession(target)
+        return
+      }
+    } catch {
+      // 列表不可用时回退到新建会话。
+    }
+    await ensureSession()
   }
 
   /** 每次打开侧边栏都新建一个会话（与 GUI/其他界面的历史完全隔离）。 */
@@ -679,6 +728,26 @@ export function App(): React.JSX.Element {
               <option value="ask">{copy.settings.sharingAsk}</option>
               <option value="off">{copy.settings.sharingOff}</option>
             </select>
+          </label>
+          <label>
+            <span>{copy.settings.autoOpenSidePanel}</span>
+            <small>{copy.settings.autoOpenSidePanelHelp}</small>
+            <input
+              type="checkbox"
+              className="local-toggle"
+              checked={settings?.autoOpenSidePanel ?? true}
+              onChange={(e) => setSettings((prev) => prev === null ? prev : { ...prev, autoOpenSidePanel: e.target.checked })}
+            />
+          </label>
+          <label>
+            <span>{copy.settings.autoResumeSession}</span>
+            <small>{copy.settings.autoResumeSessionHelp}</small>
+            <input
+              type="checkbox"
+              className="local-toggle"
+              checked={settings?.autoResumeSession ?? true}
+              onChange={(e) => setSettings((prev) => prev === null ? prev : { ...prev, autoResumeSession: e.target.checked })}
+            />
           </label>
         </div>
         <section className="trusted-origins" aria-labelledby="trusted-origins-title">

--- a/extensions/dsh-browser/src/panel/api.ts
+++ b/extensions/dsh-browser/src/panel/api.ts
@@ -37,6 +37,11 @@ interface StatusMessage {
   caps: BridgeCaps | null
 }
 
+interface ResumeHintMessage {
+  type: 'resume-hint'
+  sessionId: string | null
+}
+
 interface EventMessage {
   type: 'event'
   frame: ServerFrame
@@ -52,13 +57,14 @@ interface ApprovalResolvedMessage {
   id: string
 }
 
-type BackgroundMessage = RpcResultMessage | RespondResultMessage | StatusMessage | EventMessage | ApprovalRequestMessage | ApprovalResolvedMessage
+type BackgroundMessage = RpcResultMessage | RespondResultMessage | StatusMessage | ResumeHintMessage | EventMessage | ApprovalRequestMessage | ApprovalResolvedMessage
 
 /** The panel API surface. */
 export interface PanelApi {
   rpc<T = unknown>(method: string, payload?: unknown): Promise<T>
   respond(rpcId: string, result: RespondResult): Promise<unknown>
   onStatus(callback: (state: BridgeState, caps: BridgeCaps | null) => void): () => void
+  onResumeHint(callback: (sessionId: string | null) => void): () => void
   onEvent(callback: (frame: ServerFrame) => void): () => void
   onApprovalRequest(callback: (request: ApprovalRequest) => void): () => void
   onApprovalResolved(callback: (id: string) => void): () => void
@@ -77,6 +83,7 @@ export function connectPanel(): PanelApi {
     timer: ReturnType<typeof setTimeout>
   }>()
   const statusListeners = new Set<(state: BridgeState, caps: BridgeCaps | null) => void>()
+  const resumeHintListeners = new Set<(sessionId: string | null) => void>()
   const eventListeners = new Set<(frame: ServerFrame) => void>()
   const approvalListeners = new Set<(request: ApprovalRequest) => void>()
   const approvalResolvedListeners = new Set<(id: string) => void>()
@@ -111,6 +118,9 @@ export function connectPanel(): PanelApi {
       }
       case 'status':
         for (const listener of statusListeners) listener(msg.state, msg.caps)
+        break
+      case 'resume-hint':
+        for (const listener of resumeHintListeners) listener(msg.sessionId)
         break
       case 'event':
         for (const listener of eventListeners) listener(msg.frame)
@@ -157,6 +167,10 @@ export function connectPanel(): PanelApi {
     onStatus(callback) {
       statusListeners.add(callback)
       return () => { statusListeners.delete(callback) }
+    },
+    onResumeHint(callback) {
+      resumeHintListeners.add(callback)
+      return () => { resumeHintListeners.delete(callback) }
     },
     onEvent(callback) {
       eventListeners.add(callback)

--- a/extensions/dsh-browser/src/panel/strings.ts
+++ b/extensions/dsh-browser/src/panel/strings.ts
@@ -52,6 +52,10 @@ export interface PanelCopy {
     sharingAuto: string
     sharingAsk: string
     sharingOff: string
+    autoOpenSidePanel: string
+    autoOpenSidePanelHelp: string
+    autoResumeSession: string
+    autoResumeSessionHelp: string
     trustedOrigins: string
     trustedOriginsHelp: string
     trustedOriginInput: string
@@ -157,6 +161,10 @@ const EN: PanelCopy = {
     sharingAuto: 'Share automatically (default)',
     sharingAsk: 'Ask every time',
     sharingOff: 'Off',
+    autoOpenSidePanel: 'Browser approval notifications',
+    autoOpenSidePanelHelp: 'Notify when a browser action needs approval while the panel is closed. Off = no notifications.',
+    autoResumeSession: 'Resume current session on open',
+    autoResumeSessionHelp: 'Resume the latest conversation on open. Off = always start fresh.',
     trustedOrigins: 'Always-allowed domains',
     trustedOriginsHelp: 'The approval dialog can trust a domain for the current side-panel session only. Domains added here permanently skip action confirmation when every known origin is trusted. Wildcards include the base domain and subdomains, and stay scoped to their scheme and port; `*.example.com` defaults to HTTPS.',
     trustedOriginInput: 'Domain to always trust (e.g. https://example.com or https://*.example.com)',
@@ -262,6 +270,10 @@ const ZH: PanelCopy = {
     sharingAuto: '自动共享（默认）',
     sharingAsk: '每次询问',
     sharingOff: '关闭',
+    autoOpenSidePanel: '浏览器审批通知',
+    autoOpenSidePanelHelp: '侧边栏关闭时有浏览器操作待审批时提醒你。关闭则不再弹通知。',
+    autoResumeSession: '打开时自动续接当前会话',
+    autoResumeSessionHelp: '打开时续接最近对话；关闭则每次全新会话。',
     trustedOrigins: '永久免确认域名',
     trustedOriginsHelp: '审批框可只信任本次侧栏会话。这里添加的域名仅在所有已知来源均受信任时免除操作确认。通配符包含主域及其子域，并严格区分协议和端口；`*.example.com` 默认使用 HTTPS。',
     trustedOriginInput: '要永久信任的域名（如 https://example.com 或 https://*.example.com）',

--- a/extensions/dsh-browser/src/panel/styles.css
+++ b/extensions/dsh-browser/src/panel/styles.css
@@ -1,4 +1,4 @@
-:root {
+﻿:root {
   color-scheme: light;
   --canvas: #f4f6fa;
   --canvas-deep: #edf0f6;
@@ -1709,4 +1709,22 @@ textarea:focus-visible {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Checkbox rows in settings (browser approval notifications / resume session) */
+.settings input.local-toggle {
+  width: 16px;
+  height: 16px;
+  min-height: 0;
+  margin: 0;
+  padding: 0;
+  grid-column: 2;
+  grid-row: 1 / 3;
+  justify-self: end;
+  align-self: center;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  accent-color: var(--blue);
+  cursor: pointer;
 }


### PR DESCRIPTION
## Summary

Three related approval-UX improvements:

**1. Approval notifications & 60s wait**
- When the side panel is closed and a browser action needs approval, show a system notification (setting-gated, default on) instead of silently rejecting.
- The approval now waits up to 60s for the panel to open before failing closed (previously: immediate deny when no panel was connected).
- `sidePanel.open()` is attempted first; the notification is the fallback (the browser requires a user gesture for programmatic side-panel opens).

**2. Session resume on open**
- Track the most recently active session id from the event stream and send it to the panel as a `resume-hint`.
- On connect the panel resumes that session (falling back to the latest non-blank session, then a fresh one), so opening the side panel continues the current conversation instead of always creating a new one (setting-gated, default on).

**3. Queued approvals during session switch**
- Approvals arriving while the panel is switching/resuming a session are queued and flushed only after the session is ready, so the prompt always matches the conversation being shown.

Settings UI gains two toggles: "Browser approval notifications" and "Resume current session on open", with EN/ZH copy. `notifications` permission added to the manifest.

## Motivation

With the side panel closed, browser approvals were silently denied (`panelPorts.size === 0 → deny`), so browser tools failed in the main UI session with no way to approve. This makes approvals discoverable and keeps the panel's context aligned with the main UI session.

## Changes

- `extensions/dsh-browser/manifest.json`: + `notifications` permission
- `extensions/dsh-browser/src/background/index.ts`: settings fields, last-active-session tracking, approval wait window with polling, `ensureSidePanelOpen` (sidePanel.open → notification fallback), `resume-hint` message
- `extensions/dsh-browser/src/panel/api.ts`: `onResumeHint` channel
- `extensions/dsh-browser/src/panel/App.tsx`: settings toggles, session resume, queued approvals
- `extensions/dsh-browser/src/panel/strings.ts`: EN/ZH copy
- `extensions/dsh-browser/src/panel/styles.css`: toggle styling (scoped to `.local-toggle`)

## Validation

- `pnpm --filter dsh-browser-extension run typecheck` clean
- build clean
- Manually verified on Windows/Edge: notification shown when panel closed, opening the panel resumes the current session and displays the queued approval; the panel-open path is unchanged

## Note

Changes were assisted by DeepSeek V4 Flash.

## 中文摘要 🐳

- 侧边栏关闭时浏览器操作待审批 → 弹系统通知提醒（开关可关，默认开），审批等待 60 秒不再立即拒绝
- 打开侧边栏自动续接当前会话（从事件流跟踪最近活跃会话，开关可关，默认开）
- 会话切换期间到达的审批先排队，会话就绪后才显示，保证审批与会话上下文一致
- 设置页新增两个开关（浏览器审批通知 / 打开时自动续接会话），中英文案齐全
- 本改动由 **DeepSeek V4 Flash** 🐳 辅助生成，请审阅