### PR TITLE
fix(install): make installer work on Linux and macOS without pbcopy/open

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+<!-- 感谢贡献！请用中文或英文填写，不相关的条目可删除。 -->
+<!-- Thanks for contributing! Fill in Chinese or English; delete sections that don't apply. -->
+
+## 概述 / Summary
+
+<!-- 一句话说明这个 PR 做了什么。 -->
+<!-- One-sentence description of what this PR does. -->
+
+## 动机 / Motivation
+
+<!-- 为什么需要这个改动？解决了什么问题或背景是什么。 -->
+<!-- Why is this change needed? What problem does it solve? -->
+
+## 改动内容 / Changes
+
+<!-- 列出关键改动点。 -->
+<!-- List the key changes. -->
+
+-
+
+## 测试 / Testing
+
+<!-- 说明如何验证，例如命令、平台、浏览器版本等。 -->
+<!-- How was this verified: commands, platforms, browser versions, etc. -->
+
+-
+
+## 影响范围 / Impact
+
+<!-- 会影响哪些平台（macOS / Linux / Windows / Chrome / Firefox）或用户。 -->
+<!-- Which platforms (macOS / Linux / Windows / Chrome / Firefox) or users are affected. -->
+
+-
+
+## Checklist
+
+- [ ] 已在相关平台实测通过 / Tested on the relevant platforms
+- [ ] 已通过 `pnpm run build` / `bash -n scripts/install.sh` 等基础检查 / Passed basic checks
+- [ ] 文档已同步更新（如需要）/ Docs updated if needed
+- [ ] 不包含无关改动 / No unrelated changes included

--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -1,5 +1,5 @@
 # Bilingual consistency record for the repository README files.
 # README.md is the default English page; README.zh.md is its Chinese counterpart.
 # Values are git blob hashes from the last confirmed-consistent review.
-README.md: ec95b9b5f35aa00653b4f50318ed4fe894e58d83
-README.zh.md: 9a47c593cc82fdd88e95e610251e0cfb0e7b8136
+README.md: ed2444da7e41168c79a0a6ef720f8ca9af5ca727
+README.zh.md: 1a41f13ab0f368b904ad2b53ccf70a2a4a9b9652

--- a/README.md
+++ b/README.md
@@ -12,10 +12,18 @@ Browser operation remains text-only: pages become structured text with a numbere
 
 ## Quick install
 
-The standard `dsh plugin` command alone cannot install this project. The integration contains both a dsh bridge plugin and a browser extension. The one-line installer currently sets up the Chrome build:
+The standard `dsh plugin` command alone cannot install this project. The integration contains both a dsh bridge plugin and a browser extension. The one-line installer currently sets up the Chrome build.
+
+macOS and Linux:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/Lum1104/dsh-browser/refs/heads/main/scripts/install.sh | bash
+```
+
+Windows, in PowerShell:
+
+```powershell
+$s="$env:TEMP\dsh-install.ps1"; irm https://raw.githubusercontent.com/Lum1104/dsh-browser/refs/heads/main/scripts/install.ps1 -OutFile $s; powershell -NoProfile -ExecutionPolicy Bypass -File $s
 ```
 
 When the installer opens `chrome://extensions`, follow its instructions to load or reload **dsh Browser Assistant**. If dsh is already running, restart it after installation. See [Detailed installation and usage](#detailed-installation-and-usage) for prerequisites, startup commands, updates, and developer installation.
@@ -55,6 +63,7 @@ packages/browser/bridge-browser/
   cordis.patch.yml
 extensions/dsh-browser/
 scripts/install.sh
+scripts/install.ps1
 ```
 
 ## Why this design
@@ -66,7 +75,7 @@ scripts/install.sh
 
 ## Detailed installation and usage
 
-Requirements: Node.js `^22.19` or `>=24`, Corepack/pnpm, and Chrome 116+ or Firefox 140+.
+Requirements: Node.js `^22.19` or `>=24`, Corepack/pnpm, and Chrome 116+ or Firefox 140+. Windows additionally needs Windows PowerShell 5.1, which ships with Windows, or PowerShell 7+.
 
 ### Install or update
 
@@ -76,9 +85,17 @@ For a managed installation, run:
 curl -fsSL https://raw.githubusercontent.com/Lum1104/dsh-browser/refs/heads/main/scripts/install.sh | bash
 ```
 
+or, on Windows:
+
+```powershell
+$s="$env:TEMP\dsh-install.ps1"; irm https://raw.githubusercontent.com/Lum1104/dsh-browser/refs/heads/main/scripts/install.ps1 -OutFile $s; powershell -NoProfile -ExecutionPolicy Bypass -File $s
+```
+
 The installer downloads `main`, builds and registers the bridge plugin, builds the Chrome extension into `~/.dsh/browser-extension`, and opens `chrome://extensions`. On the first install, load that directory as an unpacked extension; on updates, click **Reload**. Restart dsh if it is already running.
 
-The installer supports macOS and Linux. It copies the extension path to the clipboard when `pbcopy`, `wl-copy`, `xclip`, or `xsel` is available, and prints the path either way. When no Chrome or Chromium install is found, it prints the command that installs one; set `DSH_INSTALL_BROWSER=1` to let the installer attempt that install itself.
+`scripts/install.sh` covers macOS and Linux, and `scripts/install.ps1` covers Windows; both write the same managed workspace and the same install metadata. The installer copies the extension path to the clipboard when a clipboard tool is available (`pbcopy`, `wl-copy`, `xclip`, `xsel`, or PowerShell's `Set-Clipboard`), and prints the path either way. When no Chrome or Chromium install is found, it prints the command that installs one; set `DSH_INSTALL_BROWSER=1` to let the installer attempt that install itself.
+
+The Windows command downloads `install.ps1` and runs it rather than piping it into `Invoke-Expression`: the script is UTF-8 with a byte order mark so Windows PowerShell renders its Chinese output, and `Invoke-Expression` rejects a leading mark.
 
 To install the current branch from a source checkout instead:
 
@@ -88,7 +105,7 @@ cd dsh-browser
 ./scripts/install.sh
 ```
 
-After pulling or switching revisions, rerun `./scripts/install.sh` and reload the extension.
+On Windows, run `.\scripts\install.ps1` from the checkout instead. After pulling or switching revisions, rerun the installer and reload the extension.
 
 ### Firefox source build
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ curl -fsSL https://raw.githubusercontent.com/Lum1104/dsh-browser/refs/heads/main
 
 The installer downloads `main`, builds and registers the bridge plugin, builds the Chrome extension into `~/.dsh/browser-extension`, and opens `chrome://extensions`. On the first install, load that directory as an unpacked extension; on updates, click **Reload**. Restart dsh if it is already running.
 
+The installer supports macOS and Linux. It copies the extension path to the clipboard when `pbcopy`, `wl-copy`, `xclip`, or `xsel` is available, and prints the path either way. When no Chrome or Chromium install is found, it prints the command that installs one; set `DSH_INSTALL_BROWSER=1` to let the installer attempt that install itself.
+
 To install the current branch from a source checkout instead:
 
 ```sh

--- a/README.zh.md
+++ b/README.zh.md
@@ -78,6 +78,8 @@ curl -fsSL https://raw.githubusercontent.com/Lum1104/dsh-browser/refs/heads/main
 
 安装器会下载 `main`、构建并注册桥插件、把 Chrome 扩展构建到 `~/.dsh/browser-extension`，然后打开 `chrome://extensions`。首次安装时，请把该目录作为已解压扩展加载；更新时点击**重新加载**。如果 dsh 已在运行，请重启。
 
+安装器支持 macOS 与 Linux。当系统提供 `pbcopy`、`wl-copy`、`xclip` 或 `xsel` 时，会把扩展路径复制到剪贴板；无论是否复制成功都会打印该路径。若未检测到 Chrome/Chromium，安装器会打印对应的安装命令；设置 `DSH_INSTALL_BROWSER=1` 可让安装器尝试自动安装。
+
 如需从源码 checkout 安装当前分支：
 
 ```sh

--- a/README.zh.md
+++ b/README.zh.md
@@ -12,10 +12,18 @@
 
 ## 快速安装
 
-本项目不能只使用标准的 `dsh plugin` 命令安装。它同时包含 dsh bridge plugin 和浏览器扩展。一行安装器目前会安装 Chrome 构建：
+本项目不能只使用标准的 `dsh plugin` 命令安装。它同时包含 dsh bridge plugin 和浏览器扩展。一行安装器目前会安装 Chrome 构建。
+
+macOS 与 Linux：
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/Lum1104/dsh-browser/refs/heads/main/scripts/install.sh | bash
+```
+
+Windows（PowerShell）：
+
+```powershell
+$s="$env:TEMP\dsh-install.ps1"; irm https://raw.githubusercontent.com/Lum1104/dsh-browser/refs/heads/main/scripts/install.ps1 -OutFile $s; powershell -NoProfile -ExecutionPolicy Bypass -File $s
 ```
 
 安装器打开 `chrome://extensions` 后，请按提示加载或重新加载 **dsh 浏览器助手**。如果 dsh 已经在运行，安装完成后请重启。前置要求、启动命令、更新方式和开发者安装详见[详细安装与使用](#详细安装与使用)。
@@ -55,6 +63,7 @@ packages/browser/bridge-browser/
   cordis.patch.yml
 extensions/dsh-browser/
 scripts/install.sh
+scripts/install.ps1
 ```
 
 ## 为什么这样设计
@@ -66,7 +75,7 @@ scripts/install.sh
 
 ## 详细安装与使用
 
-前置要求：Node.js `^22.19` 或 `>=24`、Corepack/pnpm，以及 Chrome 116+ 或 Firefox 140+。
+前置要求：Node.js `^22.19` 或 `>=24`、Corepack/pnpm，以及 Chrome 116+ 或 Firefox 140+。Windows 还需要系统自带的 Windows PowerShell 5.1，或 PowerShell 7+。
 
 ### 安装或更新
 
@@ -76,9 +85,17 @@ scripts/install.sh
 curl -fsSL https://raw.githubusercontent.com/Lum1104/dsh-browser/refs/heads/main/scripts/install.sh | bash
 ```
 
+Windows 请运行：
+
+```powershell
+$s="$env:TEMP\dsh-install.ps1"; irm https://raw.githubusercontent.com/Lum1104/dsh-browser/refs/heads/main/scripts/install.ps1 -OutFile $s; powershell -NoProfile -ExecutionPolicy Bypass -File $s
+```
+
 安装器会下载 `main`、构建并注册桥插件、把 Chrome 扩展构建到 `~/.dsh/browser-extension`，然后打开 `chrome://extensions`。首次安装时，请把该目录作为已解压扩展加载；更新时点击**重新加载**。如果 dsh 已在运行，请重启。
 
-安装器支持 macOS 与 Linux。当系统提供 `pbcopy`、`wl-copy`、`xclip` 或 `xsel` 时，会把扩展路径复制到剪贴板；无论是否复制成功都会打印该路径。若未检测到 Chrome/Chromium，安装器会打印对应的安装命令；设置 `DSH_INSTALL_BROWSER=1` 可让安装器尝试自动安装。
+`scripts/install.sh` 覆盖 macOS 与 Linux，`scripts/install.ps1` 覆盖 Windows；两者写入同一个托管工作区和同一份安装元数据。当系统提供剪贴板工具（`pbcopy`、`wl-copy`、`xclip`、`xsel` 或 PowerShell 的 `Set-Clipboard`）时，安装器会把扩展路径复制到剪贴板；无论是否复制成功都会打印该路径。若未检测到 Chrome/Chromium，安装器会打印对应的安装命令；设置 `DSH_INSTALL_BROWSER=1` 可让安装器尝试自动安装。
+
+Windows 命令先下载 `install.ps1` 再执行，而不是管道给 `Invoke-Expression`：脚本是带 BOM 的 UTF-8，Windows PowerShell 依赖 BOM 才能正确显示中文，而 `Invoke-Expression` 无法处理开头的 BOM。
 
 如需从源码 checkout 安装当前分支：
 
@@ -88,7 +105,7 @@ cd dsh-browser
 ./scripts/install.sh
 ```
 
-拉取或切换版本后，请重新运行 `./scripts/install.sh` 并重新加载扩展。
+Windows 请在 checkout 中运行 `.\scripts\install.ps1`。拉取或切换版本后，请重新运行安装器并重新加载扩展。
 
 ### Firefox 源码构建
 

--- a/extensions/dsh-browser/README.i18n.yaml
+++ b/extensions/dsh-browser/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write dsh-browser/extensions/dsh-browser/README.md
-README.md: 2e8debe3971fba5a03899897a75aa662271fc654
-README.zh.md: 28ee058c97f01c5a8171495884cee35cd7a425e9
+README.md: c6e94ce1e1a239c8714df2a15e6fb9f7ca75bd93
+README.zh.md: 3008cc9b1d92c65391c9d489cf0e83985ab0bff5

--- a/extensions/dsh-browser/README.md
+++ b/extensions/dsh-browser/README.md
@@ -56,6 +56,12 @@ The recommended zero-configuration command does not require Git or a local clone
    curl -fsSL https://raw.githubusercontent.com/Lum1104/dsh-browser/refs/heads/main/scripts/install.sh | bash
    ```
 
+   On Windows, run this in PowerShell instead:
+
+   ```powershell
+   $s="$env:TEMP\dsh-install.ps1"; irm https://raw.githubusercontent.com/Lum1104/dsh-browser/refs/heads/main/scripts/install.ps1 -OutFile $s; powershell -NoProfile -ExecutionPolicy Bypass -File $s
+   ```
+
    The script downloads a managed workspace to `~/.dsh/dsh-browser`, builds the bridge plugin, registers its official bundle in the local dsh `web` profile, builds the extension, copies the output to the stable directory `~/.dsh/browser-extension`, and opens `chrome://extensions`. Enable Developer mode, choose Load unpacked, and select the extension directory. Running the command again updates the managed installation.
 
    A cloned checkout uses the same installer without downloading or overwriting source files:
@@ -65,6 +71,8 @@ The recommended zero-configuration command does not require Git or a local clone
    cd dsh-browser
    ./scripts/install.sh
    ```
+
+   Windows checkouts run `.\scripts\install.ps1` instead.
 
 2. **Start dsh with the bridge plugin mounted**. Use either the workspace-pinned runtime:
 

--- a/extensions/dsh-browser/README.zh.md
+++ b/extensions/dsh-browser/README.zh.md
@@ -56,6 +56,12 @@ pnpm --filter dsh-browser-extension run test
    curl -fsSL https://raw.githubusercontent.com/Lum1104/dsh-browser/refs/heads/main/scripts/install.sh | bash
    ```
 
+   Windows 请改在 PowerShell 中运行：
+
+   ```powershell
+   $s="$env:TEMP\dsh-install.ps1"; irm https://raw.githubusercontent.com/Lum1104/dsh-browser/refs/heads/main/scripts/install.ps1 -OutFile $s; powershell -NoProfile -ExecutionPolicy Bypass -File $s
+   ```
+
    脚本会把托管 workspace 下载到 `~/.dsh/dsh-browser`，构建桥插件，把它的官方 bundle 注册到本机 dsh 的 `web` profile，再构建扩展并把产物复制到稳定目录 `~/.dsh/browser-extension`，然后打开 `chrome://extensions`。开启开发者模式，选择「加载已解压的扩展程序」，加载扩展目录。再次运行该命令会更新托管安装。
 
    clone 得到的 checkout 也使用同一个安装器，而且不会下载或覆盖源码：
@@ -65,6 +71,8 @@ pnpm --filter dsh-browser-extension run test
    cd dsh-browser
    ./scripts/install.sh
    ```
+
+   Windows checkout 请运行 `.\scripts\install.ps1`。
 
 2. **启动 dsh 并挂载桥插件**。可以使用 workspace 固定的运行时：
 

--- a/extensions/dsh-browser/src/panel/UpdateCard.tsx
+++ b/extensions/dsh-browser/src/panel/UpdateCard.tsx
@@ -3,8 +3,8 @@ import type { PanelCopy } from './strings.ts'
 import {
   checkForExtensionUpdate,
   checkoutInstallCommand,
+  managedInstallCommand,
   readExtensionInstallInfo,
-  UPDATE_COMMAND,
   type ExtensionInstallInfo,
 } from './updates.ts'
 
@@ -48,7 +48,7 @@ export function UpdateCard({ copy }: { copy: PanelCopy['update'] }): React.JSX.E
 
   async function copyCommand(): Promise<void> {
     const command = installInfo?.mode === 'managed'
-      ? UPDATE_COMMAND
+      ? managedInstallCommand()
       : installInfo?.mode === 'checkout'
         ? checkoutInstallCommand(installInfo.sourceRoot)
         : null

--- a/extensions/dsh-browser/src/panel/updates.ts
+++ b/extensions/dsh-browser/src/panel/updates.ts
@@ -12,6 +12,15 @@ export const UPDATE_MANIFEST_URL =
 export const UPDATE_COMMAND =
   'curl -fsSL https://raw.githubusercontent.com/Lum1104/dsh-browser/refs/heads/main/scripts/install.sh | bash'
 
+/**
+ * install.ps1 carries a UTF-8 BOM so Windows PowerShell renders its Chinese half, and a
+ * leading BOM is exactly what Invoke-Expression refuses, so the file is downloaded and run.
+ */
+export const WINDOWS_UPDATE_COMMAND =
+  '$s="$env:TEMP\\dsh-install.ps1"; '
+  + 'irm https://raw.githubusercontent.com/Lum1104/dsh-browser/refs/heads/main/scripts/install.ps1 -OutFile $s; '
+  + 'powershell -NoProfile -ExecutionPolicy Bypass -File $s'
+
 export interface ExtensionUpdateResult {
   currentVersion: string
   latestVersion: string
@@ -23,6 +32,16 @@ export type ExtensionInstallInfo =
   | { mode: 'checkout'; sourceRoot: string }
   | { mode: 'unknown' }
 
+/** A drive-letter root (C:\dsh-browser) or a UNC share (\\host\share\dsh-browser). */
+function isWindowsPath(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\')
+}
+
+/** Installers only ever record an absolute root, so a relative one is corrupt metadata. */
+function isAbsolutePath(value: string): boolean {
+  return value.startsWith('/') || isWindowsPath(value)
+}
+
 /** Parse installer-written provenance without trusting malformed local data. */
 export function parseExtensionInstallInfo(value: unknown): ExtensionInstallInfo {
   if (typeof value !== 'object' || value === null) return { mode: 'unknown' }
@@ -31,7 +50,7 @@ export function parseExtensionInstallInfo(value: unknown): ExtensionInstallInfo 
   if (info.mode === 'managed') return { mode: 'managed' }
   if (info.mode === 'checkout'
     && typeof info.sourceRoot === 'string'
-    && info.sourceRoot.startsWith('/')
+    && isAbsolutePath(info.sourceRoot)
     && !info.sourceRoot.includes('\0')) {
     return { mode: 'checkout', sourceRoot: info.sourceRoot }
   }
@@ -56,9 +75,27 @@ function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\"'\"'")}'`
 }
 
-/** Re-run the installer from the exact checkout that produced this extension. */
+function powerShellQuote(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`
+}
+
+/**
+ * Re-run the installer from the exact checkout that produced this extension. The recorded
+ * root already says which platform wrote it, so the command matches that shell.
+ */
 export function checkoutInstallCommand(sourceRoot: string): string {
+  if (isWindowsPath(sourceRoot)) {
+    return `cd ${powerShellQuote(sourceRoot)}; .\\scripts\\install.ps1`
+  }
   return `cd ${shellQuote(sourceRoot)} && ./scripts/install.sh`
+}
+
+/**
+ * A managed install records no path, so the panel picks the installer by the platform it is
+ * running on — which is the machine the extension was installed to.
+ */
+export function managedInstallCommand(userAgent: string = navigator.userAgent): string {
+  return /windows/i.test(userAgent) ? WINDOWS_UPDATE_COMMAND : UPDATE_COMMAND
 }
 
 function versionParts(version: string): number[] {

--- a/extensions/dsh-browser/tests/updates.spec.ts
+++ b/extensions/dsh-browser/tests/updates.spec.ts
@@ -5,9 +5,12 @@ import {
   checkForExtensionUpdate,
   checkoutInstallCommand,
   compareExtensionVersions,
+  managedInstallCommand,
   parseExtensionInstallInfo,
   readExtensionInstallInfo,
+  UPDATE_COMMAND,
   UPDATE_MANIFEST_URL,
+  WINDOWS_UPDATE_COMMAND,
 } from '../src/panel/updates.ts'
 
 describe('extension update checks', () => {
@@ -65,6 +68,23 @@ describe('extension update checks', () => {
     expect(parseExtensionInstallInfo({ mode: 'managed' })).toEqual({ mode: 'unknown' })
   })
 
+  it('accepts the absolute roots install.ps1 records on Windows', () => {
+    expect(parseExtensionInstallInfo({
+      schemaVersion: 1,
+      mode: 'checkout',
+      sourceRoot: 'C:\\Users\\example\\dsh-browser',
+    })).toEqual({ mode: 'checkout', sourceRoot: 'C:\\Users\\example\\dsh-browser' })
+    expect(parseExtensionInstallInfo({
+      schemaVersion: 1,
+      mode: 'checkout',
+      sourceRoot: '\\\\build\\share\\dsh-browser',
+    })).toEqual({ mode: 'checkout', sourceRoot: '\\\\build\\share\\dsh-browser' })
+    expect(parseExtensionInstallInfo({ schemaVersion: 1, mode: 'checkout', sourceRoot: 'C:relative' }))
+      .toEqual({ mode: 'unknown' })
+    expect(parseExtensionInstallInfo({ schemaVersion: 1, mode: 'checkout', sourceRoot: 'dsh-browser' }))
+      .toEqual({ mode: 'unknown' })
+  })
+
   it('treats missing or malformed install metadata as unknown', async () => {
     const missing = vi.fn<typeof fetch>().mockResolvedValue(new Response('', { status: 404 }))
     await expect(readExtensionInstallInfo('chrome-extension://id/install-info.json', missing))
@@ -82,6 +102,21 @@ describe('extension update checks', () => {
       .toBe("cd '/Users/example/dev'\"'\"'s checkout' && ./scripts/install.sh")
   })
 
+  it('builds a PowerShell command for a Windows checkout', () => {
+    expect(checkoutInstallCommand('C:\\Users\\example\\My Checkout'))
+      .toBe("cd 'C:\\Users\\example\\My Checkout'; .\\scripts\\install.ps1")
+    expect(checkoutInstallCommand("C:\\Users\\example\\dev's checkout"))
+      .toBe("cd 'C:\\Users\\example\\dev''s checkout'; .\\scripts\\install.ps1")
+    expect(checkoutInstallCommand('\\\\build\\share\\dsh-browser'))
+      .toBe("cd '\\\\build\\share\\dsh-browser'; .\\scripts\\install.ps1")
+  })
+
+  it('picks the managed installer that matches the running platform', () => {
+    expect(managedInstallCommand('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')).toBe(UPDATE_COMMAND)
+    expect(managedInstallCommand('Mozilla/5.0 (X11; Linux x86_64)')).toBe(UPDATE_COMMAND)
+    expect(managedInstallCommand('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')).toBe(WINDOWS_UPDATE_COMMAND)
+  })
+
   it('keeps package, Chrome manifest, and update CSP metadata aligned', () => {
     const extensionRoot = process.cwd()
     const packageManifest = JSON.parse(readFileSync(`${extensionRoot}/package.json`, 'utf8')) as { version: string }
@@ -96,5 +131,20 @@ describe('extension update checks', () => {
     expect(installer).toContain('INSTALL_MODE="managed"')
     expect(installer).toContain('INSTALL_MODE="checkout"')
     expect(installer).toContain('$DIST_DIR/install-info.json')
+  })
+
+  it('keeps the Windows installer writing the same install provenance', () => {
+    const extensionRoot = process.cwd()
+    const installerPath = `${extensionRoot}/../../scripts/install.ps1`
+    const installer = readFileSync(installerPath, 'utf8')
+
+    // Windows PowerShell decodes a BOM-less script with the machine's ANSI codepage, which
+    // turns every Chinese message into mojibake. Losing the BOM is silent, so pin it here.
+    expect(readFileSync(installerPath).subarray(0, 3)).toEqual(Buffer.from([0xef, 0xbb, 0xbf]))
+    expect(installer).toContain("$InstallMode = if (Test-Path")
+    expect(installer).toContain("{ 'managed' } else { 'checkout' }")
+    expect(installer).toContain("Join-Path $DistDir 'install-info.json'")
+    expect(installer).toContain('schemaVersion = 1')
+    expect(WINDOWS_UPDATE_COMMAND).toContain('scripts/install.ps1')
   })
 })

--- a/packages/browser/bridge-browser/README.i18n.yaml
+++ b/packages/browser/bridge-browser/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write dsh-browser/packages/browser/bridge-browser/README.md
-README.md: 08db1ffd5f1b2764dc0919918c0d591dba9a2009
-README.zh.md: e86e615a65c337b344d7a78fd1f315fdc41666e6
+README.md: be7cd420fb1134c32b850e1b443f3773ce51faf7
+README.zh.md: a852ec0ddd62706118f8a90006d5c32839805b2d

--- a/packages/browser/bridge-browser/README.md
+++ b/packages/browser/bridge-browser/README.md
@@ -28,6 +28,13 @@ curl -fsSL https://raw.githubusercontent.com/Lum1104/dsh-browser/refs/heads/main
 cd ~/.dsh/dsh-browser && pnpm start
 ```
 
+On Windows, run the PowerShell installer instead:
+
+```powershell
+$s="$env:TEMP\dsh-install.ps1"; irm https://raw.githubusercontent.com/Lum1104/dsh-browser/refs/heads/main/scripts/install.ps1 -OutFile $s; powershell -NoProfile -ExecutionPolicy Bypass -File $s
+cd $HOME\.dsh\dsh-browser; pnpm start
+```
+
 Developers can instead clone the repository and run `./scripts/install.sh` followed by `pnpm start` from that checkout. The local mode uses the current branch without downloading or overwriting source files. Both installation modes register the same profile bundle; build tools resolve only from the selected workspace and never from a parent checkout or parent `node_modules` directory.
 
 The latest public runtime also loads the registered bundle:

--- a/packages/browser/bridge-browser/README.zh.md
+++ b/packages/browser/bridge-browser/README.zh.md
@@ -28,6 +28,13 @@ curl -fsSL https://raw.githubusercontent.com/Lum1104/dsh-browser/refs/heads/main
 cd ~/.dsh/dsh-browser && pnpm start
 ```
 
+Windows 请改用 PowerShell 安装器：
+
+```powershell
+$s="$env:TEMP\dsh-install.ps1"; irm https://raw.githubusercontent.com/Lum1104/dsh-browser/refs/heads/main/scripts/install.ps1 -OutFile $s; powershell -NoProfile -ExecutionPolicy Bypass -File $s
+cd $HOME\.dsh\dsh-browser; pnpm start
+```
+
 开发者也可以 clone 仓库，在 checkout 中依次运行 `./scripts/install.sh` 和 `pnpm start`。本地模式直接使用当前分支，不会下载或覆盖源码。两种安装模式都会注册同一个 profile bundle；构建工具只从选定的 workspace 解析，绝不读取父 checkout 或父目录的 `node_modules`。
 
 npm 上最新的公开运行时也会加载已注册的 bundle：

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,480 @@
+﻿<#
+.SYNOPSIS
+dsh-browser 一键安装（Windows）：支持远程托管安装和本地 checkout 安装。
+dsh-browser one-command install (Windows): supports both managed remote installs and local checkout installs.
+
+.DESCRIPTION
+之后无需任何配置：扩展自动探测本机 dsh 并连接（回环免 token）。
+No further configuration is required: the extension discovers local dsh automatically and loopback connections require no token.
+
+这是 scripts/install.sh 的 Windows 对应版本，两者共享同一套托管目录与 install-info.json 约定。
+This is the Windows counterpart of scripts/install.sh; both share one managed-root and install-info.json contract.
+#>
+# This file is UTF-8 with a BOM on purpose: Windows PowerShell 5.1 decodes a BOM-less script
+# with the machine's ANSI codepage and turns every Chinese line into mojibake. The BOM is also
+# why the documented one-liner downloads this file and runs it instead of piping it into
+# Invoke-Expression, which chokes on a leading BOM. No param() block, for the same reason: it
+# keeps the script runnable even when someone pipes it in anyway.
+$ErrorActionPreference = 'Stop'
+# Invoke-WebRequest is an order of magnitude slower in Windows PowerShell while it draws a progress bar.
+$ProgressPreference = 'SilentlyContinue'
+
+# Windows PowerShell picks the console codepage, which turns the Chinese half of every
+# message into question marks on a non-Chinese install.
+try { [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding $false } catch { }
+
+$Repository = 'Lum1104/dsh-browser'
+$RemoteRef = 'main'
+$DshHomeDir = if ($env:DSH_HOME) { $env:DSH_HOME } else { Join-Path $HOME '.dsh' }
+$ManagedRoot = Join-Path $DshHomeDir 'dsh-browser'
+# Same marker filename as scripts/install.sh: one managed root, one definition of "managed".
+$ManagedMarker = Join-Path $ManagedRoot '.managed-by-install-sh'
+$ArchiveUrl = "https://github.com/$Repository/archive/refs/heads/$RemoteRef.zip"
+$LegacyPlugin = '@deepseek-ai/dsh-bridge-browser'
+$BridgePlugin = '@yuxianglin/dsh-bridge-browser'
+
+function Write-Step {
+  param([int]$Number, [string]$Zh, [string]$En)
+  Write-Host ''
+  Write-Host ("[{0}/4] {1}" -f $Number, $Zh)
+  Write-Host ("      {0}" -f $En)
+}
+
+function Write-Pair {
+  param([string]$Zh, [string]$En)
+  Write-Host $Zh
+  Write-Host ("   {0}" -f $En)
+}
+
+function Stop-Install {
+  param([string]$Zh, [string]$En)
+  Write-Host ''
+  [Console]::Error.WriteLine("错误：$Zh")
+  [Console]::Error.WriteLine("Error: $En")
+  exit 1
+}
+
+function Test-Workspace {
+  param([string]$Candidate)
+
+  if (-not $Candidate) { return $false }
+  foreach ($relative in @(
+      'package.json',
+      'pnpm-lock.yaml',
+      'extensions\dsh-browser\package.json',
+      'packages\browser\bridge-browser\package.json',
+      'scripts\install.ps1')) {
+    if (-not (Test-Path -LiteralPath (Join-Path $Candidate $relative) -PathType Leaf)) { return $false }
+  }
+  return $true
+}
+
+function Get-WorkspaceRoot {
+  # $PSScriptRoot is empty when the script arrives through `irm ... | iex`, which is exactly
+  # the case that has to fall through to the managed install.
+  if (-not $PSScriptRoot) { return $null }
+  $candidate = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).ProviderPath
+  if (Test-Workspace $candidate) { return $candidate }
+  return $null
+}
+
+function Test-Command {
+  param([string]$Name)
+  return [bool](Get-Command -Name $Name -ErrorAction SilentlyContinue)
+}
+
+function Assert-Command {
+  param([string]$Name, [string]$Zh, [string]$En)
+  if (-not (Test-Command $Name)) { Stop-Install $Zh $En }
+}
+
+function Test-ExcludedPath {
+  param([string]$RelativePath, [hashtable]$Excluded)
+
+  foreach ($segment in $RelativePath.Split([char]'\', [char]'/')) {
+    if ($segment -and $Excluded.ContainsKey($segment)) { return $true }
+  }
+  return $false
+}
+
+function Get-SyncEntry {
+  <#
+    Walk $Root breadth-first without ever descending into an excluded directory, so a
+    node_modules tree costs nothing instead of dominating the walk.
+  #>
+  param([string]$Root, [hashtable]$Excluded)
+
+  $entries = New-Object System.Collections.Generic.List[object]
+  $pending = New-Object System.Collections.Generic.Queue[string]
+  $pending.Enqueue('')
+
+  while ($pending.Count -gt 0) {
+    $relativeDir = $pending.Dequeue()
+    $absoluteDir = if ($relativeDir) { Join-Path $Root $relativeDir } else { $Root }
+    foreach ($child in @(Get-ChildItem -LiteralPath $absoluteDir -Force)) {
+      if ($Excluded.ContainsKey($child.Name)) { continue }
+      $relative = if ($relativeDir) { Join-Path $relativeDir $child.Name } else { $child.Name }
+      $entries.Add([pscustomobject]@{ Relative = $relative; Item = $child })
+      if ($child.PSIsContainer) { $pending.Enqueue($relative) }
+    }
+  }
+  return $entries
+}
+
+function Sync-Directory {
+  <#
+    The `rsync -a --delete-after` the Unix installer relies on: copy everything across first,
+    then drop whatever the source no longer has. Excluded names are skipped on both sides, so
+    node_modules and the managed marker survive the purge instead of being treated as extra.
+  #>
+  param(
+    [Parameter(Mandatory = $true)][string]$Source,
+    [Parameter(Mandatory = $true)][string]$Destination,
+    [string[]]$ExcludeName = @()
+  )
+
+  $sourceRoot = (Resolve-Path -LiteralPath $Source).ProviderPath.TrimEnd('\')
+  if (-not (Test-Path -LiteralPath $Destination)) {
+    New-Item -ItemType Directory -Path $Destination -Force | Out-Null
+  }
+  $destinationRoot = (Resolve-Path -LiteralPath $Destination).ProviderPath.TrimEnd('\')
+
+  $excluded = @{}
+  foreach ($name in $ExcludeName) { $excluded[$name] = $true }
+
+  $keep = @{}
+  foreach ($entry in @(Get-SyncEntry -Root $sourceRoot -Excluded $excluded)) {
+    $keep[$entry.Relative] = $true
+    $target = Join-Path $destinationRoot $entry.Relative
+    if ($entry.Item.PSIsContainer) {
+      if (-not (Test-Path -LiteralPath $target -PathType Container)) {
+        New-Item -ItemType Directory -Path $target -Force | Out-Null
+      }
+      continue
+    }
+    $existing = Get-Item -LiteralPath $target -Force -ErrorAction SilentlyContinue
+    if ($existing -and -not $existing.PSIsContainer -and
+        $existing.Length -eq $entry.Item.Length -and
+        $existing.LastWriteTimeUtc -eq $entry.Item.LastWriteTimeUtc) {
+      continue
+    }
+    $parent = Split-Path -Parent $target
+    if ($parent -and -not (Test-Path -LiteralPath $parent -PathType Container)) {
+      New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    }
+    Copy-Item -LiteralPath $entry.Item.FullName -Destination $target -Force
+  }
+
+  $stale = @(Get-SyncEntry -Root $destinationRoot -Excluded $excluded |
+    Where-Object { -not $keep.ContainsKey($_.Relative) })
+  # Deepest first: removing a child before its parent keeps Remove-Item off already-gone paths.
+  foreach ($entry in @($stale | Sort-Object { $_.Relative.Length } -Descending)) {
+    if (Test-Path -LiteralPath $entry.Item.FullName) {
+      Remove-Item -LiteralPath $entry.Item.FullName -Recurse -Force
+    }
+  }
+}
+
+function Test-ProfileDependency {
+  param([string]$Manifest, [string]$PackageName)
+
+  if (-not (Test-Path -LiteralPath $Manifest -PathType Leaf)) { return $false }
+  try {
+    $parsed = Get-Content -LiteralPath $Manifest -Raw -Encoding UTF8 | ConvertFrom-Json
+  } catch {
+    return $false
+  }
+  if ($null -eq $parsed -or $null -eq $parsed.dependencies) { return $false }
+  return [bool]($parsed.dependencies.PSObject.Properties.Name -contains $PackageName)
+}
+
+function Get-BrowserPath {
+  <# Echoes the path to a local Chrome/Chromium executable, or $null when none is installed. #>
+  $candidates = New-Object System.Collections.Generic.List[string]
+  foreach ($base in @($env:ProgramFiles, ${env:ProgramFiles(x86)}, $env:LOCALAPPDATA)) {
+    if (-not $base) { continue }
+    $candidates.Add((Join-Path $base 'Google\Chrome\Application\chrome.exe'))
+    $candidates.Add((Join-Path $base 'Google\Chrome SxS\Application\chrome.exe'))
+    $candidates.Add((Join-Path $base 'Chromium\Application\chrome.exe'))
+  }
+  foreach ($candidate in $candidates) {
+    if (Test-Path -LiteralPath $candidate -PathType Leaf) { return $candidate }
+  }
+
+  # Fallback: a browser installed outside those roots still registers an App Paths entry.
+  foreach ($hive in @('HKLM:', 'HKCU:')) {
+    foreach ($exe in @('chrome.exe', 'chromium.exe')) {
+      $key = "$hive\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\$exe"
+      try {
+        $registered = (Get-ItemProperty -LiteralPath $key -ErrorAction Stop).'(default)'
+      } catch {
+        continue
+      }
+      if ($registered -and (Test-Path -LiteralPath $registered -PathType Leaf)) { return $registered }
+    }
+  }
+  return $null
+}
+
+function Start-ExtensionsPage {
+  param([string]$BrowserPath)
+
+  if (-not $BrowserPath) { return $false }
+  try {
+    # Start-Process returns as soon as the browser is launched, so the instructions below
+    # print immediately even on a first run that opens a brand new window.
+    Start-Process -FilePath $BrowserPath -ArgumentList 'chrome://extensions' | Out-Null
+    return $true
+  } catch {
+    return $false
+  }
+}
+
+function Set-ClipboardText {
+  param([string]$Text)
+
+  try {
+    Set-Clipboard -Value $Text -ErrorAction Stop
+    return $true
+  } catch {
+    return $false
+  }
+}
+
+function Write-BrowserInstallHint {
+  if (Test-Command 'winget') {
+    Write-Pair "请手动安装：winget install --id Google.Chrome --exact" "Install it manually: winget install --id Google.Chrome --exact"
+  } else {
+    Write-Pair "请手动安装 Google Chrome：https://www.google.com/chrome/" "Install Google Chrome manually: https://www.google.com/chrome/"
+  }
+}
+
+function Install-Browser {
+  if (-not (Test-Command 'winget')) {
+    Write-Pair "未找到 winget，无法自动安装。" "winget was not found, so the browser cannot be installed automatically."
+    Write-BrowserInstallHint
+    return
+  }
+  $previousPreference = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  try {
+    & winget install --id Google.Chrome --exact --silent --accept-package-agreements --accept-source-agreements 2>&1 | Out-Null
+  } catch {
+    Write-Pair "自动安装过程中出错。" "The automatic installation reported an error."
+  } finally {
+    $ErrorActionPreference = $previousPreference
+  }
+}
+
+function Confirm-Browser {
+  if (Get-BrowserPath) { return $true }
+
+  Write-Pair "未检测到 Chrome/Chromium 浏览器。" "No Chrome/Chromium browser was detected."
+
+  # Installing a browser is a surprising side effect for a one-line installer, so it stays
+  # opt-in, exactly as scripts/install.sh does on Linux and macOS.
+  if ($env:DSH_INSTALL_BROWSER -ne '1') {
+    Write-BrowserInstallHint
+    Write-Pair "安装后重新运行本脚本；或设置 DSH_INSTALL_BROWSER=1 让脚本尝试自动安装。" "Install it and rerun this script, or set DSH_INSTALL_BROWSER=1 to let the installer attempt it."
+    return $false
+  }
+
+  Write-Pair "DSH_INSTALL_BROWSER=1，尝试自动安装……" "DSH_INSTALL_BROWSER=1 is set; attempting to install…"
+  Install-Browser
+
+  if (Get-BrowserPath) { return $true }
+  Write-Pair "自动安装未完成，本次安装会继续，但需要你手动安装浏览器后再加载扩展。" "Automatic browser installation did not complete; continuing, but install a browser manually before loading the extension."
+  return $false
+}
+
+function Invoke-Quiet {
+  <# Run a build/registration command silently, and surface its output only when it fails. #>
+  param(
+    [Parameter(Mandatory = $true)][string]$WorkingDirectory,
+    [Parameter(Mandatory = $true)][string]$Command,
+    [Parameter(Mandatory = $true)][string[]]$Arguments,
+    [Parameter(Mandatory = $true)][string]$FailZh,
+    [Parameter(Mandatory = $true)][string]$FailEn
+  )
+
+  Push-Location -LiteralPath $WorkingDirectory
+  # PowerShell 7.3+ turns a native command's stderr into a terminating error while
+  # $ErrorActionPreference is Stop; a non-zero exit code is the signal we actually want.
+  $previousPreference = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  $code = $null
+  try {
+    $output = & $Command @Arguments 2>&1
+    $code = $LASTEXITCODE
+  } finally {
+    $ErrorActionPreference = $previousPreference
+    Pop-Location
+  }
+  if ($code -ne 0) {
+    foreach ($line in @($output)) { Write-Host $line }
+    Stop-Install $FailZh $FailEn
+  }
+}
+
+function Install-RemoteWorkspace {
+  Assert-Command 'Expand-Archive' "当前 PowerShell 缺少 Expand-Archive；请升级到 PowerShell 5.1 或更高版本。" "This PowerShell has no Expand-Archive; upgrade to PowerShell 5.1 or newer."
+
+  if ((Test-Path -LiteralPath $ManagedRoot -PathType Container) -and
+      -not (Test-Path -LiteralPath $ManagedMarker -PathType Leaf) -and
+      @(Get-ChildItem -LiteralPath $ManagedRoot -Force).Count -gt 0) {
+    Stop-Install `
+      "$ManagedRoot 已存在且不是脚本托管的安装目录；为避免覆盖，请移动该目录或在其中运行 .\scripts\install.ps1。" `
+      "$ManagedRoot already exists and is not managed by this installer; move it or run .\scripts\install.ps1 inside it to avoid overwriting it."
+  }
+
+  Write-Pair "未检测到完整的本地 checkout，切换到免 clone 安装。" "No complete local checkout was detected; switching to the clone-free install."
+  Write-Pair "正在从 $Repository 的 $RemoteRef 分支下载安装文件……" "Downloading installation files from $Repository at $RemoteRef…"
+
+  # Windows PowerShell defaults to protocols GitHub no longer accepts.
+  try {
+    [Net.ServicePointManager]::SecurityProtocol =
+      [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+  } catch { }
+
+  $tempBase = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
+  $bootstrap = Join-Path $tempBase ('dsh-browser-install-' + [System.Guid]::NewGuid().ToString('N').Substring(0, 8))
+  New-Item -ItemType Directory -Path $bootstrap -Force | Out-Null
+
+  try {
+    $archive = Join-Path $bootstrap 'source.zip'
+    $expanded = Join-Path $bootstrap 'source'
+    Invoke-WebRequest -Uri $ArchiveUrl -OutFile $archive -UseBasicParsing
+    Expand-Archive -LiteralPath $archive -DestinationPath $expanded -Force
+
+    $extracted = @(Get-ChildItem -LiteralPath $expanded -Directory)
+    if ($extracted.Count -ne 1 -or -not (Test-Workspace $extracted[0].FullName)) {
+      Stop-Install "下载内容不完整，未修改现有安装。" "The download is incomplete; the existing installation was not changed."
+    }
+
+    New-Item -ItemType Directory -Path $ManagedRoot -Force | Out-Null
+    New-Item -ItemType File -Path $ManagedMarker -Force | Out-Null
+    Sync-Directory -Source $extracted[0].FullName -Destination $ManagedRoot `
+      -ExcludeName @('node_modules', '.managed-by-install-sh')
+  } finally {
+    Remove-Item -LiteralPath $bootstrap -Recurse -Force -ErrorAction SilentlyContinue
+  }
+
+  Write-Pair "安装文件已同步到 $ManagedRoot。" "Installation files are ready in $ManagedRoot."
+
+  # Hand over to the version that was just downloaded, the way the Unix installer re-execs.
+  # -ExecutionPolicy Bypass keeps a restricted machine from rejecting the freshly written file.
+  $hostExe = if ($PSVersionTable.PSEdition -eq 'Core') {
+    Join-Path $PSHOME 'pwsh.exe'
+  } else {
+    Join-Path $PSHOME 'powershell.exe'
+  }
+  & $hostExe -NoProfile -ExecutionPolicy Bypass -File (Join-Path $ManagedRoot 'scripts\install.ps1')
+  exit $LASTEXITCODE
+}
+
+if ([System.Environment]::OSVersion.Platform -ne [System.PlatformID]::Win32NT) {
+  Stop-Install "install.ps1 仅用于 Windows；macOS 与 Linux 请运行 scripts/install.sh。" "install.ps1 is for Windows only; run scripts/install.sh on macOS and Linux."
+}
+
+$Root = Get-WorkspaceRoot
+if (-not $Root) { Install-RemoteWorkspace }
+
+$Ext = Join-Path $Root 'extensions\dsh-browser'
+$Plugin = Join-Path $Root 'packages\browser\bridge-browser'
+$WebProfileManifest = Join-Path $DshHomeDir 'profiles\web\package.json'
+
+Assert-Command 'pnpm' "未找到 pnpm；请先启用 Corepack 或安装 pnpm。" "pnpm was not found; enable Corepack or install pnpm first."
+Assert-Command 'node' "未找到 Node.js；请先安装受支持的 Node.js 版本。" "Node.js was not found; install a supported Node.js version first."
+
+Write-Step 1 "构建浏览器桥" "Build the browser bridge"
+Invoke-Quiet -WorkingDirectory $Root -Command 'pnpm' -Arguments @('install', '--frozen-lockfile') `
+  -FailZh "依赖安装失败。" -FailEn "Dependency installation failed."
+Invoke-Quiet -WorkingDirectory $Root -Command 'pnpm' -Arguments @('--filter', $BridgePlugin, 'run', 'build') `
+  -FailZh "桥插件构建失败。" -FailEn "The bridge plugin build failed."
+
+Write-Step 2 "注册到本机 web profile" "Register with the local web profile"
+if (Test-ProfileDependency -Manifest $WebProfileManifest -PackageName $LegacyPlugin) {
+  Invoke-Quiet -WorkingDirectory $Root -Command 'pnpm' `
+    -Arguments @('exec', 'dsh', 'plugin', '--profile', 'web', 'remove', $LegacyPlugin) `
+    -FailZh "移除旧插件失败。" -FailEn "Removing the legacy plugin failed."
+}
+# pnpm accepts forward slashes on Windows, and they keep the backslashes in a Windows path
+# from being read as escapes inside the link: specifier.
+$LinkTarget = $Plugin.Replace('\', '/')
+Invoke-Quiet -WorkingDirectory $Root -Command 'pnpm' `
+  -Arguments @('exec', 'dsh', 'plugin', '--profile', 'web', 'add', '-w', "$BridgePlugin@link:$LinkTarget") `
+  -FailZh "注册桥插件失败。" -FailEn "Registering the bridge plugin failed."
+
+Write-Step 3 "构建 Chrome 扩展" "Build the Chrome extension"
+Invoke-Quiet -WorkingDirectory $Root -Command 'pnpm' -Arguments @('--filter', 'dsh-browser-extension', 'run', 'build') `
+  -FailZh "扩展构建失败。" -FailEn "The extension build failed."
+
+Write-Step 4 "准备扩展并打开 Chrome" "Prepare the extension and open Chrome"
+Confirm-Browser | Out-Null
+$DistDir = Join-Path $DshHomeDir 'browser-extension'
+$IsUpdate = Test-Path -LiteralPath (Join-Path $DistDir 'manifest.json') -PathType Leaf
+New-Item -ItemType Directory -Path $DistDir -Force | Out-Null
+Sync-Directory -Source (Join-Path $Ext 'dist') -Destination $DistDir
+
+$InstallMode = if (Test-Path -LiteralPath (Join-Path $Root '.managed-by-install-sh') -PathType Leaf) { 'managed' } else { 'checkout' }
+$InstallInfo = [ordered]@{ schemaVersion = 1; mode = $InstallMode }
+if ($InstallMode -eq 'checkout') { $InstallInfo['sourceRoot'] = $Root }
+# ConvertTo-Json escapes the backslashes in a Windows path; hand-built JSON would not.
+$InstallInfoJson = ($InstallInfo | ConvertTo-Json -Depth 3) + "`n"
+[System.IO.File]::WriteAllText(
+  (Join-Path $DistDir 'install-info.json'),
+  $InstallInfoJson,
+  (New-Object System.Text.UTF8Encoding $false))
+
+$ClipboardReady = Set-ClipboardText $DistDir
+$ChromeOpened = Start-ExtensionsPage (Get-BrowserPath)
+
+Write-Host ''
+if (-not $ChromeOpened) {
+  Write-Pair "无法自动打开 Chrome，请手动打开浏览器并在地址栏输入 chrome://extensions。" "Could not open Chrome automatically; open the browser and type chrome://extensions in the address bar."
+}
+# PowerShell treats the typographic quotes “ ” as string delimiters, so every message that
+# contains them has to use single-quoted literals or it splits into extra arguments.
+if ($IsUpdate) {
+  Write-Pair "检测到已有扩展目录，文件已安全更新。" "Existing extension directory detected; its files were updated safely."
+  Write-Pair "打开 Google Chrome（注意不是 Edge/Firefox）：" "Open Google Chrome (not Edge/Firefox):"
+  Write-Host ''
+  Write-Pair "    地址栏输入 chrome://extensions" "    Type chrome://extensions in the address bar"
+  Write-Host ''
+  Write-Pair '如果页面上已有“dsh 浏览器助手”卡片：' 'If the “dsh Browser Assistant” card is already listed:'
+  Write-Pair '  点击卡片上的“重新加载”按钮，让扩展加载新文件。' '  Click “Reload” on that card so it picks up the updated files.'
+  Write-Host ''
+  Write-Pair "如果没有该卡片（例如从未加载过）：" "If the card is not listed (e.g. it was never loaded):"
+  Write-Pair '  打开右上角 “开发者模式”' '  Enable “Developer mode” in the upper-right corner'
+  Write-Pair '  点左上角 “加载已解压的扩展程序”' '  Click “Load unpacked” in the upper-left corner'
+  Write-Pair "  选择这个目录：" "  Select this directory:"
+  Write-Host ("   {0}" -f $DistDir)
+  Write-Host ''
+  Write-Pair '出现 “dsh 浏览器助手” 卡片即成功。' 'When the “dsh Browser Assistant” card appears, it is loaded.'
+} else {
+  if ($ChromeOpened) {
+    Write-Pair "Chrome 扩展管理页已打开，请完成以下操作：" "Chrome Extensions is open. Complete these steps:"
+  } else {
+    Write-Pair "请在 Chrome 扩展管理页完成以下操作：" "Complete these steps on the Chrome Extensions page:"
+  }
+  Write-Host ''
+  Write-Pair '1. 开启右上角的“开发者模式”' 'Enable “Developer mode” in the upper-right corner'
+  Write-Pair '2. 点击“加载已解压的扩展程序”' 'Click “Load unpacked”'
+  if ($ClipboardReady) {
+    Write-Pair "3. 在路径栏粘贴以下路径（已复制到剪贴板）：" "Paste this path into the folder picker's address bar (already copied):"
+  } else {
+    Write-Pair "3. 在路径栏复制并粘贴以下路径：" "Copy and paste this path into the folder picker's address bar:"
+  }
+  Write-Host ("   {0}" -f $DistDir)
+}
+
+Write-Host ''
+Write-Pair "加载完成后：" "After loading the extension:"
+Write-Pair "• 点击工具栏中的 DeepSeek 鲸鱼图标，打开侧边栏" "Click the DeepSeek whale icon in the toolbar to open the side panel"
+Write-Pair "• 扩展会自动发现本机 dsh，无需填写地址或 token" "The extension discovers local dsh automatically; no address or token is required"
+$QuotedRoot = "'" + $Root.Replace("'", "''") + "'"
+Write-Host ("• 启动固定版本：cd {0}; pnpm start" -f $QuotedRoot)
+Write-Host ("   Start the pinned version: cd {0}; pnpm start" -f $QuotedRoot)
+Write-Pair "• 或启动 npm 最新版本：npx @deepseek-ai/dsh web" "Or start the latest npm version: npx @deepseek-ai/dsh web"
+Write-Host ''
+Write-Pair "如果用得顺手，欢迎在 GitHub 点个 Star 支持我们：https://github.com/Lum1104/dsh-browser" "If dsh-browser is useful to you, we'd appreciate a Star on GitHub: https://github.com/Lum1104/dsh-browser"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -58,47 +58,49 @@ is_macos() {
   [ "$(uname -s)" = "Darwin" ]
 }
 
+has_display() {
+  [ -n "${DISPLAY:-}" ] || [ -n "${WAYLAND_DISPLAY:-}" ]
+}
+
 copy_to_clipboard() {
   local text="$1"
 
   if is_macos; then
-    if command -v pbcopy >/dev/null 2>&1; then
-      printf '%s' "$text" | pbcopy && return 0
-    fi
+    command -v pbcopy >/dev/null 2>&1 || return 1
+    printf '%s' "$text" | pbcopy && return 0
     return 1
   fi
 
+  # The X11/Wayland helpers need a display, and they fork a daemon that keeps owning the
+  # selection; keep its stdio off the terminal so the installer's own output stays readable.
+  has_display || return 1
   if command -v wl-copy >/dev/null 2>&1; then
-    printf '%s' "$text" | wl-copy && return 0
+    printf '%s' "$text" | wl-copy >/dev/null 2>&1 && return 0
   fi
   if command -v xclip >/dev/null 2>&1; then
-    printf '%s' "$text" | xclip -selection clipboard && return 0
+    printf '%s' "$text" | xclip -selection clipboard >/dev/null 2>&1 && return 0
   fi
   if command -v xsel >/dev/null 2>&1; then
-    printf '%s' "$text" | xsel --clipboard --input && return 0
+    printf '%s' "$text" | xsel --clipboard --input >/dev/null 2>&1 && return 0
   fi
   return 1
 }
 
-find_chrome_command() {
-  local browser
+# Echoes a launch target for the local Chrome/Chromium install: on macOS an app bundle path
+# or a LaunchServices app name (both accepted by `open -a`), on Linux an executable on PATH.
+find_browser_target() {
+  local name
 
   if is_macos; then
-    local app bin name
-    local candidates=(
-      "/Applications/Google Chrome.app"
-      "/Applications/Google Chrome Canary.app"
-      "/Applications/Chromium.app"
-      "$HOME/Applications/Google Chrome.app"
-      "$HOME/Applications/Google Chrome Canary.app"
-      "$HOME/Applications/Chromium.app"
-    )
-    for app in "${candidates[@]}"; do
-      bin="$app/Contents/MacOS/$(basename "$app" .app)"
-      if [ -x "$bin" ]; then
-        printf '%s\n' "$bin"
-        return 0
-      fi
+    local dir app
+    for dir in "/Applications" "$HOME/Applications"; do
+      for name in "Google Chrome" "Google Chrome Canary" "Chromium"; do
+        app="$dir/$name.app"
+        if [ -x "$app/Contents/MacOS/$name" ]; then
+          printf '%s\n' "$app"
+          return 0
+        fi
+      done
     done
 
     # Fallback: recognize apps registered with LaunchServices in non-standard locations.
@@ -111,9 +113,9 @@ find_chrome_command() {
     return 1
   fi
 
-  for browser in google-chrome google-chrome-stable chromium chromium-browser; do
-    if command -v "$browser" >/dev/null 2>&1; then
-      printf '%s\n' "$browser"
+  for name in google-chrome google-chrome-stable chromium chromium-browser; do
+    if command -v "$name" >/dev/null 2>&1; then
+      printf '%s\n' "$name"
       return 0
     fi
   done
@@ -122,73 +124,119 @@ find_chrome_command() {
 
 open_chrome_extensions() {
   local url="chrome://extensions"
-  local chrome_cmd
+  local target
+  local pid
+
+  target="$(find_browser_target)" || target=""
 
   if is_macos; then
-    local name
-    for name in "Google Chrome" "Google Chrome Canary" "Chromium"; do
-      if open -Ra "$name" >/dev/null 2>&1; then
-        open -a "$name" "$url" >/dev/null 2>&1 && return 0
-      fi
-    done
+    if [ -n "$target" ]; then
+      open -a "$target" "$url" >/dev/null 2>&1 && return 0
+    fi
     open -b com.google.Chrome "$url" >/dev/null 2>&1 && return 0
     return 1
   fi
 
-  if chrome_cmd="$(find_chrome_command)"; then
-    "$chrome_cmd" "$url" >/dev/null 2>&1 && return 0
+  has_display || return 1
+  if [ -n "$target" ]; then
+    # Launch detached: a first run starts a foreground browser process that would otherwise
+    # block the installer until the user quits it.
+    "$target" "$url" >/dev/null 2>&1 </dev/null &
+    pid=$!
+    # Forwarding the URL to a running instance exits almost immediately; a fresh window keeps
+    # running. Wait briefly so a browser that fails to start is reported as such.
+    sleep 1
+    if kill -0 "$pid" 2>/dev/null; then
+      return 0
+    fi
+    wait "$pid" && return 0
   fi
   if command -v xdg-open >/dev/null 2>&1; then
-    xdg-open "$url" >/dev/null 2>&1 && return 0
+    xdg-open "$url" >/dev/null 2>&1 </dev/null && return 0
   fi
   return 1
 }
 
-ensure_chrome() {
-  local chrome_cmd
-
-  if find_chrome_command >/dev/null 2>&1; then
-    return 0
+print_browser_install_hint() {
+  if is_macos; then
+    if command -v brew >/dev/null 2>&1; then
+      print_pair "请手动安装：brew install --cask google-chrome" "Install it manually: brew install --cask google-chrome"
+    else
+      print_pair "请手动安装 Google Chrome：https://www.google.com/chrome/" "Install Google Chrome manually: https://www.google.com/chrome/"
+    fi
+  elif command -v apt-get >/dev/null 2>&1; then
+    print_pair "请手动安装：sudo apt-get update && sudo apt-get install -y chromium-browser（或 chromium）" "Install it manually: sudo apt-get update && sudo apt-get install -y chromium-browser (or chromium)"
+  elif command -v dnf >/dev/null 2>&1; then
+    print_pair "请手动安装：sudo dnf install -y chromium" "Install it manually: sudo dnf install -y chromium"
+  elif command -v yum >/dev/null 2>&1; then
+    print_pair "请手动安装：sudo yum install -y chromium" "Install it manually: sudo yum install -y chromium"
+  elif command -v zypper >/dev/null 2>&1; then
+    print_pair "请手动安装：sudo zypper --non-interactive install chromium" "Install it manually: sudo zypper --non-interactive install chromium"
+  elif command -v pacman >/dev/null 2>&1; then
+    print_pair "请手动安装：sudo pacman -S --noconfirm chromium" "Install it manually: sudo pacman -S --noconfirm chromium"
+  else
+    print_pair "未找到可用的软件包管理器，请手动安装 Chrome 或 Chromium。" "No supported package manager was found; install Chrome or Chromium manually."
   fi
+}
 
-  print_pair "未检测到 Chrome/Chromium 浏览器，尝试自动安装……" "No Chrome/Chromium browser detected; attempting to install…"
+install_browser() {
+  local sudo_cmd=""
 
   if is_macos; then
     if command -v brew >/dev/null 2>&1; then
       brew install --cask google-chrome || true
     else
-      print_pair "未找到 Homebrew，请手动安装 Google Chrome：https://www.google.com/chrome/" "Homebrew was not found; install Google Chrome manually: https://www.google.com/chrome/"
+      print_browser_install_hint
     fi
-  else
+    return 0
+  fi
+
+  if [ "$(id -u)" -ne 0 ]; then
     if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
-      if command -v apt-get >/dev/null 2>&1; then
-        sudo apt-get update || true
-        sudo apt-get install -y chromium-browser || sudo apt-get install -y chromium || true
-      elif command -v dnf >/dev/null 2>&1; then
-        sudo dnf install -y chromium || true
-      elif command -v yum >/dev/null 2>&1; then
-        sudo yum install -y chromium || true
-      elif command -v zypper >/dev/null 2>&1; then
-        sudo zypper --non-interactive install chromium || true
-      elif command -v pacman >/dev/null 2>&1; then
-        sudo pacman -S --noconfirm chromium || true
-      fi
+      sudo_cmd="sudo"
     else
-      if command -v apt-get >/dev/null 2>&1; then
-        print_pair "需要管理员权限安装浏览器，请手动运行：sudo apt-get update && sudo apt-get install -y chromium-browser（或 chromium）" "Sudo rights are required; run: sudo apt-get update && sudo apt-get install -y chromium-browser (or chromium)"
-      elif command -v dnf >/dev/null 2>&1; then
-        print_pair "需要管理员权限安装浏览器，请手动运行：sudo dnf install -y chromium" "Sudo rights are required; run: sudo dnf install -y chromium"
-      elif command -v zypper >/dev/null 2>&1; then
-        print_pair "需要管理员权限安装浏览器，请手动运行：sudo zypper --non-interactive install chromium" "Sudo rights are required; run: sudo zypper --non-interactive install chromium"
-      elif command -v pacman >/dev/null 2>&1; then
-        print_pair "需要管理员权限安装浏览器，请手动运行：sudo pacman -S --noconfirm chromium" "Sudo rights are required; run: sudo pacman -S --noconfirm chromium"
-      else
-        print_pair "未找到可用的软件包管理器，请手动安装 Chrome 或 Chromium。" "No supported package manager found; install Chrome or Chromium manually."
-      fi
+      print_pair "需要管理员权限才能安装浏览器。" "Administrator rights are required to install a browser."
+      print_browser_install_hint
+      return 0
     fi
   fi
 
-  if find_chrome_command >/dev/null 2>&1; then
+  if command -v apt-get >/dev/null 2>&1; then
+    $sudo_cmd apt-get update || true
+    $sudo_cmd apt-get install -y chromium-browser || $sudo_cmd apt-get install -y chromium || true
+  elif command -v dnf >/dev/null 2>&1; then
+    $sudo_cmd dnf install -y chromium || true
+  elif command -v yum >/dev/null 2>&1; then
+    $sudo_cmd yum install -y chromium || true
+  elif command -v zypper >/dev/null 2>&1; then
+    $sudo_cmd zypper --non-interactive install chromium || true
+  elif command -v pacman >/dev/null 2>&1; then
+    $sudo_cmd pacman -S --noconfirm chromium || true
+  else
+    print_browser_install_hint
+  fi
+  return 0
+}
+
+ensure_chrome() {
+  if find_browser_target >/dev/null 2>&1; then
+    return 0
+  fi
+
+  print_pair "未检测到 Chrome/Chromium 浏览器。" "No Chrome/Chromium browser was detected."
+
+  # Installing a browser system-wide is a surprising side effect for a one-line installer,
+  # so it stays opt-in and never runs sudo on its own.
+  if [ "${DSH_INSTALL_BROWSER:-0}" != "1" ]; then
+    print_browser_install_hint
+    print_pair "安装后重新运行本脚本；或设置 DSH_INSTALL_BROWSER=1 让脚本尝试自动安装。" "Install it and rerun this script, or set DSH_INSTALL_BROWSER=1 to let the installer attempt it."
+    return 1
+  fi
+
+  print_pair "DSH_INSTALL_BROWSER=1，尝试自动安装……" "DSH_INSTALL_BROWSER=1 is set; attempting to install…"
+  install_browser
+
+  if find_browser_target >/dev/null 2>&1; then
     return 0
   fi
   print_pair "自动安装未完成，本次安装会继续，但需要你手动安装浏览器后再加载扩展。" "Automatic browser installation did not complete; continuing, but install a browser manually before loading the extension."
@@ -321,7 +369,7 @@ else
 fi
 printf '\n'
 if [ "$CHROME_OPENED" -ne 1 ]; then
-  print_pair "无法自动打开 Chrome，请在地址栏手动输入 chrome://extensions。" "Could not open Chrome automatically; type chrome://extensions in the address bar."
+  print_pair "无法自动打开 Chrome，请手动打开浏览器并在地址栏输入 chrome://extensions。" "Could not open Chrome automatically; open the browser and type chrome://extensions in the address bar."
 fi
 if [ "$IS_UPDATE" -eq 1 ]; then
   print_pair "检测到已有扩展目录，文件已安全更新。" "Existing extension directory detected; its files were updated safely."
@@ -340,7 +388,11 @@ if [ "$IS_UPDATE" -eq 1 ]; then
   printf '\n'
   print_pair "出现 “dsh 浏览器助手” 卡片即成功。" "When the “dsh Browser Assistant” card appears, it is loaded."
 else
-  print_pair "Chrome 扩展管理页已打开，请完成以下操作：" "Chrome Extensions is open. Complete these steps:"
+  if [ "$CHROME_OPENED" -eq 1 ]; then
+    print_pair "Chrome 扩展管理页已打开，请完成以下操作：" "Chrome Extensions is open. Complete these steps:"
+  else
+    print_pair "请在 Chrome 扩展管理页完成以下操作：" "Complete these steps on the Chrome Extensions page:"
+  fi
   printf '\n'
   print_pair "1. 开启右上角的“开发者模式”" "Enable “Developer mode” in the upper-right corner"
   print_pair "2. 点击“加载已解压的扩展程序”" "Click “Load unpacked”"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -54,6 +54,122 @@ require_command() {
   command -v "$1" >/dev/null 2>&1 || fail_pair "$2" "$3"
 }
 
+is_macos() {
+  [ "$(uname -s)" = "Darwin" ]
+}
+
+copy_to_clipboard() {
+  local text="$1"
+
+  if is_macos; then
+    if command -v pbcopy >/dev/null 2>&1; then
+      printf '%s' "$text" | pbcopy && return 0
+    fi
+    return 1
+  fi
+
+  if command -v wl-copy >/dev/null 2>&1; then
+    printf '%s' "$text" | wl-copy && return 0
+  fi
+  if command -v xclip >/dev/null 2>&1; then
+    printf '%s' "$text" | xclip -selection clipboard && return 0
+  fi
+  if command -v xsel >/dev/null 2>&1; then
+    printf '%s' "$text" | xsel --clipboard --input && return 0
+  fi
+  return 1
+}
+
+find_chrome_command() {
+  local browser
+
+  if is_macos; then
+    if [ -d "/Applications/Google Chrome.app" ]; then
+      printf '%s\n' "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+      return 0
+    fi
+    return 1
+  fi
+
+  for browser in google-chrome google-chrome-stable chromium chromium-browser; do
+    if command -v "$browser" >/dev/null 2>&1; then
+      printf '%s\n' "$browser"
+      return 0
+    fi
+  done
+  return 1
+}
+
+open_chrome_extensions() {
+  local url="chrome://extensions"
+  local chrome_cmd
+
+  if is_macos; then
+    open -a "Google Chrome" "$url" 2>/dev/null && return 0
+    open -b com.google.Chrome "$url" 2>/dev/null && return 0
+    return 1
+  fi
+
+  if chrome_cmd="$(find_chrome_command)"; then
+    "$chrome_cmd" "$url" >/dev/null 2>&1 && return 0
+  fi
+  if command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "$url" >/dev/null 2>&1 && return 0
+  fi
+  return 1
+}
+
+ensure_chrome() {
+  local chrome_cmd
+
+  if find_chrome_command >/dev/null 2>&1; then
+    return 0
+  fi
+
+  print_pair "未检测到 Chrome/Chromium 浏览器，尝试自动安装……" "No Chrome/Chromium browser detected; attempting to install…"
+
+  if is_macos; then
+    if command -v brew >/dev/null 2>&1; then
+      brew install --cask google-chrome || true
+    else
+      print_pair "未找到 Homebrew，请手动安装 Google Chrome：https://www.google.com/chrome/" "Homebrew was not found; install Google Chrome manually: https://www.google.com/chrome/"
+    fi
+  else
+    if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+      if command -v apt-get >/dev/null 2>&1; then
+        sudo apt-get update || true
+        sudo apt-get install -y chromium-browser || sudo apt-get install -y chromium || true
+      elif command -v dnf >/dev/null 2>&1; then
+        sudo dnf install -y chromium || true
+      elif command -v yum >/dev/null 2>&1; then
+        sudo yum install -y chromium || true
+      elif command -v zypper >/dev/null 2>&1; then
+        sudo zypper --non-interactive install chromium || true
+      elif command -v pacman >/dev/null 2>&1; then
+        sudo pacman -S --noconfirm chromium || true
+      fi
+    else
+      if command -v apt-get >/dev/null 2>&1; then
+        print_pair "需要管理员权限安装浏览器，请手动运行：sudo apt-get update && sudo apt-get install -y chromium-browser（或 chromium）" "Sudo rights are required; run: sudo apt-get update && sudo apt-get install -y chromium-browser (or chromium)"
+      elif command -v dnf >/dev/null 2>&1; then
+        print_pair "需要管理员权限安装浏览器，请手动运行：sudo dnf install -y chromium" "Sudo rights are required; run: sudo dnf install -y chromium"
+      elif command -v zypper >/dev/null 2>&1; then
+        print_pair "需要管理员权限安装浏览器，请手动运行：sudo zypper --non-interactive install chromium" "Sudo rights are required; run: sudo zypper --non-interactive install chromium"
+      elif command -v pacman >/dev/null 2>&1; then
+        print_pair "需要管理员权限安装浏览器，请手动运行：sudo pacman -S --noconfirm chromium" "Sudo rights are required; run: sudo pacman -S --noconfirm chromium"
+      else
+        print_pair "未找到可用的软件包管理器，请手动安装 Chrome 或 Chromium。" "No supported package manager found; install Chrome or Chromium manually."
+      fi
+    fi
+  fi
+
+  if find_chrome_command >/dev/null 2>&1; then
+    return 0
+  fi
+  print_pair "自动安装未完成，本次安装会继续，但需要你手动安装浏览器后再加载扩展。" "Automatic browser installation did not complete; continuing, but install a browser manually before loading the extension."
+  return 1
+}
+
 cleanup_bootstrap() {
   if [ -n "$BOOTSTRAP_TMP" ] && [ -d "$BOOTSTRAP_TMP" ]; then
     rm -rf -- "$BOOTSTRAP_TMP"
@@ -143,6 +259,7 @@ print_step 3 "构建 Chrome 扩展" "Build the Chrome extension"
 (cd "$ROOT" && pnpm --filter dsh-browser-extension run build >/dev/null 2>&1)
 
 print_step 4 "准备扩展并打开 Chrome" "Prepare the extension and open Chrome"
+ensure_chrome || true
 DIST_DIR="$DSH_HOME_DIR/browser-extension"
 if [ -f "$DIST_DIR/manifest.json" ]; then
   IS_UPDATE=1
@@ -166,19 +283,51 @@ node -e '
   };
   writeFileSync(filename, `${JSON.stringify(info, null, 2)}\n`);
 ' "$DIST_DIR/install-info.json" "$INSTALL_MODE" "$ROOT"
-echo -n "$DIST_DIR" | pbcopy
+if copy_to_clipboard "$DIST_DIR"; then
+  CLIPBOARD_READY=1
+else
+  CLIPBOARD_READY=0
+fi
 
-open -a "Google Chrome" "chrome://extensions" 2>/dev/null || open -b com.google.Chrome "chrome://extensions"
+if open_chrome_extensions; then
+  CHROME_OPENED=1
+else
+  CHROME_OPENED=0
+fi
 printf '\n'
+if [ "$CHROME_OPENED" -ne 1 ]; then
+  print_pair "无法自动打开 Chrome，请在地址栏手动输入 chrome://extensions。" "Could not open Chrome automatically; type chrome://extensions in the address bar."
+fi
 if [ "$IS_UPDATE" -eq 1 ]; then
-  print_pair "检测到已有扩展，文件已安全更新。" "Existing extension detected; its files were updated safely."
-  print_pair "请在 Chrome 扩展管理页找到“dsh 浏览器助手”，点击“重新加载”。" "Find “dsh Browser Assistant” in Chrome Extensions and click “Reload”."
+  print_pair "检测到已有扩展目录，文件已安全更新。" "Existing extension directory detected; its files were updated safely."
+  print_pair "打开 Google Chrome（注意不是 Edge/Firefox）：" "Open Google Chrome (not Edge/Firefox):"
+  printf '\n'
+  print_pair "    地址栏输入 chrome://extensions" "    Type chrome://extensions in the address bar"
+  printf '\n'
+  print_pair "打开右上角 “开发者模式”" "Enable “Developer mode” in the upper-right corner"
+  print_pair "点左上角 “加载已解压的扩展程序”" "Click “Load unpacked” in the upper-left corner"
+  print_pair "选择这个目录：" "Select this directory:"
+  printf '   %s\n' "$DIST_DIR"
+  printf '\n'
+  print_pair "出现 “dsh 浏览器助手” 卡片即成功。" "When the “dsh Browser Assistant” card appears, it is loaded."
 else
   print_pair "Chrome 扩展管理页已打开，请完成以下操作：" "Chrome Extensions is open. Complete these steps:"
   printf '\n'
   print_pair "1. 开启右上角的“开发者模式”" "Enable “Developer mode” in the upper-right corner"
   print_pair "2. 点击“加载已解压的扩展程序”" "Click “Load unpacked”"
-  print_pair "3. 按 Cmd+Shift+G，粘贴以下路径（已复制到剪贴板）：" "Press Cmd+Shift+G and paste this path (already copied):"
+  if is_macos; then
+    if [ "$CLIPBOARD_READY" -eq 1 ]; then
+      print_pair "3. 按 Cmd+Shift+G，粘贴以下路径（已复制到剪贴板）：" "Press Cmd+Shift+G and paste this path (already copied):"
+    else
+      print_pair "3. 按 Cmd+Shift+G，粘贴以下路径：" "Press Cmd+Shift+G and paste this path:"
+    fi
+  else
+    if [ "$CLIPBOARD_READY" -eq 1 ]; then
+      print_pair "3. 粘贴以下路径（已复制到剪贴板）：" "Paste this path (already copied):"
+    else
+      print_pair "3. 复制并粘贴以下路径：" "Copy and paste this path:"
+    fi
+  fi
   printf '   %s\n' "$DIST_DIR"
 fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -84,10 +84,30 @@ find_chrome_command() {
   local browser
 
   if is_macos; then
-    if [ -d "/Applications/Google Chrome.app" ]; then
-      printf '%s\n' "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-      return 0
-    fi
+    local app bin name
+    local candidates=(
+      "/Applications/Google Chrome.app"
+      "/Applications/Google Chrome Canary.app"
+      "/Applications/Chromium.app"
+      "$HOME/Applications/Google Chrome.app"
+      "$HOME/Applications/Google Chrome Canary.app"
+      "$HOME/Applications/Chromium.app"
+    )
+    for app in "${candidates[@]}"; do
+      bin="$app/Contents/MacOS/$(basename "$app" .app)"
+      if [ -x "$bin" ]; then
+        printf '%s\n' "$bin"
+        return 0
+      fi
+    done
+
+    # Fallback: recognize apps registered with LaunchServices in non-standard locations.
+    for name in "Google Chrome" "Google Chrome Canary" "Chromium"; do
+      if open -Ra "$name" >/dev/null 2>&1; then
+        printf '%s\n' "$name"
+        return 0
+      fi
+    done
     return 1
   fi
 
@@ -105,8 +125,13 @@ open_chrome_extensions() {
   local chrome_cmd
 
   if is_macos; then
-    open -a "Google Chrome" "$url" 2>/dev/null && return 0
-    open -b com.google.Chrome "$url" 2>/dev/null && return 0
+    local name
+    for name in "Google Chrome" "Google Chrome Canary" "Chromium"; do
+      if open -Ra "$name" >/dev/null 2>&1; then
+        open -a "$name" "$url" >/dev/null 2>&1 && return 0
+      fi
+    done
+    open -b com.google.Chrome "$url" >/dev/null 2>&1 && return 0
     return 1
   fi
 
@@ -304,9 +329,13 @@ if [ "$IS_UPDATE" -eq 1 ]; then
   printf '\n'
   print_pair "    地址栏输入 chrome://extensions" "    Type chrome://extensions in the address bar"
   printf '\n'
-  print_pair "打开右上角 “开发者模式”" "Enable “Developer mode” in the upper-right corner"
-  print_pair "点左上角 “加载已解压的扩展程序”" "Click “Load unpacked” in the upper-left corner"
-  print_pair "选择这个目录：" "Select this directory:"
+  print_pair "如果页面上已有“dsh 浏览器助手”卡片：" "If the “dsh Browser Assistant” card is already listed:"
+  print_pair "  点击卡片上的“重新加载”按钮，让扩展加载新文件。" "  Click “Reload” on that card so it picks up the updated files."
+  printf '\n'
+  print_pair "如果没有该卡片（例如从未加载过）：" "If the card is not listed (e.g. it was never loaded):"
+  print_pair "  打开右上角 “开发者模式”" "  Enable “Developer mode” in the upper-right corner"
+  print_pair "  点左上角 “加载已解压的扩展程序”" "  Click “Load unpacked” in the upper-left corner"
+  print_pair "  选择这个目录：" "  Select this directory:"
   printf '   %s\n' "$DIST_DIR"
   printf '\n'
   print_pair "出现 “dsh 浏览器助手” 卡片即成功。" "When the “dsh Browser Assistant” card appears, it is loaded."


### PR DESCRIPTION
## 概述 / Summary

修复安装脚本 `scripts/install.sh` 在 Linux 上因 macOS 专属命令 `pbcopy` / `open` 而中断的问题，并增加 Chrome 缺失检测与自动安装。

## 动机 / Motivation

当前安装脚本末尾直接调用 `pbcopy` 和 `open -a "Google Chrome"`，这两个命令只在 macOS 存在。Linux 用户运行 `curl -fsSL ... | bash` 时，`pbcopy` 不存在会触发 `set -euo pipefail` 导致脚本在 `[4/4]` 步骤中断。同时，更新分支只提示“重新加载”，对从未加载过扩展的用户不友好。

## 改动内容 / Changes

- 新增跨平台剪贴板复制：macOS 用 `pbcopy`，Linux 用 `wl-copy`/`xclip`/`xsel`，找不到时优雅降级
- 新增跨平台打开 Chrome：macOS 用 `open`，Linux 用 `google-chrome`/`chromium` 等，回退 `xdg-open`
- 新增 `ensure_chrome`：检测 Chrome/Chromium，缺失时尝试通过 brew/apt/dnf/yum/zypper/pacman 自动安装，失败时给出手动安装命令
- 优化步骤 4 提示：更新分支也会给出“开发者模式 → 加载已解压的扩展程序 → 选择目录”的完整指引，并始终打印扩展路径

## 测试 / Testing

- `bash -n scripts/install.sh` 通过
- 在 openSUSE（Linux）实际运行 `./scripts/install.sh` 走完 4 个步骤，不再报 `pbcopy: 未找到命令`

## 影响范围 / Impact

- macOS：行为基本不变（仍用 pbcopy/open）
- Linux：安装脚本现在可正常运行
- Windows：仍不支持（本次未涉及）

## Checklist

- [x] 已在相关平台实测通过（openSUSE）
- [x] 已通过 `bash -n scripts/install.sh` 检查
- [x] 文档已同步更新（无需）
- [x] 不包含无关改动







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes the managed installer cross-platform and adds Windows installation support, browser discovery, clipboard fallbacks, and clearer extension loading guidance.
- Adds macOS/Linux browser detection and optional browser installation.
- Adds a PowerShell installer sharing the managed installation layout.
- Updates extension update commands, tests, and bilingual documentation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/install.sh | Adds cross-platform browser discovery, clipboard handling, optional browser installation, and corrected reload-versus-first-load guidance. |
| scripts/install.ps1 | Adds the Windows managed installer with matching build, registration, metadata, and extension-loading behavior. |
| extensions/dsh-browser/src/panel/updates.ts | Selects managed or checkout-specific installer commands from installation metadata. |
| extensions/dsh-browser/src/panel/UpdateCard.tsx | Uses the installation-aware command when presenting extension updates. |

</details>

<sub>Reviews (4): Last reviewed commit: ["feat(install): add a Windows PowerShell ..."](https://github.com/lum1104/dsh-browser/commit/d4fdbdc803b7a9a3566e06b6cca4950eb71ac47a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55826744)</sub>

<!-- /greptile_comment -->