### PR TITLE
fix(panel): make settings view scrollable

### DIFF
--- a/extensions/dsh-browser/manifest.json
+++ b/extensions/dsh-browser/manifest.json
@@ -3,7 +3,7 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "minimum_chrome_version": "116",
   "permissions": [
     "sidePanel",

--- a/extensions/dsh-browser/package.json
+++ b/extensions/dsh-browser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-browser-extension",
   "description": "Chrome MV3 extension: sidebar chat with a local dsh instance and text-only read/operate of a user-controlled tab through the dsh browser bridge",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Yuxiang Lin",
   "license": "MIT",
   "private": true,

--- a/extensions/dsh-browser/src/panel/styles.css
+++ b/extensions/dsh-browser/src/panel/styles.css
@@ -1292,13 +1292,16 @@ textarea:focus-visible {
 .settings {
   display: flex;
   width: 100%;
-  min-height: 100vh;
-  min-height: 100dvh;
+  height: 100vh;
+  height: 100dvh;
+  min-height: 0;
   flex-direction: column;
   gap: 16px;
   overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 18px 16px 24px;
   background: var(--canvas);
+  scrollbar-gutter: stable;
 }
 
 .settings-heading {

--- a/extensions/dsh-browser/tests/panel-styles.spec.ts
+++ b/extensions/dsh-browser/tests/panel-styles.spec.ts
@@ -1,0 +1,16 @@
+// @vitest-environment jsdom
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('panel layout styles', () => {
+  it('keeps the settings view within the viewport so overflowing content scrolls', () => {
+    const styles = readFileSync(`${process.cwd()}/src/panel/styles.css`, 'utf8')
+    const settingsRule = styles.match(/\.settings\s*\{([^}]*)\}/)?.[1]
+
+    expect(settingsRule).toBeDefined()
+    expect(settingsRule).toMatch(/(?:^|\n)\s*height:\s*100vh;/)
+    expect(settingsRule).toMatch(/(?:^|\n)\s*height:\s*100dvh;/)
+    expect(settingsRule).toMatch(/(?:^|\n)\s*overflow-y:\s*auto;/)
+    expect(settingsRule).toMatch(/(?:^|\n)\s*overscroll-behavior:\s*contain;/)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-browser",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Standalone dsh browser bridge and controlled-tab Chrome extension workspace",
   "author": "Yuxiang Lin",
   "license": "MIT",

--- a/packages/browser/bridge-browser/package.json
+++ b/packages/browser/bridge-browser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yuxianglin/dsh-bridge-browser",
   "description": "Bridge plugin: token-authenticated WebSocket carrier for the browser extension plus text-only browser_* tools that drive the user's Chrome via that extension",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": "Yuxiang Lin",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
## Summary

- constrain the settings view to the sidebar viewport so overflowing content forms a scroll container
- contain overscroll and reserve stable scrollbar space
- add a regression test for the settings viewport and overflow contract

## Root cause

The settings view used `min-height: 100dvh`. When the trusted-origin list grew, the element expanded with its content instead of overflowing. Because the outer document hides overflow, content below the viewport was clipped and unreachable.

## Impact

Users can scroll through long always-allowed domain lists and reach the save/cancel controls at the bottom of the settings view.

## Validation

- `pnpm --filter dsh-browser-extension exec vitest run tests/panel-styles.spec.ts`
- `pnpm typecheck`
- `pnpm test` (275 tests passed)
- `pnpm build`
- browser check at a 420×700 sidebar viewport: 912px of settings content scrolled to the bottom and exposed the action buttons

Fixes #33

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR constrains the settings view to the sidebar viewport and makes overflowing settings content independently scrollable. It also adds a CSS contract regression test and updates workspace version metadata.
- Replaces minimum viewport height with fixed viewport height and enables contained vertical scrolling.
- Reserves stable scrollbar space and prevents scroll chaining.
- Adds assertions covering the settings viewport and overflow declarations.
- Bumps the extension, workspace, and browser-bridge package versions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| extensions/dsh-browser/src/panel/styles.css | Constrains the settings container to the dynamic viewport and adds contained scrolling without an identified blocking failure. |
| extensions/dsh-browser/tests/panel-styles.spec.ts | Adds a focused regression test asserting the CSS declarations required by the scrolling contract. |
| extensions/dsh-browser/manifest.json | Updates the Chrome extension version consistently with its package metadata. |
| extensions/dsh-browser/package.json | Updates the extension package version to 0.1.1. |
| package.json | Updates the workspace version to 0.1.1. |
| packages/browser/bridge-browser/package.json | Updates the private browser-bridge workspace package version to 0.0.2 without affecting linked dependency resolution. |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore: bump package versions"](https://github.com/lum1104/dsh-browser/commit/82eed45837c8878727f6231b0ca0fec2049ccc0a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54825652)</sub>

<!-- /greptile_comment -->