### PR TITLE
chore: bump package versions after v0.1.1

### DIFF
--- a/extensions/dsh-browser/manifest.json
+++ b/extensions/dsh-browser/manifest.json
@@ -3,7 +3,7 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "minimum_chrome_version": "116",
   "permissions": [
     "sidePanel",

--- a/extensions/dsh-browser/package.json
+++ b/extensions/dsh-browser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-browser-extension",
   "description": "Chrome MV3 extension: sidebar chat with a local dsh instance and text-only read/operate of a user-controlled tab through the dsh browser bridge",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "Yuxiang Lin",
   "license": "MIT",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-browser",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Standalone dsh browser bridge and controlled-tab Chrome extension workspace",
   "author": "Yuxiang Lin",
   "license": "MIT",

--- a/packages/browser/bridge-browser/package.json
+++ b/packages/browser/bridge-browser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yuxianglin/dsh-bridge-browser",
   "description": "Bridge plugin: token-authenticated WebSocket carrier for the browser extension plus text-only browser_* tools that drive the user's Chrome via that extension",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": "Yuxiang Lin",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
## Summary

- bump the workspace, extension package, and Chrome manifest from `0.1.1` to `0.1.2`
- bump the private browser bridge package from `0.0.2` to `0.0.3`
- keep the upstream dsh dependency line unchanged

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- bridge non-E2E tests: 97 passed
- extension tests: 206 passed
- targeted update/version tests: 9 passed
- `pnpm build`
- `git diff --check`

## E2E note

The real Chrome bridge E2E was attempted twice and hit two different environment/lifecycle timing failures: one controlled-tab closure before approval and one panel connection timeout. No implementation code changed in this PR; all deterministic checks pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR advances the release metadata after v0.1.1 without changing implementation behavior.
- Bumps the workspace, extension package, and Chrome manifest versions from 0.1.1 to 0.1.2.
- Bumps the private browser bridge package from 0.0.2 to 0.0.3.
- Leaves dependency versions and runtime behavior unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the version metadata is internally consistent and does not alter dependencies or runtime behavior.

The extension package and Chrome manifest remain synchronized, the bridge follows its independent version line, and pnpm's lockfile does not require changes for these workspace-version-only edits.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| extensions/dsh-browser/manifest.json | Updates the Chrome extension version to 0.1.2, matching the extension package metadata. |
| extensions/dsh-browser/package.json | Updates the private extension package version to 0.1.2. |
| package.json | Updates the workspace version to 0.1.2 without changing dependencies or scripts. |
| packages/browser/bridge-browser/package.json | Updates the private bridge package's independent release version to 0.0.3. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: bump package versions after v0.1...."](https://github.com/lum1104/dsh-browser/commit/11878b176c576cf91fbb27d5402d23a853a61ca3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55489131)</sub>

<!-- /greptile_comment -->