### PR TITLE
Reduce browser round trips with automatic page context

### DIFF
--- a/extensions/dsh-browser/src/background/navigation.ts
+++ b/extensions/dsh-browser/src/background/navigation.ts
@@ -1,0 +1,59 @@
+/**
+ * One-shot rendezvous between an action that unloads a frame and the content
+ * script installed in its replacement document.
+ *
+ * @module
+ */
+
+/** Default ceiling for replacing a model-driven snapshot round trip. */
+const NAVIGATION_READY_TIMEOUT_MS = 8_000
+
+/** A cancellable wait for the next content-script document in one frame. */
+export interface NavigationWait {
+  ready: Promise<boolean>
+  cancel: () => void
+}
+
+/**
+ * Listen before dispatching a navigation so a fast replacement document
+ * cannot announce readiness between the action response and listener setup.
+ */
+export function waitForNextDocumentReady(
+  tabId: number,
+  frameId: number,
+  previousDocumentId: string | undefined,
+  signal?: AbortSignal,
+  timeoutMs: number = NAVIGATION_READY_TIMEOUT_MS,
+): NavigationWait {
+  let finish: (ready: boolean) => void = () => {}
+  const ready = new Promise<boolean>((resolve) => {
+    let settled = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const listener = (message: unknown, sender: chrome.runtime.MessageSender): void => {
+      if (typeof message !== 'object' || message === null) return
+      if ((message as { type?: unknown }).type !== 'DSH_CONTENT_READY') return
+      if (sender.tab?.id !== tabId || (sender.frameId ?? 0) !== frameId) return
+      if (previousDocumentId !== undefined && sender.documentId === previousDocumentId) return
+      finish(true)
+    }
+    const onAbort = (): void => { finish(false) }
+    finish = (isReady: boolean): void => {
+      if (settled) return
+      settled = true
+      if (timer !== undefined) clearTimeout(timer)
+      chrome.runtime.onMessage.removeListener(listener)
+      signal?.removeEventListener('abort', onAbort)
+      resolve(isReady)
+    }
+
+    if (signal?.aborted === true) {
+      finish(false)
+      return
+    }
+    chrome.runtime.onMessage.addListener(listener)
+    signal?.addEventListener('abort', onAbort, { once: true })
+    timer = setTimeout(() => { finish(false) }, timeoutMs)
+  })
+
+  return { ready, cancel: () => { finish(false) } }
+}

--- a/extensions/dsh-browser/src/background/tools.ts
+++ b/extensions/dsh-browser/src/background/tools.ts
@@ -46,6 +46,14 @@ export interface ContentBudget {
 }
 
 const CONTENT_SCRIPT_FILE = 'content.js'
+const ACTION_DELTA_TOOLS = new Set([
+  'browser_click',
+  'browser_type',
+  'browser_press',
+  'browser_scroll',
+  'browser_wait',
+])
+const ACTION_DELTA_GUIDANCE = 'The page settled and its current changes are included below. Continue from this state; take another snapshot only when broader page context is needed.'
 const pendingInjections = new Map<number, Promise<void>>()
 const snapshotDocumentsByTab = new Map<number, Map<number, string>>()
 
@@ -81,12 +89,19 @@ async function injectContentScript(tabId: number): Promise<void> {
   }
 }
 
-async function sendAction(tabId: number, call: ToolCall, frame: TabFrame, budget?: ContentBudget): Promise<unknown> {
+async function sendAction(
+  tabId: number,
+  call: ToolCall,
+  frame: TabFrame,
+  budget?: ContentBudget,
+  includePageDelta: boolean = false,
+): Promise<unknown> {
   return chrome.tabs.sendMessage(tabId, {
     type: 'DSH_ACTION',
     action: call.name,
     args: withoutFrame(call.args),
     ...budget === undefined ? {} : { budget },
+    ...includePageDelta ? { includePageDelta: true } : {},
   }, frame.documentId === undefined ? { frameId: frame.frameId } : { documentId: frame.documentId })
 }
 
@@ -152,6 +167,22 @@ function answerText(answer: ToolAnswer): string | undefined {
   if (!answer.ok || typeof answer.result !== 'object' || answer.result === null) return undefined
   const text = (answer.result as { text?: unknown }).text
   return typeof text === 'string' ? text : undefined
+}
+
+function answerPageContent(answer: ToolAnswer): string | undefined {
+  if (!answer.ok || typeof answer.result !== 'object' || answer.result === null) return undefined
+  const pageContent = (answer.result as { pageContent?: unknown }).pageContent
+  return typeof pageContent === 'string' ? pageContent : undefined
+}
+
+/** Keep extension-authored action status outside the nonce-bound page-data boundary. */
+function wrapActionDelta(status: string, pageContent: string, frame: TabFrame, maxChars: number): string {
+  const prefix = `${status}\n${ACTION_DELTA_GUIDANCE}`
+  const separator = '\n\n'
+  const boundaryBudget = maxChars - prefix.length - separator.length
+  if (boundaryBudget <= 0) return prefix.slice(0, maxChars)
+  const framedContent = frame.frameId === 0 ? pageContent : `${frameHeader(frame)}\n${pageContent}`
+  return `${prefix}${separator}${wrapUntrustedContent(framedContent, boundaryBudget)}`
 }
 
 async function snapshotAllFrames(
@@ -222,6 +253,7 @@ async function dispatchOnce(
   budget: ContentBudget,
   signal?: AbortSignal,
   targetStillAllowed?: () => boolean,
+  includeActionDelta: boolean = false,
 ): Promise<ToolAnswer> {
   if (isCancelled(call, signal)) return cancelled()
   if (targetStillAllowed?.() === false) return targetChanged()
@@ -237,16 +269,29 @@ async function dispatchOnce(
   // approval cannot cross the final state-changing dispatch boundary.
   if (isCancelled(call, signal)) return cancelled()
   if (targetStillAllowed?.() === false) return targetChanged()
-  // Snapshot calls need negotiated limits; other actions avoid carrying and
-  // merging the same unused budget object on every message.
-  const response = await sendAction(tabId, call, frame)
+  const hasSnapshotBaseline = snapshotDocumentsByTab.get(tabId)?.get(frameId) === frameDocumentKey(frame)
+  const requestPageDelta = includeActionDelta && hasSnapshotBaseline && ACTION_DELTA_TOOLS.has(call.name)
+  const response = await sendAction(
+    tabId,
+    call,
+    frame,
+    requestPageDelta ? budget : undefined,
+    requestPageDelta,
+  )
   if (isCancelled(call, signal)) return cancelled()
   if (!isToolAnswer(response)) return unavailable('The page content script returned an invalid response.')
-  if (call.name !== 'browser_get_text') return response
   const text = answerText(response)
-  return text === undefined
-    ? response
-    : { ok: true, result: { text: wrapUntrustedContent(text, budget.maxChars) } }
+  if (text === undefined) return response
+  if (call.name === 'browser_get_text') {
+    return { ok: true, result: { text: wrapUntrustedContent(text, budget.maxChars) } }
+  }
+  const pageContent = requestPageDelta ? answerPageContent(response) : undefined
+  return {
+    ok: true,
+    result: {
+      text: pageContent === undefined ? text : wrapActionDelta(text, pageContent, frame, budget.maxChars),
+    },
+  }
 }
 
 /**
@@ -313,7 +358,15 @@ export async function dispatchToolCall(
     if (refreshedTargetError !== undefined) return refreshedTargetError
   }
   try {
-    return await dispatchOnce(tab.id, executionFrames, call, effectiveBudget, signal, targetStillAllowed)
+    return await dispatchOnce(
+      tab.id,
+      executionFrames,
+      call,
+      effectiveBudget,
+      signal,
+      targetStillAllowed,
+      sharePageContent === 'auto',
+    )
   } catch {
     if (isCancelled(call, signal)) return cancelled()
     // Manifest content scripts do not run retroactively in tabs that were
@@ -339,7 +392,15 @@ export async function dispatchToolCall(
           return unavailable('The page changed while the content script was loading. Call browser_snapshot again before retrying.')
         }
       }
-      return await dispatchOnce(tab.id, refreshedFrames, call, effectiveBudget, signal, targetStillAllowed)
+      return await dispatchOnce(
+        tab.id,
+        refreshedFrames,
+        call,
+        effectiveBudget,
+        signal,
+        targetStillAllowed,
+        sharePageContent === 'auto',
+      )
     } catch {
       return unavailable('The content script could not be loaded on this page. Chrome internal and protected pages do not support browser operations.')
     }

--- a/extensions/dsh-browser/src/background/tools.ts
+++ b/extensions/dsh-browser/src/background/tools.ts
@@ -196,7 +196,7 @@ function wrapActionDelta(status: string, pageContent: string, frame: TabFrame, m
   const prefix = `${status}\n${ACTION_DELTA_GUIDANCE}`
   const separator = '\n\n'
   const boundaryBudget = maxChars - prefix.length - separator.length
-  if (boundaryBudget <= 0) return prefix.slice(0, maxChars)
+  if (boundaryBudget < 500) return prefix.slice(0, maxChars)
   const framedContent = frame.frameId === 0 ? pageContent : `${frameHeader(frame)}\n${pageContent}`
   return `${prefix}${separator}${wrapUntrustedContent(framedContent, boundaryBudget)}`
 }

--- a/extensions/dsh-browser/src/background/tools.ts
+++ b/extensions/dsh-browser/src/background/tools.ts
@@ -19,6 +19,7 @@ import {
 } from './frames.ts'
 import { wrapUntrustedContent } from './untrusted.ts'
 import { approvalPromptForCall } from './authorization.ts'
+import { waitForNextDocumentReady } from './navigation.ts'
 import type { ApprovalAuthorization, ApprovalPrompt } from '../security/approval.ts'
 
 /** A tool call from the bridge. */
@@ -54,6 +55,14 @@ const ACTION_DELTA_TOOLS = new Set([
   'browser_wait',
 ])
 const ACTION_DELTA_GUIDANCE = 'The page settled and its current changes are included below. Continue from this state; take another snapshot only when broader page context is needed.'
+const NAVIGATION_CANDIDATE_TOOLS = new Set([
+  'browser_click',
+  'browser_navigate',
+  'browser_back',
+  'browser_forward',
+  'browser_reload',
+])
+const NAVIGATION_SNAPSHOT_GUIDANCE = 'Navigation completed and the current page snapshot is included below. Use it directly instead of taking an immediate duplicate snapshot.'
 const pendingInjections = new Map<number, Promise<void>>()
 const snapshotDocumentsByTab = new Map<number, Map<number, string>>()
 
@@ -175,6 +184,13 @@ function answerPageContent(answer: ToolAnswer): string | undefined {
   return typeof pageContent === 'string' ? pageContent : undefined
 }
 
+function answerNavigationPending(answer: ToolAnswer): boolean {
+  return answer.ok
+    && typeof answer.result === 'object'
+    && answer.result !== null
+    && (answer.result as { navigationPending?: unknown }).navigationPending === true
+}
+
 /** Keep extension-authored action status outside the nonce-bound page-data boundary. */
 function wrapActionDelta(status: string, pageContent: string, frame: TabFrame, maxChars: number): string {
   const prefix = `${status}\n${ACTION_DELTA_GUIDANCE}`
@@ -246,6 +262,33 @@ function frameHeader(frame: TabFrame): string {
   return `\n--- iframe frame=${frame.frameId} parent=${frame.parentFrameId} origin=${frameOrigin(frame)} ---`
 }
 
+function stripDuplicateSnapshotPrompt(status: string): string {
+  return status.replace(/ Call browser_snapshot again after (?:navigation settles|the page loads|it loads)\.$/, '')
+}
+
+async function snapshotAfterNavigation(
+  tabId: number,
+  call: ToolCall,
+  status: string,
+  budget: ContentBudget,
+  targetStillAllowed?: () => boolean,
+): Promise<ToolAnswer | undefined> {
+  const prefix = `${stripDuplicateSnapshotPrompt(status)}\n${NAVIGATION_SNAPSHOT_GUIDANCE}`
+  const snapshotMaxChars = budget.maxChars - prefix.length - 2
+  if (snapshotMaxChars < 500) return undefined
+  const frames = await listTabFrames(tabId, undefined)
+  if (targetStillAllowed?.() === false) return targetChanged()
+  const answer = await snapshotAllFrames(
+    tabId,
+    frames,
+    { ...call, name: 'browser_snapshot', args: {} },
+    { ...budget, maxChars: snapshotMaxChars },
+  )
+  const snapshot = answerText(answer)
+  if (snapshot === undefined) return undefined
+  return { ok: true, result: { text: `${prefix}\n\n${snapshot}` } }
+}
+
 async function dispatchOnce(
   tabId: number,
   frames: TabFrame[],
@@ -271,17 +314,51 @@ async function dispatchOnce(
   if (targetStillAllowed?.() === false) return targetChanged()
   const hasSnapshotBaseline = snapshotDocumentsByTab.get(tabId)?.get(frameId) === frameDocumentKey(frame)
   const requestPageDelta = includeActionDelta && hasSnapshotBaseline && ACTION_DELTA_TOOLS.has(call.name)
-  const response = await sendAction(
-    tabId,
-    call,
-    frame,
-    requestPageDelta ? budget : undefined,
-    requestPageDelta,
-  )
-  if (isCancelled(call, signal)) return cancelled()
-  if (!isToolAnswer(response)) return unavailable('The page content script returned an invalid response.')
+  const navigationWait = includeActionDelta && NAVIGATION_CANDIDATE_TOOLS.has(call.name)
+    ? waitForNextDocumentReady(tabId, frameId, frame.documentId, signal)
+    : undefined
+  let response: unknown
+  try {
+    response = await sendAction(
+      tabId,
+      call,
+      frame,
+      requestPageDelta ? budget : undefined,
+      requestPageDelta,
+    )
+  } catch (error: unknown) {
+    navigationWait?.cancel()
+    throw error
+  }
+  if (isCancelled(call, signal)) {
+    navigationWait?.cancel()
+    return cancelled()
+  }
+  if (!isToolAnswer(response)) {
+    navigationWait?.cancel()
+    return unavailable('The page content script returned an invalid response.')
+  }
   const text = answerText(response)
-  if (text === undefined) return response
+  if (text === undefined) {
+    navigationWait?.cancel()
+    return response
+  }
+  if (answerNavigationPending(response) && navigationWait !== undefined) {
+    const ready = await navigationWait.ready
+    if (isCancelled(call, signal)) return cancelled()
+    if (targetStillAllowed?.() === false) return targetChanged()
+    if (ready) {
+      try {
+        const snapshot = await snapshotAfterNavigation(tabId, call, text, budget, targetStillAllowed)
+        if (snapshot !== undefined) return snapshot
+      } catch {
+        // Preserve the successful navigation status when the replacement page
+        // becomes unavailable before its opportunistic snapshot completes.
+      }
+    }
+  } else {
+    navigationWait?.cancel()
+  }
   if (call.name === 'browser_get_text') {
     return { ok: true, result: { text: wrapUntrustedContent(text, budget.maxChars) } }
   }

--- a/extensions/dsh-browser/src/content/actions.ts
+++ b/extensions/dsh-browser/src/content/actions.ts
@@ -228,18 +228,43 @@ async function clickAction(args: Record<string, unknown>, ctx: ActionContext): P
   const el = elementOrThrow(ctx.ids, index)
   el.scrollIntoView({ block: 'center', behavior: 'instant' })
   if (el instanceof HTMLAnchorElement) {
-    // A normal link can unload this content script before an awaited settle
-    // sends its response. Answer first and start the click in the next task,
-    // matching the explicit navigation actions.
-    setTimeout(() => { el.click() }, 0)
     const target = el.target.trim().toLowerCase()
-    const sameFrameNavigation = (target === '' || target === '_self') && !el.hasAttribute('download')
-    return sameFrameNavigation
-      ? {
-          text: `Clicked link [${index}]. Call browser_snapshot again after navigation settles.`,
-          navigationPending: true,
-        }
-      : { text: `Clicked link [${index}]. The link may open outside the controlled frame.` }
+    const sameFrameTarget = target === '' || target === '_self'
+    let href: URL | undefined
+    try { href = new URL(el.href) } catch { /* let the native click handle unusual links */ }
+    const controlledNavigation = sameFrameTarget
+      && !el.hasAttribute('download')
+      && (href?.protocol === 'http:' || href?.protocol === 'https:')
+    if (controlledNavigation && href !== undefined) {
+      // Dispatch the click handlers without its default navigation so a
+      // client-side router can cancel synchronously and keep this document.
+      const shouldNavigate = el.dispatchEvent(new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+      }))
+      if (!shouldNavigate) {
+        await waitForPageSettled(ACTION_SETTLE)
+        return withPageDelta(`Clicked link [${index}].`, ctx)
+      }
+      const sameDocument = href.origin === location.origin
+        && href.pathname === location.pathname
+        && href.search === location.search
+      if (sameDocument) {
+        if (href.hash !== location.hash) location.hash = href.hash
+        await waitForPageSettled(ACTION_SETTLE)
+        return withPageDelta(`Clicked link [${index}].`, ctx)
+      }
+      // A cross-document navigation can unload this content script before an
+      // awaited response. Answer first and navigate in the next task.
+      setTimeout(() => { location.href = href.href }, 0)
+      return {
+        text: `Clicked link [${index}]. Call browser_snapshot again after navigation settles.`,
+        navigationPending: true,
+      }
+    }
+    setTimeout(() => { el.click() }, 0)
+    return { text: `Clicked link [${index}]. The link may open outside the controlled frame.` }
   }
   if (el instanceof HTMLButtonElement && el.disabled) {
     throw new ActionError('action-failed', `Button [${index}] is disabled.`)

--- a/extensions/dsh-browser/src/content/actions.ts
+++ b/extensions/dsh-browser/src/content/actions.ts
@@ -18,6 +18,8 @@ import { buildSnapshot, renderSnapshot } from './snapshot.ts'
 /** A settled action result. */
 export interface ActionResult {
   text: string
+  /** Page-authored snapshot delta; the background must wrap it as untrusted. */
+  pageContent?: string
 }
 
 /** How long an action should observe a ready document before returning. */
@@ -36,6 +38,8 @@ const TYPE_SETTLE: PageSettlePolicy = { minimumMs: 32, quietMs: 32, maxAfterRead
 const ACTION_SETTLE: PageSettlePolicy = { minimumMs: 100, quietMs: 50, maxAfterReadyMs: 250, timeoutMs: 5_000 }
 const SCROLL_SETTLE: PageSettlePolicy = { minimumMs: 50, quietMs: 50, maxAfterReadyMs: 150, timeoutMs: 5_000 }
 const EXPLICIT_WAIT_SETTLE: PageSettlePolicy = { minimumMs: 100, quietMs: 100, maxAfterReadyMs: 1_000, timeoutMs: 5_000 }
+/** Keep automatic action context focused while preserving the negotiated full snapshot budget. */
+const ACTION_DELTA_MAX_CHARS = 4_000
 
 /**
  * Wait for document readiness and a mutation-free window. The old fixed delay
@@ -155,6 +159,8 @@ function setNativeValue(input: HTMLInputElement | HTMLTextAreaElement, value: st
 export interface ActionContext {
   ids: ElementIds
   budget: SnapshotBudget
+  /** Enabled only when the background may share page content without another approval. */
+  includePageDelta?: boolean
 }
 
 /** Run one named action with its args. */
@@ -167,9 +173,9 @@ export async function runAction(action: string, args: Record<string, unknown>, c
     case 'browser_type':
       return typeAction(args, ctx)
     case 'browser_press':
-      return pressAction(args)
+      return pressAction(args, ctx)
     case 'browser_scroll':
-      return scrollAction(args)
+      return scrollAction(args, ctx)
     case 'browser_navigate':
       return navigateAction(args)
     case 'browser_back':
@@ -181,7 +187,7 @@ export async function runAction(action: string, args: Record<string, unknown>, c
     case 'browser_get_text':
       return getTextAction(args)
     case 'browser_wait':
-      return waitAction(args)
+      return waitAction(args, ctx)
     default:
       throw new ActionError('bad-args', `Unknown action: ${action}`)
   }
@@ -204,6 +210,17 @@ function resetDeltaState(): void {
   lastSnapshot = null
 }
 
+/** Attach the settled page change while retaining the full view as the next delta baseline. */
+function withPageDelta(text: string, ctx: ActionContext): ActionResult {
+  if (ctx.includePageDelta !== true || lastSnapshot === null) return { text }
+  const view = buildSnapshot(ctx.ids, { delta: true, budget: ctx.budget }, lastSnapshot)
+  lastSnapshot = view
+  return {
+    text,
+    pageContent: renderSnapshot(view, true, Math.min(ctx.budget.maxChars, ACTION_DELTA_MAX_CHARS)),
+  }
+}
+
 async function clickAction(args: Record<string, unknown>, ctx: ActionContext): Promise<ActionResult> {
   const index = numberArg(args, 'index')
   const el = elementOrThrow(ctx.ids, index)
@@ -220,7 +237,7 @@ async function clickAction(args: Record<string, unknown>, ctx: ActionContext): P
   }
   ;(el as HTMLElement).click()
   await waitForPageSettled(ACTION_SETTLE)
-  return { text: `Clicked [${index}].` }
+  return withPageDelta(`Clicked [${index}].`, ctx)
 }
 
 async function typeAction(args: Record<string, unknown>, ctx: ActionContext): Promise<ActionResult> {
@@ -242,10 +259,10 @@ async function typeAction(args: Record<string, unknown>, ctx: ActionContext): Pr
     setNativeValue(el, `${el.value}${text}`)
   }
   await waitForPageSettled(TYPE_SETTLE)
-  return { text: `Entered ${text.length} characters into [${index}].` }
+  return withPageDelta(`Entered ${text.length} characters into [${index}].`, ctx)
 }
 
-async function pressAction(args: Record<string, unknown>): Promise<ActionResult> {
+async function pressAction(args: Record<string, unknown>, ctx: ActionContext): Promise<ActionResult> {
   const key = typeof args.key === 'string' && args.key !== '' ? args.key : ''
   if (key === '') throw new ActionError('bad-args', 'key must not be empty.')
   const target = document.activeElement instanceof HTMLElement ? document.activeElement : document.body
@@ -255,10 +272,10 @@ async function pressAction(args: Record<string, unknown>): Promise<ActionResult>
     target.form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
   }
   await waitForPageSettled(ACTION_SETTLE)
-  return { text: `Sent key "${key}".` }
+  return withPageDelta(`Sent key "${key}".`, ctx)
 }
 
-async function scrollAction(args: Record<string, unknown>): Promise<ActionResult> {
+async function scrollAction(args: Record<string, unknown>, ctx: ActionContext): Promise<ActionResult> {
   const direction = typeof args.direction === 'string' ? args.direction : ''
   const amount = typeof args.amount === 'number' ? args.amount : Math.floor(window.innerHeight * 0.8)
   switch (direction) {
@@ -278,7 +295,7 @@ async function scrollAction(args: Record<string, unknown>): Promise<ActionResult
       throw new ActionError('bad-args', `direction must be up, down, top, or bottom; received "${direction}".`)
   }
   await waitForPageSettled(SCROLL_SETTLE)
-  return { text: `Scrolled ${direction}.` }
+  return withPageDelta(`Scrolled ${direction}.`, ctx)
 }
 
 async function navigateAction(args: Record<string, unknown>): Promise<ActionResult> {
@@ -322,11 +339,11 @@ async function getTextAction(args: Record<string, unknown>): Promise<ActionResul
   return { text: truncated.text + (truncated.truncated > 0 ? `\n(Truncated ${truncated.truncated} characters.)` : '') }
 }
 
-async function waitAction(args: Record<string, unknown>): Promise<ActionResult> {
+async function waitAction(args: Record<string, unknown>, ctx: ActionContext): Promise<ActionResult> {
   const ms = typeof args.ms === 'number' && args.ms > 0 ? args.ms : 0
   await waitForPageSettled(EXPLICIT_WAIT_SETTLE)
   if (ms > 0) await sleep(ms)
-  return { text: `The page is stable${ms > 0 ? ` after an additional ${ms}ms wait` : ''}.` }
+  return withPageDelta(`The page is stable${ms > 0 ? ` after an additional ${ms}ms wait` : ''}.`, ctx)
 }
 
 function numberArg(args: Record<string, unknown>, name: string): number {

--- a/extensions/dsh-browser/src/content/actions.ts
+++ b/extensions/dsh-browser/src/content/actions.ts
@@ -236,14 +236,20 @@ async function clickAction(args: Record<string, unknown>, ctx: ActionContext): P
       && !el.hasAttribute('download')
       && (href?.protocol === 'http:' || href?.protocol === 'https:')
     if (controlledNavigation && href !== undefined) {
-      // Manual location assignment cannot preserve referrer-suppression
-      // attributes. Keep the browser's native navigation for those links.
+      // Manual location assignment cannot preserve browser-managed link
+      // semantics such as referrer suppression, hyperlink auditing, or
+      // attribution registration. Keep native activation for those links,
+      // but do not claim a replacement document is guaranteed: an SPA may
+      // still cancel the click and remain in this document.
       const hasReferrerPolicy = typeof el.referrerPolicy === 'string' && el.referrerPolicy !== ''
-      if (el.relList.contains('noreferrer') || hasReferrerPolicy) {
+      const requiresNativeActivation = el.relList.contains('noreferrer')
+        || hasReferrerPolicy
+        || el.hasAttribute('ping')
+        || el.hasAttribute('attributionsrc')
+      if (requiresNativeActivation) {
         setTimeout(() => { el.click() }, 0)
         return {
-          text: `Clicked link [${index}]. Call browser_snapshot again after navigation settles.`,
-          navigationPending: true,
+          text: `Clicked link [${index}] using native browser activation. Call browser_snapshot to read the resulting state.`,
         }
       }
       // Dispatch the click handlers without its default navigation so a

--- a/extensions/dsh-browser/src/content/actions.ts
+++ b/extensions/dsh-browser/src/content/actions.ts
@@ -20,6 +20,8 @@ export interface ActionResult {
   text: string
   /** Page-authored snapshot delta; the background must wrap it as untrusted. */
   pageContent?: string
+  /** A same-frame document navigation was scheduled after this response. */
+  navigationPending?: boolean
 }
 
 /** How long an action should observe a ready document before returning. */
@@ -230,7 +232,14 @@ async function clickAction(args: Record<string, unknown>, ctx: ActionContext): P
     // sends its response. Answer first and start the click in the next task,
     // matching the explicit navigation actions.
     setTimeout(() => { el.click() }, 0)
-    return { text: `Clicked link [${index}]. Call browser_snapshot again after navigation settles.` }
+    const target = el.target.trim().toLowerCase()
+    const sameFrameNavigation = (target === '' || target === '_self') && !el.hasAttribute('download')
+    return sameFrameNavigation
+      ? {
+          text: `Clicked link [${index}]. Call browser_snapshot again after navigation settles.`,
+          navigationPending: true,
+        }
+      : { text: `Clicked link [${index}]. The link may open outside the controlled frame.` }
   }
   if (el instanceof HTMLButtonElement && el.disabled) {
     throw new ActionError('action-failed', `Button [${index}] is disabled.`)
@@ -315,20 +324,29 @@ async function navigateAction(args: Record<string, unknown>): Promise<ActionResu
   // tabs.sendMessage response port before any await settles — so answer
   // FIRST, then navigate in a fresh task. The model re-snapshots after load.
   setTimeout(() => { location.href = parsed.href }, 0)
-  return { text: `Navigating to ${parsed.href}. Call browser_snapshot again after the page loads.` }
+  return {
+    text: `Navigating to ${parsed.href}. Call browser_snapshot again after the page loads.`,
+    navigationPending: true,
+  }
 }
 
 async function historyAction(delta: 1 | -1): Promise<ActionResult> {
   resetDeltaState()
   // 同 navigate：先响应再导航（文档卸载会销毁响应端口）。
   setTimeout(() => { if (delta === -1) history.back(); else history.forward() }, 0)
-  return { text: 'Navigating through browser history. Call browser_snapshot again after the page loads.' }
+  return {
+    text: 'Navigating through browser history. Call browser_snapshot again after the page loads.',
+    navigationPending: true,
+  }
 }
 
 function reloadAction(): ActionResult {
   resetDeltaState()
   setTimeout(() => { location.reload() }, 0)
-  return { text: 'The page is reloading. Call browser_snapshot again after it loads.' }
+  return {
+    text: 'The page is reloading. Call browser_snapshot again after it loads.',
+    navigationPending: true,
+  }
 }
 
 async function getTextAction(args: Record<string, unknown>): Promise<ActionResult> {

--- a/extensions/dsh-browser/src/content/actions.ts
+++ b/extensions/dsh-browser/src/content/actions.ts
@@ -236,6 +236,16 @@ async function clickAction(args: Record<string, unknown>, ctx: ActionContext): P
       && !el.hasAttribute('download')
       && (href?.protocol === 'http:' || href?.protocol === 'https:')
     if (controlledNavigation && href !== undefined) {
+      // Manual location assignment cannot preserve referrer-suppression
+      // attributes. Keep the browser's native navigation for those links.
+      const hasReferrerPolicy = typeof el.referrerPolicy === 'string' && el.referrerPolicy !== ''
+      if (el.relList.contains('noreferrer') || hasReferrerPolicy) {
+        setTimeout(() => { el.click() }, 0)
+        return {
+          text: `Clicked link [${index}]. Call browser_snapshot again after navigation settles.`,
+          navigationPending: true,
+        }
+      }
       // Dispatch the click handlers without its default navigation so a
       // client-side router can cancel synchronously and keep this document.
       const shouldNavigate = el.dispatchEvent(new MouseEvent('click', {

--- a/extensions/dsh-browser/src/content/extract.ts
+++ b/extensions/dsh-browser/src/content/extract.ts
@@ -85,7 +85,8 @@ export function truncate(text: string, max: number): { text: string; truncated: 
 
 /**
  * The accessible name of an element, following the ARIA precedence chain
- * (aria-label → aria-labelledby → label[for] → own text → placeholder/alt).
+ * (aria-label → aria-labelledby → associated label → own text →
+ * placeholder/alt).
  * @param el - element.
  * @returns a ≤80-char name, or the tag name as last resort.
  */
@@ -100,10 +101,17 @@ export function accessibleName(el: Element): string {
     if (refText !== undefined && refText.trim() !== '') return truncate(clean(refText), MAX_ITEM_NAME_CHARS).text
   }
 
-  if (el instanceof HTMLInputElement && el.id !== '') {
-    const label = document.querySelector<HTMLLabelElement>(`label[for="${cssEscape(el.id)}"]`)
-    const labelText = label?.textContent
-    if (labelText !== undefined && labelText.trim() !== '') return truncate(clean(labelText), MAX_ITEM_NAME_CHARS).text
+  const labelable = el instanceof HTMLInputElement || el instanceof HTMLSelectElement || el instanceof HTMLTextAreaElement
+  if (labelable) {
+    if (el.id !== '') {
+      const label = el.ownerDocument.querySelector<HTMLLabelElement>(`label[for="${cssEscape(el.id)}"]`)
+      const labelText = label?.textContent
+      if (labelText !== undefined && labelText.trim() !== '') return truncate(clean(labelText), MAX_ITEM_NAME_CHARS).text
+    }
+    const wrappingLabelText = el.closest('label')?.textContent
+    if (wrappingLabelText !== undefined && wrappingLabelText.trim() !== '') {
+      return truncate(clean(wrappingLabelText), MAX_ITEM_NAME_CHARS).text
+    }
   }
 
   const ownText = el instanceof HTMLInputElement ? '' : el.textContent
@@ -147,17 +155,18 @@ export function collectInteractive(root: Document | Element): Element[] {
 }
 
 /**
- * Best-effort main-content extraction (readability-lite): prefer
- * `<article>`/`<main>`, else the largest block containing at least two
- * paragraphs. Intended for article pages; SPA shells degrade to body text.
+ * Best-effort main-content extraction (readability-lite): prefer a main
+ * landmark, then a single standalone article, else the largest block
+ * containing at least two paragraphs. Multiple articles commonly represent
+ * cards or feed entries, so selecting only the first would hide page content.
  * @param doc - the document.
  * @returns the cleaned main text (unbounded; callers apply budgets).
  */
 export function mainText(doc: Document): string {
-  const article = doc.querySelector('article')
-  if (article !== null) return clean(elementText(article))
-  const main = doc.querySelector('main')
+  const main = doc.querySelector('main, [role="main"]')
   if (main !== null) return clean(elementText(main))
+  const articles = doc.querySelectorAll('article')
+  if (articles.length === 1) return clean(elementText(articles[0]!))
 
   let best: Element | null = null
   let bestScore = 0

--- a/extensions/dsh-browser/src/content/index.ts
+++ b/extensions/dsh-browser/src/content/index.ts
@@ -25,7 +25,7 @@ type ContentListener = typeof onMessage
 /** A tool-call result for the bridge. */
 export interface ToolResult {
   ok: boolean
-  result?: { text: string }
+  result?: { text: string; pageContent?: string }
   error?: { code: string; message: string }
 }
 
@@ -45,11 +45,16 @@ function onMessage(message: unknown, _sender: chrome.runtime.MessageSender, send
     action?: string
     args?: Record<string, unknown>
     budget?: Partial<SnapshotBudget>
+    includePageDelta?: boolean
   }
   const action = actionMsg.action ?? ''
   const args = actionMsg.args ?? {}
   const actionBudget = actionMsg.budget === undefined ? budget : { ...budget, ...actionMsg.budget }
-  void runAction(action, args, { ids, budget: actionBudget }).then(
+  void runAction(action, args, {
+    ids,
+    budget: actionBudget,
+    includePageDelta: actionMsg.includePageDelta === true,
+  }).then(
     (result) => { sendResponse({ ok: true, result }) },
     (error: unknown) => {
       const code = error instanceof ActionError ? error.code : 'action-failed'

--- a/extensions/dsh-browser/src/content/index.ts
+++ b/extensions/dsh-browser/src/content/index.ts
@@ -25,7 +25,7 @@ type ContentListener = typeof onMessage
 /** A tool-call result for the bridge. */
 export interface ToolResult {
   ok: boolean
-  result?: { text: string; pageContent?: string }
+  result?: { text: string; pageContent?: string; navigationPending?: boolean }
   error?: { code: string; message: string }
 }
 
@@ -75,3 +75,7 @@ if (previousListener !== undefined) {
 }
 contentGlobal[CONTENT_SCRIPT_LISTENER] = onMessage
 chrome.runtime.onMessage.addListener(onMessage)
+
+// A navigation action answers before unloading. The replacement content
+// script announces when the new document can accept its automatic snapshot.
+void chrome.runtime.sendMessage({ type: 'DSH_CONTENT_READY' }).catch(() => {})

--- a/extensions/dsh-browser/src/content/snapshot.ts
+++ b/extensions/dsh-browser/src/content/snapshot.ts
@@ -254,6 +254,7 @@ function sameForm(a: FormFieldView, b: FormFieldView): boolean {
  * block; no images anywhere).
  * @param view - snapshot to render.
  * @param delta - whether this is a delta render (changes only).
+ * @param maxChars - optional render cap for compact derivative responses.
  * @returns the text payload.
  */
 /** 渲染结果的整体预算：主文/清单之外的部分（标题、URL、包装行）也计入。 */
@@ -289,7 +290,7 @@ function appendTruncationNotes(lines: string[], view: SnapshotView): void {
   if (notes.length > 0) lines.push(`\n(${notes.join('; ')}. Use browser_get_text or specify region for more content.)`)
 }
 
-export function renderSnapshot(view: SnapshotView, delta: boolean): string {
+export function renderSnapshot(view: SnapshotView, delta: boolean, maxChars: number = view.budgetChars): string {
   const lines: string[] = []
   if (delta) {
     lines.push(`Page change v${view.version} (${view.url})`)
@@ -321,7 +322,7 @@ export function renderSnapshot(view: SnapshotView, delta: boolean): string {
     if (view.removed.length > 0) lines.push(`Removed elements: ${view.removed.join(', ')}`)
     if (view.changed.length === 0 && view.removed.length === 0) lines.push('(No visible changes.)')
     appendTruncationNotes(lines, view)
-    return capRendered(lines.join('\n'), view.budgetChars)
+    return capRendered(lines.join('\n'), maxChars)
   }
   lines.push(`Title: ${view.title || '(untitled)'}`)
   lines.push(`URL: ${view.url}`)
@@ -345,5 +346,5 @@ export function renderSnapshot(view: SnapshotView, delta: boolean): string {
     }
   }
   appendTruncationNotes(lines, view)
-  return capRendered(lines.join('\n'), view.budgetChars)
+  return capRendered(lines.join('\n'), maxChars)
 }

--- a/extensions/dsh-browser/src/content/snapshot.ts
+++ b/extensions/dsh-browser/src/content/snapshot.ts
@@ -52,6 +52,7 @@ interface FormFieldView {
   kind: string
   value: string
   masked: boolean
+  checked?: boolean
   required?: boolean
 }
 
@@ -148,6 +149,8 @@ export function buildSnapshot(ids: ElementIds, options: SnapshotOptions, last: S
       if (el.disabled) item.disabled = true
       if (el.type === 'checkbox' || el.type === 'radio') item.checked = el.checked
     }
+    const ariaChecked = el.getAttribute('aria-checked')
+    if (ariaChecked === 'true' || ariaChecked === 'false') item.checked = ariaChecked === 'true'
     if (el instanceof HTMLOptionElement && el.selected) item.selected = true
     if (el instanceof HTMLAnchorElement && el.href !== '') item.href = hrefHeadline(el.href)
     items.push(item)
@@ -163,7 +166,10 @@ export function buildSnapshot(ids: ElementIds, options: SnapshotOptions, last: S
     const index = ids.indexOf(el)
     if (index === undefined) continue
     const masked = isSensitiveField(el)
-    const value = el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement
+    const checkable = el instanceof HTMLInputElement && (el.type === 'checkbox' || el.type === 'radio')
+    const value = checkable
+      ? ''
+      : el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement
       ? el.value
       : el instanceof HTMLSelectElement
         ? selectedText(el)
@@ -174,6 +180,7 @@ export function buildSnapshot(ids: ElementIds, options: SnapshotOptions, last: S
       kind: el instanceof HTMLInputElement ? el.type : el.tagName.toLowerCase(),
       value: masked ? maskValue(value) : value.slice(0, 120),
       masked,
+      ...checkable ? { checked: el.checked } : {},
       ...el instanceof HTMLInputElement && el.required ? { required: true } : {},
     })
   }
@@ -239,6 +246,7 @@ function sameItem(a: InventoryItem, b: InventoryItem): boolean {
 
 function sameForm(a: FormFieldView, b: FormFieldView): boolean {
   return a.label === b.label && a.kind === b.kind && a.value === b.value && a.masked === b.masked
+    && a.checked === b.checked && a.required === b.required
 }
 
 /**
@@ -254,16 +262,65 @@ function capRendered(text: string, budgetChars: number): string {
   return `${text.slice(0, budgetChars)}…(truncated to the snapshot character budget)`
 }
 
+function renderItem(item: InventoryItem): string {
+  const state = [
+    item.disabled === true ? 'disabled' : undefined,
+    item.checked === undefined ? undefined : item.checked ? 'checked' : 'unchecked',
+    item.inViewport ? undefined : 'outside viewport',
+  ].filter((value) => value !== undefined).join('/')
+  const stateText = state === '' ? '' : ` [${state}]`
+  const hrefText = item.href !== undefined ? ` → ${item.href}` : ''
+  return `  [${item.index}] ${item.role} "${item.name}"${stateText}${hrefText}`
+}
+
+function renderForm(form: FormFieldView, includeIdentity: boolean): string {
+  const identity = includeIdentity ? `${form.label} (${form.kind}) ` : ''
+  const state = form.checked === undefined
+    ? `value="${form.masked ? '••••' : form.value}"`
+    : `checked=${String(form.checked)}`
+  return `  [${form.index}] ${identity}${state}${form.required === true ? ' required' : ''}`
+}
+
+function appendTruncationNotes(lines: string[], view: SnapshotView): void {
+  const notes: string[] = []
+  if (view.truncated.mainChars > 0) notes.push(`Main content truncated by ${view.truncated.mainChars} characters`)
+  if (view.truncated.itemsDropped > 0) notes.push(`${view.truncated.itemsDropped} additional elements omitted`)
+  if (view.truncated.formsDropped > 0) notes.push(`${view.truncated.formsDropped} additional form fields omitted`)
+  if (notes.length > 0) lines.push(`\n(${notes.join('; ')}. Use browser_get_text or specify region for more content.)`)
+}
+
 export function renderSnapshot(view: SnapshotView, delta: boolean): string {
   const lines: string[] = []
   if (delta) {
     lines.push(`Page change v${view.version} (${view.url})`)
-    if (view.changed.includes(-1)) lines.push('Main content, title, or URL changed.')
     const elementChanges = view.changed.filter((id) => id !== -1)
-    if (elementChanges.length > 0) lines.push(`Changed elements: ${elementChanges.join(', ')}`)
+    const changedIds = new Set(elementChanges)
+    const changedItems = view.items.filter((item) => changedIds.has(item.index))
+    const changedForms = view.forms.filter((form) => changedIds.has(form.index))
+
+    lines.push(`Status: ${view.ready}${view.reindexed ? ' (element indices were reassigned; use the indices in this snapshot)' : ''}`)
+    if (view.changed.includes(-1)) {
+      lines.push(`Title: ${view.title || '(untitled)'}`)
+      if (view.main.length > 0) {
+        lines.push('')
+        lines.push('Changed main content:')
+        lines.push(view.main)
+      }
+    }
+    if (changedItems.length > 0) {
+      lines.push('')
+      lines.push('Changed interactive elements:')
+      for (const item of changedItems) lines.push(renderItem(item))
+    }
+    if (changedForms.length > 0) {
+      lines.push('')
+      lines.push('Changed form fields:')
+      const renderedItems = new Set(changedItems.map((item) => item.index))
+      for (const form of changedForms) lines.push(renderForm(form, !renderedItems.has(form.index)))
+    }
     if (view.removed.length > 0) lines.push(`Removed elements: ${view.removed.join(', ')}`)
     if (view.changed.length === 0 && view.removed.length === 0) lines.push('(No visible changes.)')
-    lines.push('Call browser_snapshot again without delta for a full snapshot.')
+    appendTruncationNotes(lines, view)
     return capRendered(lines.join('\n'), view.budgetChars)
   }
   lines.push(`Title: ${view.title || '(untitled)'}`)
@@ -277,30 +334,16 @@ export function renderSnapshot(view: SnapshotView, delta: boolean): string {
   if (view.items.length > 0) {
     lines.push('')
     lines.push('Interactive elements:')
-    for (const item of view.items) {
-      const state = [
-        item.disabled === true ? 'disabled' : undefined,
-        item.checked === true ? 'checked' : undefined,
-        item.inViewport ? undefined : 'outside viewport',
-      ].filter((x) => x !== undefined).join('/')
-      const stateText = state === '' ? '' : ` [${state}]`
-      const hrefText = item.href !== undefined ? ` → ${item.href}` : ''
-      lines.push(`  [${item.index}] ${item.role} "${item.name}"${stateText}${hrefText}`)
-    }
+    for (const item of view.items) lines.push(renderItem(item))
   }
   if (view.forms.length > 0) {
     lines.push('')
     lines.push('Form fields:')
     const renderedItems = new Set(view.items.map((item) => item.index))
     for (const form of view.forms) {
-      const identity = renderedItems.has(form.index) ? '' : `${form.label} (${form.kind}) `
-      lines.push(`  [${form.index}] ${identity}value="${form.masked ? '••••' : form.value}"${form.required === true ? ' required' : ''}`)
+      lines.push(renderForm(form, !renderedItems.has(form.index)))
     }
   }
-  const notes: string[] = []
-  if (view.truncated.mainChars > 0) notes.push(`Main content truncated by ${view.truncated.mainChars} characters`)
-  if (view.truncated.itemsDropped > 0) notes.push(`${view.truncated.itemsDropped} additional elements omitted`)
-  if (view.truncated.formsDropped > 0) notes.push(`${view.truncated.formsDropped} additional form fields omitted`)
-  if (notes.length > 0) lines.push(`\n(${notes.join('; ')}. Use browser_get_text or specify region for more content.)`)
+  appendTruncationNotes(lines, view)
   return capRendered(lines.join('\n'), view.budgetChars)
 }

--- a/extensions/dsh-browser/tests/actions-delta.spec.ts
+++ b/extensions/dsh-browser/tests/actions-delta.spec.ts
@@ -92,4 +92,27 @@ describe('automatic action deltas', () => {
     await expect(pending).resolves.toEqual({ text: expect.stringContaining('Clicked') })
   })
 
+  it('returns a delta immediately when a client-side router cancels navigation', async () => {
+    document.body.innerHTML = '<main>Home</main><a href="/orders">Orders</a>'
+    const link = document.querySelector('a')!
+    link.scrollIntoView = vi.fn()
+    link.addEventListener('click', (event) => {
+      event.preventDefault()
+      document.querySelector('main')!.textContent = 'Orders'
+    })
+    const ids = new ElementIds()
+    await runAction('browser_snapshot', {}, { ids, budget: BUDGET })
+
+    const pending = runAction('browser_click', { index: ids.indexOf(link) }, {
+      ids,
+      budget: BUDGET,
+      includePageDelta: true,
+    })
+    await vi.advanceTimersByTimeAsync(100)
+    const result = await pending
+
+    expect(result.navigationPending).toBeUndefined()
+    expect(result.pageContent).toContain('Orders')
+  })
+
 })

--- a/extensions/dsh-browser/tests/actions-delta.spec.ts
+++ b/extensions/dsh-browser/tests/actions-delta.spec.ts
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { runAction } from '../src/content/actions.ts'
+import { ElementIds } from '../src/content/ids.ts'
+
+const BUDGET = { maxItems: 20, maxForms: 10, maxChars: 8_000 }
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.spyOn(document, 'readyState', 'get').mockReturnValue('complete')
+  vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+    top: 0,
+    left: 0,
+    right: 100,
+    bottom: 20,
+    width: 100,
+    height: 20,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  } as DOMRect)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+  document.body.replaceChildren()
+})
+
+describe('automatic action deltas', () => {
+  it('returns settled page changes after a click when sharing is enabled', async () => {
+    document.body.innerHTML = '<main>Pending</main><button>Complete</button>'
+    const button = document.querySelector('button')!
+    button.scrollIntoView = vi.fn()
+    button.addEventListener('click', () => {
+      document.querySelector('main')!.textContent = 'Complete'
+    })
+    const ids = new ElementIds()
+    await runAction('browser_snapshot', {}, { ids, budget: BUDGET })
+
+    const pending = runAction('browser_click', { index: ids.indexOf(button) }, {
+      ids,
+      budget: BUDGET,
+      includePageDelta: true,
+    })
+    await vi.advanceTimersByTimeAsync(100)
+
+    await expect(pending).resolves.toMatchObject({
+      text: expect.stringContaining('Clicked'),
+      pageContent: expect.stringContaining('Complete'),
+    })
+  })
+
+  it('masks sensitive values in the delta returned after typing', async () => {
+    document.body.innerHTML = '<main>Sign in</main><input aria-label="Password" type="password">'
+    const input = document.querySelector('input')!
+    const ids = new ElementIds()
+    await runAction('browser_snapshot', {}, { ids, budget: BUDGET })
+
+    const pending = runAction('browser_type', {
+      index: ids.indexOf(input),
+      text: 'secret-value',
+    }, {
+      ids,
+      budget: BUDGET,
+      includePageDelta: true,
+    })
+    await vi.advanceTimersByTimeAsync(32)
+    const result = await pending
+
+    expect(result.pageContent).toContain('value="••••"')
+    expect(result.pageContent).not.toContain('secret-value')
+  })
+
+  it('does not extract page changes when automatic sharing is disabled', async () => {
+    document.body.innerHTML = '<main>Pending</main><button>Complete</button>'
+    const button = document.querySelector('button')!
+    button.scrollIntoView = vi.fn()
+    button.addEventListener('click', () => {
+      document.querySelector('main')!.textContent = 'Complete'
+    })
+    const ids = new ElementIds()
+    await runAction('browser_snapshot', {}, { ids, budget: BUDGET })
+
+    const pending = runAction('browser_click', { index: ids.indexOf(button) }, {
+      ids,
+      budget: BUDGET,
+      includePageDelta: false,
+    })
+    await vi.advanceTimersByTimeAsync(100)
+
+    await expect(pending).resolves.toEqual({ text: expect.stringContaining('Clicked') })
+  })
+
+})

--- a/extensions/dsh-browser/tests/actions-settle.spec.ts
+++ b/extensions/dsh-browser/tests/actions-settle.spec.ts
@@ -76,8 +76,29 @@ describe('navigation action responses', () => {
     await expect(runAction('browser_click', { index: 1 }, {
       ids,
       budget: { maxItems: 20, maxForms: 10, maxChars: 2_000 },
-    })).resolves.toMatchObject({ text: expect.stringContaining('Clicked link [1]') })
+    })).resolves.toMatchObject({
+      text: expect.stringContaining('Clicked link [1]'),
+      navigationPending: true,
+    })
     expect(link.click).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(link.click).toHaveBeenCalledOnce()
+  })
+
+  it('does not wait for a replacement document when a link opens a new tab', async () => {
+    vi.useFakeTimers()
+    const link = document.createElement('a')
+    link.href = 'https://example.com/next'
+    link.target = '_blank'
+    link.scrollIntoView = vi.fn()
+    link.click = vi.fn()
+    const ids = { elementByIndex: vi.fn(() => link) } as unknown as ElementIds
+
+    await expect(runAction('browser_click', { index: 1 }, {
+      ids,
+      budget: { maxItems: 20, maxForms: 10, maxChars: 2_000 },
+    })).resolves.toEqual({ text: expect.stringContaining('outside the controlled frame') })
 
     await vi.advanceTimersByTimeAsync(0)
     expect(link.click).toHaveBeenCalledOnce()

--- a/extensions/dsh-browser/tests/actions-settle.spec.ts
+++ b/extensions/dsh-browser/tests/actions-settle.spec.ts
@@ -100,4 +100,22 @@ describe('navigation action responses', () => {
     await vi.advanceTimersByTimeAsync(0)
     expect(link.click).toHaveBeenCalledOnce()
   })
+
+  it('preserves native referrer policy for same-frame links', async () => {
+    vi.useFakeTimers()
+    const link = document.createElement('a')
+    link.href = 'https://example.com/private'
+    link.rel = 'noreferrer'
+    link.scrollIntoView = vi.fn()
+    link.click = vi.fn()
+    const ids = { elementByIndex: vi.fn(() => link) } as unknown as ElementIds
+
+    await expect(runAction('browser_click', { index: 1 }, {
+      ids,
+      budget: { maxItems: 20, maxForms: 10, maxChars: 2_000 },
+    })).resolves.toMatchObject({ navigationPending: true })
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(link.click).toHaveBeenCalledOnce()
+  })
 })

--- a/extensions/dsh-browser/tests/actions-settle.spec.ts
+++ b/extensions/dsh-browser/tests/actions-settle.spec.ts
@@ -101,7 +101,7 @@ describe('navigation action responses', () => {
     expect(link.click).toHaveBeenCalledOnce()
   })
 
-  it('preserves native referrer policy for same-frame links', async () => {
+  it('preserves native referrer policy without waiting for a guaranteed navigation', async () => {
     vi.useFakeTimers()
     const link = document.createElement('a')
     link.href = 'https://example.com/private'
@@ -110,11 +110,35 @@ describe('navigation action responses', () => {
     link.click = vi.fn()
     const ids = { elementByIndex: vi.fn(() => link) } as unknown as ElementIds
 
-    await expect(runAction('browser_click', { index: 1 }, {
+    const result = await runAction('browser_click', { index: 1 }, {
       ids,
       budget: { maxItems: 20, maxForms: 10, maxChars: 2_000 },
-    })).resolves.toMatchObject({ navigationPending: true })
+    })
 
+    expect(result.text).toContain('native browser activation')
+    expect(result.navigationPending).toBeUndefined()
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(link.click).toHaveBeenCalledOnce()
+  })
+
+  it('preserves hyperlink auditing without entering the replacement-document wait', async () => {
+    vi.useFakeTimers()
+    const link = document.createElement('a')
+    link.href = 'https://example.com/next'
+    link.setAttribute('ping', 'https://audit.example/link')
+    link.scrollIntoView = vi.fn()
+    link.click = vi.fn()
+    const dispatch = vi.spyOn(link, 'dispatchEvent')
+    const ids = { elementByIndex: vi.fn(() => link) } as unknown as ElementIds
+
+    const result = await runAction('browser_click', { index: 1 }, {
+      ids,
+      budget: { maxItems: 20, maxForms: 10, maxChars: 2_000 },
+    })
+
+    expect(result.navigationPending).toBeUndefined()
+    expect(dispatch).not.toHaveBeenCalled()
     await vi.advanceTimersByTimeAsync(0)
     expect(link.click).toHaveBeenCalledOnce()
   })

--- a/extensions/dsh-browser/tests/actions-settle.spec.ts
+++ b/extensions/dsh-browser/tests/actions-settle.spec.ts
@@ -70,7 +70,7 @@ describe('navigation action responses', () => {
     const link = document.createElement('a')
     link.href = 'https://example.com/next'
     link.scrollIntoView = vi.fn()
-    link.click = vi.fn()
+    const dispatch = vi.spyOn(link, 'dispatchEvent').mockReturnValue(true)
     const ids = { elementByIndex: vi.fn(() => link) } as unknown as ElementIds
 
     await expect(runAction('browser_click', { index: 1 }, {
@@ -80,10 +80,7 @@ describe('navigation action responses', () => {
       text: expect.stringContaining('Clicked link [1]'),
       navigationPending: true,
     })
-    expect(link.click).not.toHaveBeenCalled()
-
-    await vi.advanceTimersByTimeAsync(0)
-    expect(link.click).toHaveBeenCalledOnce()
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'click' }))
   })
 
   it('does not wait for a replacement document when a link opens a new tab', async () => {

--- a/extensions/dsh-browser/tests/background-tools.spec.ts
+++ b/extensions/dsh-browser/tests/background-tools.spec.ts
@@ -185,7 +185,73 @@ describe('dispatchToolCall', () => {
       type: 'DSH_ACTION',
       action: 'browser_click',
       args: { index: 3 },
+      budget: expect.objectContaining({ maxItems: 60 }),
+      includePageDelta: true,
     }, { documentId: 'child-doc' })
+  })
+
+  it('returns automatic action deltas inside a fresh untrusted-content boundary', async () => {
+    const call: ToolCall = { id: 'tool-delta', name: 'browser_click', args: { index: 3 } }
+    const budget = { maxItems: 10, maxChars: 1_000 }
+    const chromeMock = mockChrome({
+      tab: { id: 33, url: 'https://app.example/' },
+      respond: (message) => (message as { action?: string }).action === 'browser_snapshot'
+        ? { ok: true, result: { text: 'Initial page' } }
+        : {
+            ok: true,
+            result: {
+              text: 'Clicked [3].',
+              pageContent: 'Page change v2\nChanged main content:\nOrder complete',
+            },
+          },
+    })
+    await dispatchToolCall(CALL, 'auto', budget)
+    chromeMock.sendMessage.mockClear()
+
+    const answer = await dispatchToolCall(call, 'auto', budget, async () => 'approved')
+
+    expect(answer.ok).toBe(true)
+    const result = answer.result as { text: string; pageContent?: string }
+    expect(result.text).toContain('Clicked [3].')
+    expect(result.text).toContain('Continue from this state')
+    expect(result.text).toContain('UNTRUSTED_PAGE_CONTENT')
+    expect(result.text).toContain('Order complete')
+    expect(result.text.length).toBeLessThanOrEqual(budget.maxChars)
+    expect(result.pageContent).toBeUndefined()
+    expect(chromeMock.sendMessage).toHaveBeenCalledWith(33, {
+      type: 'DSH_ACTION',
+      action: 'browser_click',
+      args: { index: 3 },
+      budget,
+      includePageDelta: true,
+    }, { documentId: 'document-33' })
+  })
+
+  it('does not extract or forward an action delta when reads require approval', async () => {
+    const call: ToolCall = { id: 'tool-private-delta', name: 'browser_click', args: { index: 2 } }
+    const chromeMock = mockChrome({
+      tab: { id: 34, url: 'https://private.example/' },
+      respond: (message) => (message as { action?: string }).action === 'browser_snapshot'
+        ? { ok: true, result: { text: 'Initial private page' } }
+        : {
+            ok: true,
+            result: {
+              text: 'Clicked [2].',
+              pageContent: 'This content must not cross the sharing boundary',
+            },
+          },
+    })
+    await dispatchToolCall(CALL, 'auto')
+    chromeMock.sendMessage.mockClear()
+
+    const answer = await dispatchToolCall(call, 'ask', undefined, async () => 'approved')
+
+    expect(answer).toEqual({ ok: true, result: { text: 'Clicked [2].' } })
+    expect(chromeMock.sendMessage).toHaveBeenCalledWith(34, {
+      type: 'DSH_ACTION',
+      action: 'browser_click',
+      args: { index: 2 },
+    }, { documentId: 'document-34' })
   })
 
   it('wraps browser_get_text output in the same untrusted-content boundary', async () => {

--- a/extensions/dsh-browser/tests/background-tools.spec.ts
+++ b/extensions/dsh-browser/tests/background-tools.spec.ts
@@ -13,6 +13,7 @@ function mockChrome(options: {
   respond?: (message: unknown, frameId: number) => unknown
 }) {
   const responses = [...(options.responses ?? [OK])]
+  const runtimeListeners = new Set<(message: unknown, sender: chrome.runtime.MessageSender) => void>()
   const currentFrames = () => options.frames ?? (options.tab?.id === undefined ? [] : [{
     frameId: 0,
     parentFrameId: -1,
@@ -40,8 +41,23 @@ function mockChrome(options: {
     tabs: { query, sendMessage },
     scripting: { executeScript },
     webNavigation: { getAllFrames },
+    runtime: {
+      onMessage: {
+        addListener: (listener: (message: unknown, sender: chrome.runtime.MessageSender) => void) => {
+          runtimeListeners.add(listener)
+        },
+        removeListener: (listener: (message: unknown, sender: chrome.runtime.MessageSender) => void) => {
+          runtimeListeners.delete(listener)
+        },
+      },
+    },
   })
-  return { executeScript, getAllFrames, query, sendMessage }
+  const emitContentReady = (tabId: number, frameId: number, documentId: string): void => {
+    for (const listener of runtimeListeners) {
+      listener({ type: 'DSH_CONTENT_READY' }, { tab: { id: tabId }, frameId, documentId } as chrome.runtime.MessageSender)
+    }
+  }
+  return { emitContentReady, executeScript, getAllFrames, query, sendMessage }
 }
 
 afterEach(() => {
@@ -252,6 +268,81 @@ describe('dispatchToolCall', () => {
       action: 'browser_click',
       args: { index: 2 },
     }, { documentId: 'document-34' })
+  })
+
+  it('returns the replacement page snapshot in the same navigation tool call', async () => {
+    const frames = [
+      { frameId: 0, parentFrameId: -1, documentId: 'document-before', url: 'https://app.example/start' },
+    ]
+    const budget = { maxItems: 10, maxChars: 2_000 }
+    const chromeMock = mockChrome({
+      tab: { id: 35, url: 'https://app.example/start' },
+      frames,
+      respond: (message) => (message as { action?: string }).action === 'browser_navigate'
+        ? {
+            ok: true,
+            result: {
+              text: 'Navigating to https://app.example/next. Call browser_snapshot again after the page loads.',
+              navigationPending: true,
+            },
+          }
+        : { ok: true, result: { text: 'Title: Next page\nURL: https://app.example/next' } },
+    })
+
+    const pending = dispatchToolCall(
+      { id: 'tool-navigation', name: 'browser_navigate', args: { url: 'https://app.example/next' } },
+      'auto',
+      budget,
+      async () => 'approved',
+    )
+    await vi.waitFor(() => { expect(chromeMock.sendMessage).toHaveBeenCalledTimes(1) })
+    frames[0] = {
+      frameId: 0,
+      parentFrameId: -1,
+      documentId: 'document-after',
+      url: 'https://app.example/next',
+    }
+    chromeMock.emitContentReady(35, 0, 'document-after')
+
+    const answer = await pending
+    const text = (answer.result as { text: string }).text
+    expect(text).toContain('Navigation completed')
+    expect(text).toContain('Title: Next page')
+    expect(text).toContain('UNTRUSTED_PAGE_CONTENT')
+    expect(text).not.toContain('Call browser_snapshot again')
+    expect(text.length).toBeLessThanOrEqual(budget.maxChars)
+    expect(chromeMock.sendMessage).toHaveBeenCalledTimes(2)
+    expect(chromeMock.sendMessage).toHaveBeenLastCalledWith(35, expect.objectContaining({
+      action: 'browser_snapshot',
+      args: { delta: false },
+      budget: expect.objectContaining({ maxChars: expect.any(Number) }),
+    }), { documentId: 'document-after' })
+  })
+
+  it('does not wait for or return navigation page content when reads are not automatic', async () => {
+    const chromeMock = mockChrome({
+      tab: { id: 36, url: 'https://app.example/start' },
+      respond: () => ({
+        ok: true,
+        result: {
+          text: 'Navigating to https://app.example/next. Call browser_snapshot again after the page loads.',
+          navigationPending: true,
+        },
+      }),
+    })
+
+    const answer = await dispatchToolCall(
+      { id: 'tool-private-navigation', name: 'browser_navigate', args: { url: 'https://app.example/next' } },
+      'ask',
+      undefined,
+      async () => 'approved',
+    )
+
+    expect(answer).toEqual({
+      ok: true,
+      result: { text: expect.stringContaining('Call browser_snapshot again') },
+    })
+    expect(chromeMock.sendMessage).toHaveBeenCalledTimes(1)
   })
 
   it('wraps browser_get_text output in the same untrusted-content boundary', async () => {

--- a/extensions/dsh-browser/tests/content-index.spec.ts
+++ b/extensions/dsh-browser/tests/content-index.spec.ts
@@ -13,8 +13,9 @@ describe('content script registration', () => {
   it('replaces a stale listener when content.js is injected again', async () => {
     const addListener = vi.fn()
     const removeListener = vi.fn()
+    const sendMessage = vi.fn(async () => undefined)
     vi.stubGlobal('chrome', {
-      runtime: { onMessage: { addListener, removeListener } },
+      runtime: { onMessage: { addListener, removeListener }, sendMessage },
     })
 
     await import('../src/content/index.ts')
@@ -28,5 +29,7 @@ describe('content script registration', () => {
     expect(removeListener).toHaveBeenCalledWith(firstListener)
     expect(addListener).toHaveBeenCalledTimes(2)
     expect(addListener.mock.calls[1]?.[0]).not.toBe(firstListener)
+    expect(sendMessage).toHaveBeenCalledTimes(2)
+    expect(sendMessage).toHaveBeenLastCalledWith({ type: 'DSH_CONTENT_READY' })
   })
 })

--- a/extensions/dsh-browser/tests/extract.spec.ts
+++ b/extensions/dsh-browser/tests/extract.spec.ts
@@ -48,6 +48,11 @@ describe('accessibleName', () => {
     expect(accessibleName(input)).toBe('邮箱地址')
   })
 
+  it('resolves a wrapping label for form controls', () => {
+    document.body.innerHTML = '<label><input type="checkbox">邮件通知</label>'
+    expect(accessibleName(document.querySelector('input')!)).toBe('邮件通知')
+  })
+
   it('falls back to own text then tag name', () => {
     const button = document.createElement('button')
     button.textContent = '  提交  '
@@ -84,5 +89,19 @@ describe('mainText', () => {
   it('falls back to body text without an article', () => {
     document.body.innerHTML = '<div>只有一段话的页面。</div>'
     expect(mainText(document)).toContain('只有一段话的页面')
+  })
+
+  it('keeps all article cards inside the main landmark', () => {
+    document.body.innerHTML = `
+      <nav>导航垃圾文字</nav>
+      <main>
+        <article>Delta 收纳盒</article>
+        <article>Cedar 收纳盒</article>
+      </main>
+    `
+    const text = mainText(document)
+    expect(text).toContain('Delta 收纳盒')
+    expect(text).toContain('Cedar 收纳盒')
+    expect(text).not.toContain('导航垃圾')
   })
 })

--- a/extensions/dsh-browser/tests/navigation.spec.ts
+++ b/extensions/dsh-browser/tests/navigation.spec.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { waitForNextDocumentReady } from '../src/background/navigation.ts'
+
+type Listener = (message: unknown, sender: chrome.runtime.MessageSender) => void
+let listeners: Set<Listener>
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  listeners = new Set()
+  vi.stubGlobal('chrome', {
+    runtime: {
+      onMessage: {
+        addListener: (listener: Listener) => { listeners.add(listener) },
+        removeListener: (listener: Listener) => { listeners.delete(listener) },
+      },
+    },
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+function emit(tabId: number, frameId: number, documentId: string): void {
+  for (const listener of listeners) {
+    listener({ type: 'DSH_CONTENT_READY' }, {
+      tab: { id: tabId },
+      frameId,
+      documentId,
+    } as chrome.runtime.MessageSender)
+  }
+}
+
+describe('navigation readiness', () => {
+  it('resolves only for a replacement document in the target frame', async () => {
+    const wait = waitForNextDocumentReady(7, 2, 'old-document')
+    let resolved = false
+    void wait.ready.then(() => { resolved = true })
+
+    emit(8, 2, 'other-tab')
+    emit(7, 3, 'other-frame')
+    emit(7, 2, 'old-document')
+    await Promise.resolve()
+    expect(resolved).toBe(false)
+
+    emit(7, 2, 'new-document')
+    await expect(wait.ready).resolves.toBe(true)
+    expect(listeners.size).toBe(0)
+  })
+
+  it('cleans up when cancelled or timed out', async () => {
+    const cancelled = waitForNextDocumentReady(7, 0, 'old-document')
+    cancelled.cancel()
+    await expect(cancelled.ready).resolves.toBe(false)
+    expect(listeners.size).toBe(0)
+
+    const timedOut = waitForNextDocumentReady(7, 0, 'old-document', undefined, 50)
+    await vi.advanceTimersByTimeAsync(50)
+    await expect(timedOut.ready).resolves.toBe(false)
+    expect(listeners.size).toBe(0)
+  })
+})

--- a/extensions/dsh-browser/tests/snapshot.spec.ts
+++ b/extensions/dsh-browser/tests/snapshot.spec.ts
@@ -55,11 +55,46 @@ describe('buildSnapshot', () => {
     const second = buildSnapshot(ids, { delta: true, budget: BUDGET }, first)
     expect(second.changed).toContain(ids.indexOf(a))
     expect(second.changed).not.toContain(bIndex)
+    const secondText = renderSnapshot(second, true)
+    expect(secondText).toContain('Changed interactive elements:')
+    expect(secondText).toContain('甲已改名')
+    expect(secondText).not.toContain('Call browser_snapshot again')
 
     document.getElementById('b')!.remove()
     const third = buildSnapshot(ids, { delta: true, budget: BUDGET }, second)
     expect(third.removed).toContain(bIndex)
     expect(renderSnapshot(third, true)).toContain('Removed elements:')
+  })
+
+  it('renders wrapped checkbox labels and explicit checked state', () => {
+    document.body.innerHTML = '<label><input type="checkbox">邮件通知</label>'
+    const checkbox = document.querySelector<HTMLInputElement>('input')!
+    const ids = new ElementIds()
+    const first = buildSnapshot(ids, { budget: BUDGET }, null)
+    const firstText = renderSnapshot(first, false)
+
+    expect(firstText).toContain('checkbox "邮件通知" [unchecked]')
+    expect(firstText).toContain('checked=false')
+    expect(firstText).not.toContain('value="on"')
+
+    checkbox.checked = true
+    const second = buildSnapshot(ids, { delta: true, budget: BUDGET }, first)
+    const secondText = renderSnapshot(second, true)
+    expect(second.changed).toContain(ids.indexOf(checkbox))
+    expect(secondText).toContain('checkbox "邮件通知" [checked]')
+    expect(secondText).toContain('checked=true')
+  })
+
+  it('includes changed main content in delta snapshots', () => {
+    document.body.innerHTML = '<main>处理中</main>'
+    const ids = new ElementIds()
+    const first = buildSnapshot(ids, { budget: BUDGET }, null)
+    document.querySelector('main')!.textContent = '结算完成'
+
+    const second = buildSnapshot(ids, { delta: true, budget: BUDGET }, first)
+    const text = renderSnapshot(second, true)
+    expect(text).toContain('Changed main content:')
+    expect(text).toContain('结算完成')
   })
 
   it('caps inventory by budget and reports drops', () => {

--- a/packages/browser/bridge-browser/src/browser-context.ts
+++ b/packages/browser/bridge-browser/src/browser-context.ts
@@ -23,7 +23,7 @@ const DEFAULT_MAX_PENDING = 32
 export function createBrowserSnapshotMessage(snapshot: string): UserMessage {
   const text = [
     'The user chose to follow the newly active browser tab. The browser page context was refreshed immediately after that choice.',
-    'The following browser_snapshot is the current page state. Use it for the next request instead of asking whether the page was read.',
+    'The following is an already completed browser_snapshot of the current page. Use its stable indices directly for the next request; do not take an immediate duplicate snapshot unless required context is missing.',
     snapshot,
   ].join('\n\n')
   return createUserMessage({

--- a/packages/browser/bridge-browser/src/index.ts
+++ b/packages/browser/bridge-browser/src/index.ts
@@ -191,7 +191,8 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
       name: 'tool:bridge-browser',
       order: 107,
       text: 'A browser bridge may be connected. To read or operate the user\'s active browser page, call browser_snapshot '
-        + '(text-only; numbered items are the click/type targets). Never assume page content you have not snapshotted.',
+        + '(text-only; numbered items are the click/type targets), unless the current turn already includes a plugin-provided '
+        + 'followed-page browser_snapshot. Reuse that injected snapshot and its indices directly. Never assume page content you have not snapshotted.',
     }), 'bridge-browser: system prompt section')
   }
 

--- a/packages/browser/bridge-browser/tests/browser-context.spec.ts
+++ b/packages/browser/bridge-browser/tests/browser-context.spec.ts
@@ -28,6 +28,8 @@ describe('browser page context', () => {
       type: 'text',
       text: expect.stringContaining('browser page context was refreshed'),
     }])
+    expect(message.content[0].text).toContain('already completed browser_snapshot')
+    expect(message.content[0].text).toContain('do not take an immediate duplicate snapshot')
   })
 
   it('injects immediately when the Agent is live', () => {

--- a/packages/browser/bridge-browser/tests/composition.spec.ts
+++ b/packages/browser/bridge-browser/tests/composition.spec.ts
@@ -166,6 +166,7 @@ describe('real Loader composition', () => {
     const browserPrompt = (await ctx.systemPrompt.assemble()).sections
       .find((section) => section.name === 'tool:bridge-browser')?.text
     expect(browserPrompt).toContain('page content you have not snapshotted')
+    expect(browserPrompt).toContain('Reuse that injected snapshot')
     expect(browserPrompt).not.toMatch(/\p{Script=Han}/u)
 
     // Zero-config discovery endpoint answers with the bridge WebSocket URL.


### PR DESCRIPTION
## Summary

- preserve complete main content, accessible control names, and actionable snapshot deltas
- attach compact post-action deltas after click, type, press, scroll, and wait
- reuse the snapshot already injected after an explicit page follow
- attach a fresh snapshot after same-frame navigation, while returning SPA and hash-route deltas immediately
- keep trusted action receipts outside nonce-bound untrusted page content

## Security and behavior

- automatic page context is enabled only when page sharing is set to `auto`
- sensitive form values remain masked
- action deltas retain the full negotiated snapshot as their next baseline while capping response context
- native navigation is preserved for referrer-sensitive links
- navigation readiness is bounded and falls back to the existing explicit snapshot guidance

## Verification

- `pnpm test` (97 bridge tests, 176 extension tests)
- `pnpm typecheck`
- `pnpm build`
- no benchmark code, results, or reports are included in this PR

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR reduces browser round trips by attaching bounded action deltas and post-navigation snapshots when automatic page sharing is enabled. It also completes the prior anchor fixes by preserving native activation where browser-managed link semantics are required and by returning immediate deltas for canceled or same-document transitions.

- Adds a replacement-document readiness rendezvous and automatic post-navigation snapshots.
- Carries compact, nonce-wrapped page deltas after settled actions.
- Preserves native activation for referrer-sensitive, audited, and attribution-enabled links.
- Expands snapshot extraction and rendering for main landmarks, labels, checked states, and actionable deltas.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| extensions/dsh-browser/src/content/actions.ts | Adds settled action deltas and distinguishes canceled, same-document, controlled cross-document, and native anchor activation paths; the two previously reported anchor issues are addressed. |
| extensions/dsh-browser/src/background/tools.ts | Negotiates automatic deltas, waits only for explicitly pending replacement documents, and wraps page-authored context as untrusted content. |
| extensions/dsh-browser/src/background/navigation.ts | Adds a bounded, cancellable, frame- and document-aware readiness rendezvous for replacement content scripts. |
| extensions/dsh-browser/src/content/snapshot.ts | Produces richer bounded delta output and tracks checked and required form state in snapshot comparisons. |
| extensions/dsh-browser/src/content/extract.ts | Improves accessible label resolution and avoids dropping content from pages containing multiple articles. |
| extensions/dsh-browser/src/content/index.ts | Propagates automatic-delta options and announces replacement-document readiness to the background. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant B as Bridge
    participant BG as Background
    participant C as Content Script
    participant P as Replacement Page
    B->>BG: browser action
    BG->>C: DSH_ACTION
    alt settled same-document action
        C-->>BG: status + page delta
        BG-->>B: trusted receipt + wrapped delta
    else controlled cross-document navigation
        C-->>BG: navigationPending
        C->>P: navigate
        P-->>BG: DSH_CONTENT_READY
        BG->>P: browser_snapshot
        P-->>BG: current snapshot
        BG-->>B: status + wrapped snapshot
    else native anchor activation
        C-->>BG: native activation guidance
        C->>P: native click when applicable
        BG-->>B: guidance without speculative wait
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(content): preserve native anchor act..."](https://github.com/lum1104/dsh-browser/commit/8b3b293cfab256e1e228d9b4b9e4740c7fb48142) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54006395)</sub>

<!-- /greptile_comment -->