### PR TITLE
fix(browser): normalize tool schemas before registration

### DIFF
--- a/packages/browser/bridge-browser/src/tools.ts
+++ b/packages/browser/bridge-browser/src/tools.ts
@@ -13,7 +13,7 @@
  */
 
 import type { Context } from '@deepseek-ai/cordis'
-import type { ToolDefinition, ToolRunContext } from '@deepseek-ai/dsh-tools'
+import { defineTool, type ToolDefinition, type ToolRunContext } from '@deepseek-ai/dsh-tools'
 import type { BridgeServer } from './server.ts'
 
 /** Options resolved from plugin config before tool registration. */
@@ -32,23 +32,18 @@ interface TextResult {
 }
 
 /** Output contract shared by every browser tool. */
-const TEXT_OUTPUT: ToolDefinition['output'] = {
+const TEXT_OUTPUT = {
   schema: {
     type: 'object',
     additionalProperties: false,
-    properties: { text: { type: 'string' } },
-    required: ['text'],
+    properties: { text: { type: 'string', required: true } },
   },
-  render: (_args, value) => {
-    const result = value as unknown as TextResult
-    return [{ type: 'text', text: result.text }]
+  render: (_args: unknown, value: unknown) => {
+    const result = value as TextResult
+    return [{ type: 'text' as const, text: result.text }]
   },
-}
+} as const
 
-/** 显式 JSON Schema object 顶层：空 parameters 对象会被 DeepSeek 适配器序列化成
- * `{ type: null }` 并遭 API 拒绝（400 INVALID_REQUEST），所以每个工具的参数
- * schema 都必须显式声明 `type: 'object'`。 */
-const OBJECT_SCHEMA = { type: 'object' as const, additionalProperties: false as const }
 const FRAME_PARAMETER = {
   type: 'number' as const,
   description: 'Iframe number from browser_snapshot; omit for the top page.',
@@ -115,11 +110,10 @@ interface Call {
 
 /** The v1 tool set, model-perspective contracts only (no transport vocabulary). */
 function defineTools(call: Call, options: BrowserToolsOptions): ToolDefinition[] {
-  const snapshot = (): ToolDefinition => ({
+  const snapshot = (): ToolDefinition => defineTool({
     name: 'browser_snapshot',
     description: `Read the page and accessible iframes as structured text with numbered action targets. Use frame for iframe targets and delta=true for changes only. ${UNTRUSTED_CONTENT_WARNING}`,
     parameters: {
-      ...OBJECT_SCHEMA,
       delta: { type: 'boolean', description: 'Return changes since the previous snapshot.' },
       region: { type: 'string', description: 'CSS selector or "main" to read only that region.' },
     },
@@ -134,11 +128,10 @@ function defineTools(call: Call, options: BrowserToolsOptions): ToolDefinition[]
     },
   })
 
-  const click = (): ToolDefinition => ({
+  const click = (): ToolDefinition => defineTool({
     name: 'browser_click',
     description: 'Click an element from the latest browser_snapshot by index; include frame for an iframe target.',
     parameters: {
-      ...OBJECT_SCHEMA,
       index: { type: 'number', required: true, description: 'Element index from the browser_snapshot inventory.' },
       frame: FRAME_PARAMETER,
     },
@@ -147,11 +140,10 @@ function defineTools(call: Call, options: BrowserToolsOptions): ToolDefinition[]
     execute: (args, exec) => call(exec, 'browser_click', args as Record<string, unknown>),
   })
 
-  const type = (): ToolDefinition => ({
+  const type = (): ToolDefinition => defineTool({
     name: 'browser_type',
     description: 'Append text to a field from browser_snapshot, or clear it first with replace=true. Include frame for an iframe target. Sensitive values are never returned.',
     parameters: {
-      ...OBJECT_SCHEMA,
       index: { type: 'number', required: true, description: 'Form-field index from the browser_snapshot forms inventory.' },
       frame: FRAME_PARAMETER,
       text: { type: 'string', required: true, description: 'Text to enter.' },
@@ -170,11 +162,10 @@ function defineTools(call: Call, options: BrowserToolsOptions): ToolDefinition[]
     },
   })
 
-  const press = (): ToolDefinition => ({
+  const press = (): ToolDefinition => defineTool({
     name: 'browser_press',
     description: 'Send one key press, such as Enter, Tab, Escape, an arrow, Backspace, or Delete.',
     parameters: {
-      ...OBJECT_SCHEMA,
       key: { type: 'string', required: true, description: 'Key name using KeyboardEvent.key semantics.' },
       frame: FRAME_PARAMETER,
     },
@@ -183,11 +174,10 @@ function defineTools(call: Call, options: BrowserToolsOptions): ToolDefinition[]
     execute: (args, exec) => call(exec, 'browser_press', args as Record<string, unknown>),
   })
 
-  const scroll = (): ToolDefinition => ({
+  const scroll = (): ToolDefinition => defineTool({
     name: 'browser_scroll',
     description: 'Scroll up, down, top, or bottom; amount is optional pixels.',
     parameters: {
-      ...OBJECT_SCHEMA,
       direction: { type: 'string', required: true, enum: ['up', 'down', 'top', 'bottom'], description: 'Scroll direction.' },
       amount: { type: 'number', description: 'Number of pixels to scroll; ignored for top and bottom.' },
       frame: FRAME_PARAMETER,
@@ -204,11 +194,10 @@ function defineTools(call: Call, options: BrowserToolsOptions): ToolDefinition[]
     },
   })
 
-  const navigate = (): ToolDefinition => ({
+  const navigate = (): ToolDefinition => defineTool({
     name: 'browser_navigate',
     description: 'Navigate the controlled tab to an HTTP(S) URL while preserving its login state.',
     parameters: {
-      ...OBJECT_SCHEMA,
       url: { type: 'string', required: true, description: 'Complete http or https URL.' },
     },
     timeoutMs: options.toolTimeoutMs,
@@ -216,20 +205,19 @@ function defineTools(call: Call, options: BrowserToolsOptions): ToolDefinition[]
     execute: (args, exec) => call(exec, 'browser_navigate', args as Record<string, unknown>),
   })
 
-  const simple = (name: 'browser_back' | 'browser_forward' | 'browser_reload', description: string): ToolDefinition => ({
+  const simple = (name: 'browser_back' | 'browser_forward' | 'browser_reload', description: string): ToolDefinition => defineTool({
     name,
     description,
-    parameters: { ...OBJECT_SCHEMA, properties: {} },
+    parameters: {},
     timeoutMs: options.toolTimeoutMs,
     output: TEXT_OUTPUT,
     execute: (_args, exec) => call(exec, name, {}),
   })
 
-  const getText = (): ToolDefinition => ({
+  const getText = (): ToolDefinition => defineTool({
     name: 'browser_get_text',
     description: `Read plain text from the page or a selector. ${UNTRUSTED_CONTENT_WARNING}`,
     parameters: {
-      ...OBJECT_SCHEMA,
       selector: { type: 'string', description: 'CSS selector. Omit to read the whole page.' },
       frame: FRAME_PARAMETER,
     },
@@ -244,11 +232,10 @@ function defineTools(call: Call, options: BrowserToolsOptions): ToolDefinition[]
     },
   })
 
-  const wait = (): ToolDefinition => ({
+  const wait = (): ToolDefinition => defineTool({
     name: 'browser_wait',
     description: 'Wait for loading and DOM changes to settle, with an optional extra delay.',
     parameters: {
-      ...OBJECT_SCHEMA,
       ms: { type: 'number', description: 'Additional milliseconds to wait. Omit to perform only the settle check.' },
       frame: FRAME_PARAMETER,
     },

--- a/packages/browser/bridge-browser/tests/tools.spec.ts
+++ b/packages/browser/bridge-browser/tests/tools.spec.ts
@@ -121,13 +121,20 @@ describe('registerBrowserTools', () => {
     expect(requestTool).toHaveBeenLastCalledWith('browser_wait', { frame: 4 }, exec.signal, 1_000)
   })
 
-  it('declares a JSON Schema object root on every tool (empty objects serialize to type:null and get 400)', () => {
+  it('normalizes every DSH parameter map to JSON Schema before registration', () => {
     const { ctx, bridge, registered } = makeHarness()
     registerBrowserTools(ctx, bridge, { toolTimeoutMs: 1_000, snapshotMaxChars: 12_000, maxInteractiveItems: 60 })
     for (const { definition } of registered) {
-      const params = definition.parameters as { type?: unknown }
+      const params = definition.parameters as { type?: unknown; properties?: unknown }
       expect(params.type).toBe('object')
+      expect(params.properties).toBeDefined()
     }
+    const click = registered.find(({ name }) => name === 'browser_click')!.definition.parameters as {
+      properties: Record<string, unknown>
+      required?: string[]
+    }
+    expect(click.properties.index).toBeDefined()
+    expect(click.required).toContain('index')
   })
 
   it('declares cooperative timeoutMs on every tool', () => {
@@ -160,12 +167,12 @@ describe('registerBrowserTools', () => {
     registerBrowserTools(ctx, bridge, { toolTimeoutMs: 5_000, snapshotMaxChars: 12_000, maxInteractiveItems: 60 })
     const byName = new Map(registered.map((entry) => [entry.name, entry.definition]))
     for (const name of ['browser_click', 'browser_type', 'browser_press', 'browser_scroll', 'browser_get_text', 'browser_wait']) {
-      const params = byName.get(name)!.parameters as { frame?: { type?: unknown } }
-      expect(params.frame?.type).toBe('number')
+      const params = byName.get(name)!.parameters as { properties: { frame?: { type?: unknown } } }
+      expect(params.properties.frame?.type).toBe('number')
     }
     for (const name of ['browser_snapshot', 'browser_navigate', 'browser_back', 'browser_forward', 'browser_reload']) {
-      const params = byName.get(name)!.parameters as { frame?: unknown }
-      expect(params.frame).toBeUndefined()
+      const params = byName.get(name)!.parameters as { properties: { frame?: unknown } }
+      expect(params.properties.frame).toBeUndefined()
     }
   })
 


### PR DESCRIPTION
## Summary

- define every browser tool through `defineTool()` before registering it
- keep parameters in the DSH authoring DSL and let DSH emit valid JSON Schema
- express the shared text output schema with DSL-style per-property requiredness
- add regression coverage for object roots, properties, required fields, and iframe routing

## Problem

The bridge registered authoring-time parameter maps as if they were final `ToolDefinition` JSON Schemas. Parameterized browser tools therefore reached OpenAI-compatible Responses endpoints with malformed shapes, while no-argument tools could be sent with an empty `{}` schema. LM Studio rejected the request before generation, for example:

```text
OpenAI API error (400): {"message":"Invalid input","type":"invalid_request_error","param":"tools.3","code":"custom"}
```

Using `defineTool()` at each factory boundary compiles the DSH DSL into a registry-ready schema, including `{ type: "object", properties: ... }` and top-level required arrays.

## Validation

- `TMPDIR=/tmp pnpm test` (274 tests)
- `pnpm typecheck`
- `pnpm build`
- manually verified a local LM Studio `openai-responses` model can complete a Web turn with the browser tools loaded

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR normalizes browser tool definitions through `defineTool()` so authoring-time DSL parameter and output maps become registry-ready JSON Schemas.

- Wraps every browser tool definition with `defineTool()`.
- Rewrites the shared text output schema using DSL-style property requiredness.
- Adds regression coverage for object roots, properties, required parameters, and iframe routing.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete changed-code defect identified.

The normalized schemas are asserted after registration, and the existing execution coverage continues to verify argument forwarding and iframe routing.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/browser/bridge-browser/src/tools.ts | Normalizes all browser tool parameter and output declarations through `defineTool()` while retaining existing execution forwarding. |
| packages/browser/bridge-browser/tests/tools.spec.ts | Updates schema assertions for normalized definitions and verifies required fields and iframe-capable parameter placement. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Browser tool DSL definition] --> B[defineTool normalization]
  B --> C[JSON Schema object root]
  B --> D[Properties and required arrays]
  C --> E[Tool registry]
  D --> E
  E --> F[OpenAI-compatible provider]
  E --> G[Browser bridge execution]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(browser): normalize tool schemas bef..."](https://github.com/lum1104/dsh-browser/commit/f745d2819ccb4cedf4f94f8d83939d54c5c5094b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54213744)</sub>

<!-- /greptile_comment -->