### PR TITLE
feat(panel): add managed extension update checks

### DIFF
--- a/extensions/dsh-browser/manifest.json
+++ b/extensions/dsh-browser/manifest.json
@@ -48,7 +48,7 @@
     }
   ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'; connect-src ws://127.0.0.1:* http://127.0.0.1:*"
+    "extension_pages": "script-src 'self'; object-src 'self'; connect-src ws://127.0.0.1:* http://127.0.0.1:* https://raw.githubusercontent.com"
   },
   "icons": {
     "16": "assets/icons/icon16.png",

--- a/extensions/dsh-browser/src/panel/App.tsx
+++ b/extensions/dsh-browser/src/panel/App.tsx
@@ -20,6 +20,7 @@ import type { ApprovalDecision, ApprovalRequest } from '../security/approval.ts'
 import { getUiLocale } from '../i18n.ts'
 import { PANEL_COPY, type PanelCopy } from './strings.ts'
 import { QuestionCard } from './QuestionCard.tsx'
+import { UpdateCard } from './UpdateCard.tsx'
 import type { QuestionAnswer } from './questions.ts'
 import {
   hasPendingQuestion,
@@ -836,6 +837,7 @@ export function App(): React.JSX.Element {
             <h1>{copy.settings.title}</h1>
           </div>
         </div>
+        <UpdateCard copy={copy.update} />
         <div className="settings-panel">
           <label>
             <span>{copy.settings.bridgeAddress}</span>

--- a/extensions/dsh-browser/src/panel/UpdateCard.tsx
+++ b/extensions/dsh-browser/src/panel/UpdateCard.tsx
@@ -1,6 +1,12 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { PanelCopy } from './strings.ts'
-import { checkForExtensionUpdate, UPDATE_COMMAND } from './updates.ts'
+import {
+  checkForExtensionUpdate,
+  checkoutInstallCommand,
+  readExtensionInstallInfo,
+  UPDATE_COMMAND,
+  type ExtensionInstallInfo,
+} from './updates.ts'
 
 type CheckState =
   | { status: 'idle' }
@@ -16,6 +22,15 @@ export function UpdateCard({ copy }: { copy: PanelCopy['update'] }): React.JSX.E
   const currentVersion = chrome.runtime.getManifest().version
   const [checkState, setCheckState] = useState<CheckState>({ status: 'idle' })
   const [copyState, setCopyState] = useState<CopyState>('idle')
+  const [installInfo, setInstallInfo] = useState<ExtensionInstallInfo | null>(null)
+
+  useEffect(() => {
+    let current = true
+    void readExtensionInstallInfo(chrome.runtime.getURL('install-info.json')).then((info) => {
+      if (current) setInstallInfo(info)
+    })
+    return () => { current = false }
+  }, [])
 
   async function check(): Promise<void> {
     if (checkState.status === 'checking') return
@@ -32,8 +47,14 @@ export function UpdateCard({ copy }: { copy: PanelCopy['update'] }): React.JSX.E
   }
 
   async function copyCommand(): Promise<void> {
+    const command = installInfo?.mode === 'managed'
+      ? UPDATE_COMMAND
+      : installInfo?.mode === 'checkout'
+        ? checkoutInstallCommand(installInfo.sourceRoot)
+        : null
+    if (command === null) return
     try {
-      await navigator.clipboard.writeText(UPDATE_COMMAND)
+      await navigator.clipboard.writeText(command)
       setCopyState('copied')
     } catch {
       setCopyState('error')
@@ -49,6 +70,13 @@ export function UpdateCard({ copy }: { copy: PanelCopy['update'] }): React.JSX.E
         : checkState.status === 'available'
           ? copy.availableTitle(checkState.latestVersion)
           : copy.errorTitle
+  const availableBody = installInfo === null
+    ? copy.availableLoadingBody
+    : installInfo.mode === 'managed'
+      ? copy.availableManagedBody
+      : installInfo.mode === 'checkout'
+        ? copy.availableCheckoutBody
+        : copy.availableUnknownBody
   const statusBody = checkState.status === 'idle'
     ? copy.idleBody
     : checkState.status === 'checking'
@@ -56,8 +84,18 @@ export function UpdateCard({ copy }: { copy: PanelCopy['update'] }): React.JSX.E
       : checkState.status === 'current'
         ? copy.currentBody(checkState.latestVersion)
         : checkState.status === 'available'
-          ? copy.availableBody
+          ? availableBody
           : copy.errorBody
+  const installMode = installInfo?.mode ?? 'loading'
+  const installLabel = installMode === 'managed'
+    ? copy.managedInstall
+    : installMode === 'checkout'
+      ? copy.checkoutInstall
+      : installMode === 'unknown'
+        ? copy.unknownInstall
+        : copy.loadingInstall
+  const updateCommandAvailable = installInfo?.mode === 'managed' || installInfo?.mode === 'checkout'
+  const copyLabel = installInfo?.mode === 'checkout' ? copy.copyCheckoutCommand : copy.copyManagedCommand
 
   return (
     <section className={`update-card update-${checkState.status}`} aria-labelledby="update-card-title">
@@ -66,7 +104,10 @@ export function UpdateCard({ copy }: { copy: PanelCopy['update'] }): React.JSX.E
           <span className="eyebrow">{copy.eyebrow}</span>
           <h2 id="update-card-title">{copy.title}</h2>
         </div>
-        <span className="version-pill">v{currentVersion}</span>
+        <div className="update-meta">
+          <span className={`install-pill install-${installMode}`}>{installLabel}</span>
+          <span className="version-pill">v{currentVersion}</span>
+        </div>
       </div>
       <div className="update-status" role="status" aria-live="polite" aria-busy={checkState.status === 'checking'}>
         <span className="update-beacon" aria-hidden="true" />
@@ -86,9 +127,9 @@ export function UpdateCard({ copy }: { copy: PanelCopy['update'] }): React.JSX.E
           onClick={() => { void check() }}>
           {checkState.status === 'checking' ? copy.checking : copy.check}
         </button>
-        {checkState.status === 'available' && (
+        {checkState.status === 'available' && updateCommandAvailable && (
           <button type="button" className="update-copy" onClick={() => { void copyCommand() }}>
-            {copyState === 'copied' ? copy.copied : copy.copyCommand}
+            {copyState === 'copied' ? copy.copied : copyLabel}
           </button>
         )}
       </div>

--- a/extensions/dsh-browser/src/panel/UpdateCard.tsx
+++ b/extensions/dsh-browser/src/panel/UpdateCard.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react'
+import type { PanelCopy } from './strings.ts'
+import { checkForExtensionUpdate, UPDATE_COMMAND } from './updates.ts'
+
+type CheckState =
+  | { status: 'idle' }
+  | { status: 'checking' }
+  | { status: 'current'; latestVersion: string }
+  | { status: 'available'; latestVersion: string }
+  | { status: 'error' }
+
+type CopyState = 'idle' | 'copied' | 'error'
+
+/** Read-only update check plus the existing managed installer handoff. */
+export function UpdateCard({ copy }: { copy: PanelCopy['update'] }): React.JSX.Element {
+  const currentVersion = chrome.runtime.getManifest().version
+  const [checkState, setCheckState] = useState<CheckState>({ status: 'idle' })
+  const [copyState, setCopyState] = useState<CopyState>('idle')
+
+  async function check(): Promise<void> {
+    if (checkState.status === 'checking') return
+    setCheckState({ status: 'checking' })
+    setCopyState('idle')
+    try {
+      const result = await checkForExtensionUpdate(currentVersion)
+      setCheckState(result.updateAvailable
+        ? { status: 'available', latestVersion: result.latestVersion }
+        : { status: 'current', latestVersion: result.latestVersion })
+    } catch {
+      setCheckState({ status: 'error' })
+    }
+  }
+
+  async function copyCommand(): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(UPDATE_COMMAND)
+      setCopyState('copied')
+    } catch {
+      setCopyState('error')
+    }
+  }
+
+  const statusTitle = checkState.status === 'idle'
+    ? copy.idleTitle
+    : checkState.status === 'checking'
+      ? copy.checking
+      : checkState.status === 'current'
+        ? copy.currentTitle
+        : checkState.status === 'available'
+          ? copy.availableTitle(checkState.latestVersion)
+          : copy.errorTitle
+  const statusBody = checkState.status === 'idle'
+    ? copy.idleBody
+    : checkState.status === 'checking'
+      ? copy.checkingBody
+      : checkState.status === 'current'
+        ? copy.currentBody(checkState.latestVersion)
+        : checkState.status === 'available'
+          ? copy.availableBody
+          : copy.errorBody
+
+  return (
+    <section className={`update-card update-${checkState.status}`} aria-labelledby="update-card-title">
+      <div className="update-heading">
+        <div>
+          <span className="eyebrow">{copy.eyebrow}</span>
+          <h2 id="update-card-title">{copy.title}</h2>
+        </div>
+        <span className="version-pill">v{currentVersion}</span>
+      </div>
+      <div className="update-status" role="status" aria-live="polite" aria-busy={checkState.status === 'checking'}>
+        <span className="update-beacon" aria-hidden="true" />
+        <span>
+          <strong>{statusTitle}</strong>
+          <small>{statusBody}</small>
+        </span>
+      </div>
+      {checkState.status === 'available' && (
+        <div className="update-reload-reminder">
+          <span className="update-reload-glyph" aria-hidden="true">↻</span>
+          <strong>{copy.reloadReminder}</strong>
+        </div>
+      )}
+      <div className="update-actions">
+        <button type="button" className="update-check" disabled={checkState.status === 'checking'}
+          onClick={() => { void check() }}>
+          {checkState.status === 'checking' ? copy.checking : copy.check}
+        </button>
+        {checkState.status === 'available' && (
+          <button type="button" className="update-copy" onClick={() => { void copyCommand() }}>
+            {copyState === 'copied' ? copy.copied : copy.copyCommand}
+          </button>
+        )}
+      </div>
+      {copyState === 'error' && <small className="update-copy-error">{copy.copyError}</small>}
+    </section>
+  )
+}

--- a/extensions/dsh-browser/src/panel/strings.ts
+++ b/extensions/dsh-browser/src/panel/strings.ts
@@ -85,6 +85,25 @@ export interface PanelCopy {
     cancel: string
     snapshotHint: (maxChars: number) => string
   }
+  update: {
+    eyebrow: string
+    title: string
+    idleTitle: string
+    idleBody: string
+    checking: string
+    checkingBody: string
+    currentTitle: string
+    currentBody: (latestVersion: string) => string
+    availableTitle: (latestVersion: string) => string
+    availableBody: string
+    reloadReminder: string
+    errorTitle: string
+    errorBody: string
+    check: string
+    copyCommand: string
+    copied: string
+    copyError: string
+  }
   app: {
     openSettings: string
     settings: string
@@ -183,8 +202,8 @@ const EN: PanelCopy = {
   },
   settings: {
     back: 'Back to chat',
-    eyebrow: 'Preferences',
-    title: 'Connection & Privacy',
+    eyebrow: 'Browser assistant',
+    title: 'Settings',
     bridgeAddress: 'Bridge address',
     bridgeHelp: 'Leave blank to detect a local service automatically',
     bridgePlaceholder: 'Auto-detect 3080 / 3081 / 3090',
@@ -210,6 +229,25 @@ const EN: PanelCopy = {
     save: 'Save & Connect',
     cancel: 'Cancel',
     snapshotHint: (maxChars) => `Page snapshots are limited to ${maxChars} characters and longer content is truncated. Change snapshotMaxChars in the dsh plugin to adjust this limit.`,
+  },
+  update: {
+    eyebrow: 'Release channel',
+    title: 'Updates',
+    idleTitle: 'Ready to check',
+    idleBody: 'Compare this build with the version on GitHub main.',
+    checking: 'Checking…',
+    checkingBody: 'Reading the latest extension manifest from GitHub.',
+    currentTitle: 'No update found',
+    currentBody: (latestVersion) => `Repository version: v${latestVersion}.`,
+    availableTitle: (latestVersion) => `Version ${latestVersion} is available`,
+    availableBody: 'Copy the managed update command and run it in Terminal.',
+    reloadReminder: 'After updating, open chrome://extensions, find “dsh Browser Assistant,” click the rotating-arrow Reload button on its card, then restart dsh.',
+    errorTitle: 'Could not check for updates',
+    errorBody: 'Check your network connection and try again.',
+    check: 'Check for updates',
+    copyCommand: 'Copy update command',
+    copied: 'Command copied',
+    copyError: 'Could not copy the command. Use the update command in the project README instead.',
   },
   app: {
     openSettings: 'Open settings',
@@ -309,8 +347,8 @@ const ZH: PanelCopy = {
   },
   settings: {
     back: '返回对话',
-    eyebrow: '偏好设置',
-    title: '连接与隐私',
+    eyebrow: '浏览器助手',
+    title: '设置',
     bridgeAddress: '桥地址',
     bridgeHelp: '留空时自动检测本机服务',
     bridgePlaceholder: '自动检测 3080 / 3081 / 3090',
@@ -336,6 +374,25 @@ const ZH: PanelCopy = {
     save: '保存并连接',
     cancel: '取消',
     snapshotHint: (maxChars) => `页面快照上限为 ${maxChars} 字符，超出内容会被截断。可在 dsh 插件中调整 snapshotMaxChars。`,
+  },
+  update: {
+    eyebrow: '发布通道',
+    title: '软件更新',
+    idleTitle: '可以检查新版本',
+    idleBody: '与 GitHub main 上的扩展版本进行比较。',
+    checking: '正在检查…',
+    checkingBody: '正在读取 GitHub 上的最新扩展清单。',
+    currentTitle: '未发现更新',
+    currentBody: (latestVersion) => `仓库版本：v${latestVersion}。`,
+    availableTitle: (latestVersion) => `发现新版本 ${latestVersion}`,
+    availableBody: '复制托管更新命令并在终端运行。',
+    reloadReminder: '更新完成后，打开 chrome://extensions，找到“dsh 浏览器助手”，点击卡片上的“重新加载”旋转箭头，然后重启 dsh。',
+    errorTitle: '暂时无法检查更新',
+    errorBody: '请检查网络连接，然后重试。',
+    check: '检查更新',
+    copyCommand: '复制更新命令',
+    copied: '命令已复制',
+    copyError: '无法复制命令，请改用项目 README 中的更新命令。',
   },
   app: {
     openSettings: '打开设置',

--- a/extensions/dsh-browser/src/panel/strings.ts
+++ b/extensions/dsh-browser/src/panel/strings.ts
@@ -95,12 +95,20 @@ export interface PanelCopy {
     currentTitle: string
     currentBody: (latestVersion: string) => string
     availableTitle: (latestVersion: string) => string
-    availableBody: string
+    availableLoadingBody: string
+    availableManagedBody: string
+    availableCheckoutBody: string
+    availableUnknownBody: string
     reloadReminder: string
+    loadingInstall: string
+    managedInstall: string
+    checkoutInstall: string
+    unknownInstall: string
     errorTitle: string
     errorBody: string
     check: string
-    copyCommand: string
+    copyManagedCommand: string
+    copyCheckoutCommand: string
     copied: string
     copyError: string
   }
@@ -240,14 +248,22 @@ const EN: PanelCopy = {
     currentTitle: 'No update found',
     currentBody: (latestVersion) => `Repository version: v${latestVersion}.`,
     availableTitle: (latestVersion) => `Version ${latestVersion} is available`,
-    availableBody: 'Copy the managed update command and run it in Terminal.',
+    availableLoadingBody: 'Confirming how this extension was installed before offering an update command.',
+    availableManagedBody: 'Copy the managed update command and run it in Terminal.',
+    availableCheckoutBody: 'Pull or switch to the revision you want in the original checkout, then rerun its installer.',
+    availableUnknownBody: 'This copy predates install-source metadata. Use the same update flow you originally installed with; no command will be copied.',
     reloadReminder: 'After updating, open chrome://extensions, find “dsh Browser Assistant,” click the rotating-arrow Reload button on its card, then restart dsh.',
+    loadingInstall: 'Identifying install…',
+    managedInstall: 'Managed install',
+    checkoutInstall: 'Local checkout',
+    unknownInstall: 'Install source unknown',
     errorTitle: 'Could not check for updates',
     errorBody: 'Check your network connection and try again.',
     check: 'Check for updates',
-    copyCommand: 'Copy update command',
+    copyManagedCommand: 'Copy update command',
+    copyCheckoutCommand: 'Copy checkout command',
     copied: 'Command copied',
-    copyError: 'Could not copy the command. Use the update command in the project README instead.',
+    copyError: 'Could not copy the command. Run the installer from the original installation source instead.',
   },
   app: {
     openSettings: 'Open settings',
@@ -385,14 +401,22 @@ const ZH: PanelCopy = {
     currentTitle: '未发现更新',
     currentBody: (latestVersion) => `仓库版本：v${latestVersion}。`,
     availableTitle: (latestVersion) => `发现新版本 ${latestVersion}`,
-    availableBody: '复制托管更新命令并在终端运行。',
+    availableLoadingBody: '正在确认此扩展的安装来源，然后再提供更新命令。',
+    availableManagedBody: '复制托管更新命令并在终端运行。',
+    availableCheckoutBody: '请先在原 checkout 中 pull 或切换到目标 revision，再重新运行其中的安装脚本。',
+    availableUnknownBody: '这个副本没有安装来源记录。请沿用最初的更新方式；这里不会复制可能覆盖来源的命令。',
     reloadReminder: '更新完成后，打开 chrome://extensions，找到“dsh 浏览器助手”，点击卡片上的“重新加载”旋转箭头，然后重启 dsh。',
+    loadingInstall: '正在识别安装来源…',
+    managedInstall: '托管安装',
+    checkoutInstall: '本地 checkout',
+    unknownInstall: '安装来源未知',
     errorTitle: '暂时无法检查更新',
     errorBody: '请检查网络连接，然后重试。',
     check: '检查更新',
-    copyCommand: '复制更新命令',
+    copyManagedCommand: '复制更新命令',
+    copyCheckoutCommand: '复制 checkout 命令',
     copied: '命令已复制',
-    copyError: '无法复制命令，请改用项目 README 中的更新命令。',
+    copyError: '无法复制命令，请回到原安装来源重新运行安装脚本。',
   },
   app: {
     openSettings: '打开设置',

--- a/extensions/dsh-browser/src/panel/styles.css
+++ b/extensions/dsh-browser/src/panel/styles.css
@@ -1396,6 +1396,44 @@ textarea:focus-visible {
   line-height: 1.3;
 }
 
+.update-meta {
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 5px;
+}
+
+.install-pill {
+  max-width: 128px;
+  overflow: hidden;
+  padding: 3px 6px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.82);
+  color: var(--muted);
+  font-size: 8.5px;
+  font-weight: 650;
+  line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.install-pill.install-managed {
+  border-color: #ccd6ff;
+  color: var(--blue-ink);
+}
+
+.install-pill.install-checkout {
+  border-color: #cddbd4;
+  color: #356a50;
+}
+
+.install-pill.install-unknown {
+  border-color: #ead9ae;
+  color: var(--security);
+}
+
 .version-pill {
   flex: 0 0 auto;
   padding: 4px 7px;

--- a/extensions/dsh-browser/src/panel/styles.css
+++ b/extensions/dsh-browser/src/panel/styles.css
@@ -1344,6 +1344,216 @@ textarea:focus-visible {
   box-shadow: 0 6px 18px rgba(23, 32, 51, 0.05);
 }
 
+.update-card {
+  position: relative;
+  display: flex;
+  overflow: hidden;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid #d5ddfb;
+  border-radius: 16px;
+  background: linear-gradient(145deg, #ffffff 0%, var(--blue-wash) 100%);
+  box-shadow: 0 7px 20px rgba(41, 69, 199, 0.07);
+}
+
+.update-card::before {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: var(--blue);
+  content: "";
+}
+
+.update-card.update-available::before {
+  background: var(--warning);
+}
+
+.update-card.update-error::before {
+  background: var(--danger);
+}
+
+.update-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.update-heading > div {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.update-heading h2 {
+  margin: 0;
+  color: var(--ink-strong);
+  font-size: 14px;
+  font-weight: 720;
+  letter-spacing: -0.02em;
+  line-height: 1.3;
+}
+
+.version-pill {
+  flex: 0 0 auto;
+  padding: 4px 7px;
+  border: 1px solid #ccd6ff;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.85);
+  color: var(--blue-ink);
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.update-status {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: start;
+  gap: 9px;
+}
+
+.update-status > span:last-child {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.update-status strong {
+  color: var(--ink);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.update-status small {
+  color: var(--muted);
+  font-size: 9.5px;
+  line-height: 1.48;
+}
+
+.update-beacon {
+  width: 8px;
+  height: 8px;
+  margin-top: 3px;
+  border: 2px solid #ffffff;
+  border-radius: 50%;
+  background: var(--blue);
+  box-shadow: 0 0 0 2px rgba(77, 107, 254, 0.18);
+}
+
+.update-checking .update-beacon {
+  animation: update-pulse 1.2s ease-in-out infinite;
+}
+
+.update-available .update-beacon {
+  background: var(--warning);
+  box-shadow: 0 0 0 2px rgba(208, 138, 23, 0.2);
+}
+
+.update-error .update-beacon {
+  background: var(--danger);
+  box-shadow: 0 0 0 2px rgba(180, 35, 24, 0.16);
+}
+
+.update-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.update-reload-reminder {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: start;
+  gap: 8px;
+  padding: 9px 10px;
+  border: 1px solid #ead9ae;
+  border-radius: 10px;
+  background: #fffaf0;
+  color: var(--security);
+}
+
+.update-reload-reminder strong {
+  font-size: 9.5px;
+  font-weight: 650;
+  line-height: 1.5;
+}
+
+.update-reload-glyph {
+  display: grid;
+  width: 20px;
+  height: 20px;
+  border: 1px solid #e0c989;
+  border-radius: 50%;
+  background: #ffffff;
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 1;
+  place-items: center;
+}
+
+.update-actions button {
+  min-height: 32px;
+  padding: 7px 10px;
+  border-radius: 9px;
+  cursor: pointer;
+  font-size: 10px;
+  font-weight: 700;
+  transition: border-color 150ms ease, background-color 150ms ease, transform 150ms ease;
+}
+
+.update-actions button:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.update-actions button:disabled {
+  cursor: wait;
+  opacity: 0.68;
+}
+
+.update-check {
+  border: 1px solid var(--line-strong);
+  background: var(--surface);
+  color: var(--ink);
+}
+
+.update-check:hover:not(:disabled) {
+  border-color: #adb7c7;
+}
+
+.update-copy {
+  border: 1px solid var(--blue);
+  background: var(--blue);
+  color: #ffffff;
+}
+
+.update-copy:hover {
+  border-color: var(--blue-hover);
+  background: var(--blue-hover);
+}
+
+.update-copy-error {
+  color: var(--danger);
+  font-size: 9.5px;
+  line-height: 1.45;
+}
+
+@keyframes update-pulse {
+  0%, 100% { box-shadow: 0 0 0 2px rgba(77, 107, 254, 0.16); }
+  50% { box-shadow: 0 0 0 5px rgba(77, 107, 254, 0.05); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .update-checking .update-beacon {
+    animation: none;
+  }
+}
+
 .settings label {
   display: grid;
   min-width: 0;

--- a/extensions/dsh-browser/src/panel/updates.ts
+++ b/extensions/dsh-browser/src/panel/updates.ts
@@ -18,6 +18,49 @@ export interface ExtensionUpdateResult {
   updateAvailable: boolean
 }
 
+export type ExtensionInstallInfo =
+  | { mode: 'managed' }
+  | { mode: 'checkout'; sourceRoot: string }
+  | { mode: 'unknown' }
+
+/** Parse installer-written provenance without trusting malformed local data. */
+export function parseExtensionInstallInfo(value: unknown): ExtensionInstallInfo {
+  if (typeof value !== 'object' || value === null) return { mode: 'unknown' }
+  const info = value as { schemaVersion?: unknown; mode?: unknown; sourceRoot?: unknown }
+  if (info.schemaVersion !== 1) return { mode: 'unknown' }
+  if (info.mode === 'managed') return { mode: 'managed' }
+  if (info.mode === 'checkout'
+    && typeof info.sourceRoot === 'string'
+    && info.sourceRoot.startsWith('/')
+    && !info.sourceRoot.includes('\0')) {
+    return { mode: 'checkout', sourceRoot: info.sourceRoot }
+  }
+  return { mode: 'unknown' }
+}
+
+/** Read install provenance from the extension package; older installs safely resolve as unknown. */
+export async function readExtensionInstallInfo(
+  url: string,
+  request: typeof fetch = fetch,
+): Promise<ExtensionInstallInfo> {
+  try {
+    const response = await request(url, { cache: 'no-store' })
+    if (!response.ok) return { mode: 'unknown' }
+    return parseExtensionInstallInfo(await response.json())
+  } catch {
+    return { mode: 'unknown' }
+  }
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\"'\"'")}'`
+}
+
+/** Re-run the installer from the exact checkout that produced this extension. */
+export function checkoutInstallCommand(sourceRoot: string): string {
+  return `cd ${shellQuote(sourceRoot)} && ./scripts/install.sh`
+}
+
 function versionParts(version: string): number[] {
   if (!/^\d+(?:\.\d+){0,3}$/.test(version)) throw new Error('invalid extension version')
   return version.split('.').map((part) => Number(part))

--- a/extensions/dsh-browser/src/panel/updates.ts
+++ b/extensions/dsh-browser/src/panel/updates.ts
@@ -1,0 +1,57 @@
+/**
+ * Release checks for the unpacked browser extension.
+ *
+ * The managed installer follows the repository's main branch, so that
+ * branch's manifest is the update source of truth. The check is deliberately
+ * read-only: Chrome does not let an unpacked extension replace itself.
+ */
+
+export const UPDATE_MANIFEST_URL =
+  'https://raw.githubusercontent.com/Lum1104/dsh-browser/refs/heads/main/extensions/dsh-browser/manifest.json'
+
+export const UPDATE_COMMAND =
+  'curl -fsSL https://raw.githubusercontent.com/Lum1104/dsh-browser/refs/heads/main/scripts/install.sh | bash'
+
+export interface ExtensionUpdateResult {
+  currentVersion: string
+  latestVersion: string
+  updateAvailable: boolean
+}
+
+function versionParts(version: string): number[] {
+  if (!/^\d+(?:\.\d+){0,3}$/.test(version)) throw new Error('invalid extension version')
+  return version.split('.').map((part) => Number(part))
+}
+
+/** Compare Chrome's one-to-four-part numeric extension versions. */
+export function compareExtensionVersions(left: string, right: string): number {
+  const leftParts = versionParts(left)
+  const rightParts = versionParts(right)
+  const length = Math.max(leftParts.length, rightParts.length)
+
+  for (let index = 0; index < length; index += 1) {
+    const difference = (leftParts[index] ?? 0) - (rightParts[index] ?? 0)
+    if (difference !== 0) return difference < 0 ? -1 : 1
+  }
+  return 0
+}
+
+/** Fetch the main-branch manifest and compare it with the running extension. */
+export async function checkForExtensionUpdate(
+  currentVersion: string,
+  request: typeof fetch = fetch,
+): Promise<ExtensionUpdateResult> {
+  versionParts(currentVersion)
+  const response = await request(UPDATE_MANIFEST_URL, { cache: 'no-store' })
+  if (!response.ok) throw new Error(`update manifest request failed (${response.status})`)
+
+  const manifest = await response.json() as { version?: unknown }
+  if (typeof manifest.version !== 'string') throw new Error('update manifest has no version')
+  versionParts(manifest.version)
+
+  return {
+    currentVersion,
+    latestVersion: manifest.version,
+    updateAvailable: compareExtensionVersions(currentVersion, manifest.version) < 0,
+  }
+}

--- a/extensions/dsh-browser/tests/updates.spec.ts
+++ b/extensions/dsh-browser/tests/updates.spec.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { readFileSync } from 'node:fs'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  checkForExtensionUpdate,
+  compareExtensionVersions,
+  UPDATE_MANIFEST_URL,
+} from '../src/panel/updates.ts'
+
+describe('extension update checks', () => {
+  it('compares Chrome numeric versions component by component', () => {
+    expect(compareExtensionVersions('0.2.0', '0.2')).toBe(0)
+    expect(compareExtensionVersions('0.2.9', '0.10.0')).toBeLessThan(0)
+    expect(compareExtensionVersions('1.0.0.1', '1.0.0')).toBeGreaterThan(0)
+    expect(() => compareExtensionVersions('1.0.0-beta', '1.0.0')).toThrow('invalid extension version')
+  })
+
+  it('reports a newer main-branch manifest', async () => {
+    const request = vi.fn<typeof fetch>().mockResolvedValue(new Response(
+      JSON.stringify({ version: '0.3.0' }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    ))
+
+    await expect(checkForExtensionUpdate('0.2.0', request)).resolves.toEqual({
+      currentVersion: '0.2.0',
+      latestVersion: '0.3.0',
+      updateAvailable: true,
+    })
+    expect(request).toHaveBeenCalledWith(UPDATE_MANIFEST_URL, { cache: 'no-store' })
+  })
+
+  it('treats equal or older remote versions as current', async () => {
+    const request = vi.fn<typeof fetch>().mockResolvedValue(new Response(
+      JSON.stringify({ version: '0.2.0' }),
+      { status: 200 },
+    ))
+    await expect(checkForExtensionUpdate('0.2.0', request)).resolves.toMatchObject({
+      updateAvailable: false,
+    })
+  })
+
+  it('rejects unavailable and malformed manifests', async () => {
+    const unavailable = vi.fn<typeof fetch>().mockResolvedValue(new Response('', { status: 503 }))
+    await expect(checkForExtensionUpdate('0.2.0', unavailable)).rejects.toThrow('(503)')
+
+    const malformed = vi.fn<typeof fetch>().mockResolvedValue(new Response(
+      JSON.stringify({ version: 'next' }),
+      { status: 200 },
+    ))
+    await expect(checkForExtensionUpdate('0.2.0', malformed)).rejects.toThrow('invalid extension version')
+  })
+
+  it('keeps package, Chrome manifest, and update CSP metadata aligned', () => {
+    const extensionRoot = process.cwd()
+    const packageManifest = JSON.parse(readFileSync(`${extensionRoot}/package.json`, 'utf8')) as { version: string }
+    const chromeManifest = JSON.parse(readFileSync(`${extensionRoot}/manifest.json`, 'utf8')) as {
+      version: string
+      content_security_policy: { extension_pages: string }
+    }
+
+    expect(packageManifest.version).toBe(chromeManifest.version)
+    expect(chromeManifest.content_security_policy.extension_pages).toContain(new URL(UPDATE_MANIFEST_URL).origin)
+  })
+})

--- a/extensions/dsh-browser/tests/updates.spec.ts
+++ b/extensions/dsh-browser/tests/updates.spec.ts
@@ -3,7 +3,10 @@ import { readFileSync } from 'node:fs'
 import { describe, expect, it, vi } from 'vitest'
 import {
   checkForExtensionUpdate,
+  checkoutInstallCommand,
   compareExtensionVersions,
+  parseExtensionInstallInfo,
+  readExtensionInstallInfo,
   UPDATE_MANIFEST_URL,
 } from '../src/panel/updates.ts'
 
@@ -50,6 +53,35 @@ describe('extension update checks', () => {
     await expect(checkForExtensionUpdate('0.2.0', malformed)).rejects.toThrow('invalid extension version')
   })
 
+  it('distinguishes managed, checkout, and unknown install provenance', () => {
+    expect(parseExtensionInstallInfo({ schemaVersion: 1, mode: 'managed' })).toEqual({ mode: 'managed' })
+    expect(parseExtensionInstallInfo({
+      schemaVersion: 1,
+      mode: 'checkout',
+      sourceRoot: '/Users/example/dsh-browser',
+    })).toEqual({ mode: 'checkout', sourceRoot: '/Users/example/dsh-browser' })
+    expect(parseExtensionInstallInfo({ schemaVersion: 1, mode: 'checkout', sourceRoot: '../relative' }))
+      .toEqual({ mode: 'unknown' })
+    expect(parseExtensionInstallInfo({ mode: 'managed' })).toEqual({ mode: 'unknown' })
+  })
+
+  it('treats missing or malformed install metadata as unknown', async () => {
+    const missing = vi.fn<typeof fetch>().mockResolvedValue(new Response('', { status: 404 }))
+    await expect(readExtensionInstallInfo('chrome-extension://id/install-info.json', missing))
+      .resolves.toEqual({ mode: 'unknown' })
+
+    const malformed = vi.fn<typeof fetch>().mockResolvedValue(new Response('{', { status: 200 }))
+    await expect(readExtensionInstallInfo('chrome-extension://id/install-info.json', malformed))
+      .resolves.toEqual({ mode: 'unknown' })
+  })
+
+  it('builds a shell-safe command for the originating checkout', () => {
+    expect(checkoutInstallCommand('/Users/example/My Checkout'))
+      .toBe("cd '/Users/example/My Checkout' && ./scripts/install.sh")
+    expect(checkoutInstallCommand("/Users/example/dev's checkout"))
+      .toBe("cd '/Users/example/dev'\"'\"'s checkout' && ./scripts/install.sh")
+  })
+
   it('keeps package, Chrome manifest, and update CSP metadata aligned', () => {
     const extensionRoot = process.cwd()
     const packageManifest = JSON.parse(readFileSync(`${extensionRoot}/package.json`, 'utf8')) as { version: string }
@@ -57,8 +89,12 @@ describe('extension update checks', () => {
       version: string
       content_security_policy: { extension_pages: string }
     }
+    const installer = readFileSync(`${extensionRoot}/../../scripts/install.sh`, 'utf8')
 
     expect(packageManifest.version).toBe(chromeManifest.version)
     expect(chromeManifest.content_security_policy.extension_pages).toContain(new URL(UPDATE_MANIFEST_URL).origin)
+    expect(installer).toContain('INSTALL_MODE="managed"')
+    expect(installer).toContain('INSTALL_MODE="checkout"')
+    expect(installer).toContain('$DIST_DIR/install-info.json')
   })
 })

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -126,6 +126,7 @@ profile_has_dependency() {
 }
 
 require_command pnpm "未找到 pnpm；请先启用 Corepack 或安装 pnpm。" "pnpm was not found; enable Corepack or install pnpm first."
+require_command node "未找到 Node.js；请先安装受支持的 Node.js 版本。" "Node.js was not found; install a supported Node.js version first."
 require_command rsync "未找到 rsync；请先安装 rsync。" "rsync was not found; install rsync first."
 
 print_step 1 "构建浏览器桥" "Build the browser bridge"
@@ -150,6 +151,21 @@ else
 fi
 mkdir -p "$DIST_DIR"
 rsync -a --delete-after "$EXT/dist/" "$DIST_DIR/"
+if [ -f "$ROOT/.managed-by-install-sh" ]; then
+  INSTALL_MODE="managed"
+else
+  INSTALL_MODE="checkout"
+fi
+node -e '
+  const { writeFileSync } = require("node:fs");
+  const [filename, mode, sourceRoot] = process.argv.slice(1);
+  const info = {
+    schemaVersion: 1,
+    mode,
+    ...(mode === "checkout" ? { sourceRoot } : {}),
+  };
+  writeFileSync(filename, `${JSON.stringify(info, null, 2)}\n`);
+' "$DIST_DIR/install-info.json" "$INSTALL_MODE" "$ROOT"
 echo -n "$DIST_DIR" | pbcopy
 
 open -a "Google Chrome" "chrome://extensions" 2>/dev/null || open -b com.google.Chrome "chrome://extensions"


### PR DESCRIPTION
## Summary

- compare the running extension version with the manifest on GitHub `main` through a read-only update check
- record whether `scripts/install.sh` installed the extension from the managed source or a local checkout
- label the detected install source and provide source-safe update actions in localized panel states
- copy the remote installer only for managed installs; checkout installs copy a command that reruns their originating checkout; unknown legacy installs receive instructions but no copy action
- explicitly remind users to reload the extension from `chrome://extensions` and restart dsh after updating
- allow the panel CSP to read the repository manifest without changing the extension version

## Why

Managed installations currently rely on users remembering to rerun the installer. The panel now makes update availability visible while keeping execution explicit: it never runs downloaded code or replaces the unpacked extension itself. Install provenance prevents the managed update command from replacing a documented local-checkout installation.

## User impact

Users can check for updates from Settings. When a newer version is found, the panel provides an update action that matches the original installation source and a clear post-update reload reminder. Existing connection, privacy, and browser-control behavior is unchanged.

## Validation

- `pnpm test` — 250 tests passed
- `pnpm typecheck`
- `pnpm build`
- `bash -n scripts/install.sh`
- verified checkout installs copy `cd '<checkout>' && ./scripts/install.sh`
- verified unknown install provenance exposes no copy action
- verified the update states at 360 px and 420 px side-panel widths with no horizontal overflow

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an explicit extension-update workflow to the settings panel, including installation provenance and source-specific update commands. The version-only comparison currently cannot detect this release for existing installations because the manifest version remains unchanged.

- Fetches and compares the extension manifest from GitHub main.
- Records managed versus checkout provenance during installation.
- Adds localized update states, copy actions, reload guidance, and responsive styling.
- Extends the panel CSP for the read-only manifest request.

<h3>Confidence Score: 4/5</h3>

The update notification defect should be fixed before merging because existing managed installations will report this new build as current.

The checker relies exclusively on a numeric manifest version comparison while both the installed pre-merge build and main after this PR identify themselves as 0.1.0, making the feature unable to surface its own release.

**Files Needing Attention:** extensions/dsh-browser/src/panel/updates.ts, extensions/dsh-browser/manifest.json

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| extensions/dsh-browser/src/panel/updates.ts | Implements provenance parsing, shell-safe checkout commands, and remote version comparison; the comparison cannot distinguish same-version builds. |
| extensions/dsh-browser/src/panel/UpdateCard.tsx | Adds the update-check UI state machine and source-specific clipboard actions. |
| scripts/install.sh | Records managed or checkout provenance in the installed extension while preserving the existing installation flow. |
| extensions/dsh-browser/manifest.json | Permits the GitHub manifest request but retains version 0.1.0, preventing existing 0.1.0 builds from detecting this release. |
| extensions/dsh-browser/tests/updates.spec.ts | Covers comparison, malformed responses, provenance parsing, quoting, and metadata alignment, but not the unchanged-version release scenario. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Open Settings] --> B[Read install-info.json]
  A --> C[Check for updates]
  C --> D[Fetch manifest from GitHub main]
  D --> E{Running version < main version?}
  E -- No --> F[Show no update found]
  E -- Yes --> G{Installation provenance}
  G -- Managed --> H[Offer managed update command]
  G -- Checkout --> I[Offer originating checkout command]
  G -- Unknown --> J[Show instructions without copy action]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test(panel): cover install-aware update ..."](https://github.com/lum1104/dsh-browser/commit/763cd580a94d95144118dec9a9a7164da1df84f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53898229)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->