### PR TITLE
fix(extension): support the Opera sidebar, and compose manifests per browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 !benchmark/lib/**
 **/dist/
 **/dist-firefox/
+**/dist-opera/

--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -1,5 +1,5 @@
 # Bilingual consistency record for the repository README files.
 # README.md is the default English page; README.zh.md is its Chinese counterpart.
 # Values are git blob hashes from the last confirmed-consistent review.
-README.md: ed2444da7e41168c79a0a6ef720f8ca9af5ca727
-README.zh.md: 1a41f13ab0f368b904ad2b53ccf70a2a4a9b9652
+README.md: d793289c9d19e5d9864fcc71984f5894ba5a0f45
+README.zh.md: bb8edc85bb27ed98ca66b5240cb5e86328e44711

--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -1,5 +1,5 @@
 # Bilingual consistency record for the repository README files.
 # README.md is the default English page; README.zh.md is its Chinese counterpart.
 # Values are git blob hashes from the last confirmed-consistent review.
-README.md: 4b3873701da4c05075c3c5370e41c2cb920e726f
-README.zh.md: da6f504ff4fc15251c9271169699c498321fa541
+README.md: 6d84b7cb841e707a52f3619e0270cd822d6fe605
+README.zh.md: 92aedd76c39cc660869052cbe6bb0b8f83e4d359

--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -1,5 +1,5 @@
 # Bilingual consistency record for the repository README files.
 # README.md is the default English page; README.zh.md is its Chinese counterpart.
 # Values are git blob hashes from the last confirmed-consistent review.
-README.md: e8a87543fac03a9310668c0db56f63d82d8a5cdb
-README.zh.md: c568dacd6551e98c5d7eca501a8b3e6c9697f6ac
+README.md: 4b3873701da4c05075c3c5370e41c2cb920e726f
+README.zh.md: da6f504ff4fc15251c9271169699c498321fa541

--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -1,5 +1,5 @@
 # Bilingual consistency record for the repository README files.
 # README.md is the default English page; README.zh.md is its Chinese counterpart.
 # Values are git blob hashes from the last confirmed-consistent review.
-README.md: d793289c9d19e5d9864fcc71984f5894ba5a0f45
-README.zh.md: bb8edc85bb27ed98ca66b5240cb5e86328e44711
+README.md: e8a87543fac03a9310668c0db56f63d82d8a5cdb
+README.zh.md: c568dacd6551e98c5d7eca501a8b3e6c9697f6ac

--- a/README.md
+++ b/README.md
@@ -132,9 +132,6 @@ pnpm --filter dsh-browser-extension run build:opera
 
 Then open `opera://extensions`, enable **Developer mode**, choose **Load unpacked**, and select `extensions/dsh-browser/dist-opera/`. The panel docks as its own icon in Opera's left sidebar.
 
-> [!NOTE]
-> The Opera build has not been verified on Opera itself yet; see [#34](https://github.com/Lum1104/dsh-browser/issues/34).
-
 ### Start and use
 
 Start the managed installation with:

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Local Chrome use requires no configuration; Firefox requires the local bridge to
 
 **Clicking the toolbar icon does nothing**
 
-The extension picks its panel host at runtime. Chrome 116+ uses the native side panel; Firefox and Opera use the sidebar, which they dock from the `sidebar_action` manifest key; any other Chromium browser gets a narrow popup window. On Opera the panel also appears as its own icon in the left sidebar. If nothing opens at all, check the extension's service-worker console for the failing call.
+The extension picks its panel host at runtime. Chrome 116+ uses the native side panel; Firefox and Opera use the sidebar, which they dock from the `sidebar_action` manifest key. On Opera the panel also appears as its own icon in the left sidebar. A browser with neither host raises a notification saying so — the panel is not opened in an ordinary window, because a `chrome-extension://` tab would compete with the page the browser tools are bound to.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ The paired Playwright / extension duration ratio was **1.24** (95% CI **1.16–1
 packages/browser/bridge-browser/
   cordis.patch.yml
 extensions/dsh-browser/
+  manifest.json          # Chrome, and the base for the others
+  manifest.firefox.json  # delta
+  manifest.opera.json    # delta
 scripts/install.sh
 scripts/install.ps1
 ```
@@ -109,7 +112,7 @@ On Windows, run `.\scripts\install.ps1` from the checkout instead. After pulling
 
 ### Firefox source build
 
-Firefox uses a separate MV3 manifest, event-page background, and sidebar. Build it from a checkout, then open `about:debugging#/runtime/this-firefox`, choose **Load Temporary Add-on**, and select `extensions/dsh-browser/dist-firefox/manifest.json`:
+Firefox uses an event-page background and the sidebar. Its manifest is composed at build time from `manifest.json` plus the `manifest.firefox.json` delta, so shared metadata cannot drift between targets. Build it from a checkout, then open `about:debugging#/runtime/this-firefox`, choose **Load Temporary Add-on**, and select `extensions/dsh-browser/dist-firefox/manifest.json`:
 
 ```sh
 pnpm install
@@ -117,6 +120,20 @@ pnpm --filter dsh-browser-extension run build:firefox
 ```
 
 The bridge address is still auto-discovered. Firefox's `moz-extension://` UUID does not authenticate an add-on, so copy the bearer token from `~/.dsh/ext-bridge-token` into the extension settings (the dsh startup log reports that file's path). Signed distribution can package the same `dist-firefox/` output.
+
+### Opera source build
+
+Opera has no Side Panel API but renders the legacy `sidebar_action` manifest key natively, so it gets its own build. Chrome reports an unrecognized-key warning for `sidebar_action` on every unpacked install, which is why the key ships only in the Opera manifest rather than in the shared one:
+
+```sh
+pnpm install
+pnpm --filter dsh-browser-extension run build:opera
+```
+
+Then open `opera://extensions`, enable **Developer mode**, choose **Load unpacked**, and select `extensions/dsh-browser/dist-opera/`. The panel docks as its own icon in Opera's left sidebar.
+
+> [!NOTE]
+> The Opera build has not been verified on Opera itself yet; see [#34](https://github.com/Lum1104/dsh-browser/issues/34).
 
 ### Start and use
 
@@ -144,7 +161,7 @@ Local Chrome use requires no configuration; Firefox requires the local bridge to
 
 **Clicking the toolbar icon does nothing**
 
-The extension picks its panel host at runtime. Chrome 116+ uses the native side panel; Firefox and Opera use the sidebar, which they dock from the `sidebar_action` manifest key. On Opera the panel also appears as its own icon in the left sidebar. A browser with neither host raises a notification saying so — the panel is not opened in an ordinary window, because a `chrome-extension://` tab would compete with the page the browser tools are bound to.
+The extension picks its panel host at runtime: Chrome 116+ uses the native side panel, while Firefox and Opera use the sidebar they dock from the `sidebar_action` manifest key. Each target ships only the key its browser understands, so make sure you loaded the build that matches the browser (`dist/`, `dist-firefox/`, or `dist-opera/`). A browser with neither host raises a notification saying so — the panel is not opened in an ordinary window, because a `chrome-extension://` tab would compete with the page the browser tools are bound to.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ Local Chrome use requires no configuration; Firefox requires the local bridge to
 - Verify the bridge is loaded: open `http://127.0.0.1:3080/ext/bridge-config`. It should return JSON such as `{"wsUrl":"ws://127.0.0.1:3080/ext/bridge"}`. If it returns a web page instead of JSON, the running dsh predates the bridge registration — restart dsh and refresh the page; the extension reconnects on its own.
 - The extension probes ports 3080, 3081, 3090, and 14389 automatically. If dsh runs on another port — or you use a remote `--host 0.0.0.0` deployment — set the address (and bridge token) in the panel settings. Firefox always requires the token.
 
+**Clicking the toolbar icon does nothing**
+
+The extension picks its panel host at runtime. Chrome 116+ uses the native side panel; Firefox and Opera use the sidebar, which they dock from the `sidebar_action` manifest key; any other Chromium browser gets a narrow popup window. On Opera the panel also appears as its own icon in the left sidebar. If nothing opens at all, check the extension's service-worker console for the failing call.
+
 ## Development
 
 The bridge plugin and Chrome/Firefox extension are both members of this repository's workspace. Run all commands from the repository root. For the first development installation, run `pnpm install`.

--- a/README.zh.md
+++ b/README.zh.md
@@ -144,7 +144,7 @@ Chrome 本机使用无需配置；Firefox 需要填写上述本地桥 token。�
 
 **点击工具栏图标没有反应**
 
-扩展会在运行时选择面板载体：Chrome 116+ 使用原生侧边面板；Firefox 和 Opera 使用侧栏，由 `sidebar_action` manifest 键完成停靠；其他 Chromium 浏览器则打开一个窄弹出窗口。在 Opera 上，面板还会作为独立图标出现在左侧栏。如果完全没有反应，请查看扩展 service worker 控制台中失败的调用。
+扩展会在运行时选择面板载体：Chrome 116+ 使用原生侧边面板；Firefox 和 Opera 使用侧栏，由 `sidebar_action` manifest 键完成停靠。在 Opera 上，面板还会作为独立图标出现在左侧栏。两者都不支持的浏览器会收到一条通知说明原因——扩展不会退回到普通窗口，因为 `chrome-extension://` 标签页会与浏览器工具绑定的页面相互干扰。
 
 ## 开发
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -142,6 +142,10 @@ Chrome 本机使用无需配置；Firefox 需要填写上述本地桥 token。�
 - 确认桥接已加载：浏览器打开 `http://127.0.0.1:3080/ext/bridge-config`，应返回类似 `{"wsUrl":"ws://127.0.0.1:3080/ext/bridge"}` 的 JSON。如果返回的是网页而不是 JSON，说明当前运行的 dsh 早于桥接注册——重启 dsh 并刷新页面即可，扩展会自动重连。
 - 扩展会自动探测 3080/3081/3090/14389 端口。若 dsh 运行在其它端口，或使用 `--host 0.0.0.0` 远程部署，请在面板设置中填写地址与桥接 token。Firefox 始终需要 token。
 
+**点击工具栏图标没有反应**
+
+扩展会在运行时选择面板载体：Chrome 116+ 使用原生侧边面板；Firefox 和 Opera 使用侧栏，由 `sidebar_action` manifest 键完成停靠；其他 Chromium 浏览器则打开一个窄弹出窗口。在 Opera 上，面板还会作为独立图标出现在左侧栏。如果完全没有反应，请查看扩展 service worker 控制台中失败的调用。
+
 ## 开发
 
 桥接插件和 Chrome/Firefox 扩展都属于本仓库 workspace；所有命令均在本仓库根目录执行。首次开发安装运行 `pnpm install`。

--- a/README.zh.md
+++ b/README.zh.md
@@ -62,6 +62,9 @@ Playwright / 扩展的配对耗时比为 **1.24**（95% CI **1.16–1.34**）：
 packages/browser/bridge-browser/
   cordis.patch.yml
 extensions/dsh-browser/
+  manifest.json          # Chrome，同时是其他目标的 base
+  manifest.firefox.json  # 差异
+  manifest.opera.json    # 差异
 scripts/install.sh
 scripts/install.ps1
 ```
@@ -109,7 +112,7 @@ Windows 请在 checkout 中运行 `.\scripts\install.ps1`。拉取或切换版�
 
 ### Firefox 源码构建
 
-Firefox 使用独立的 MV3 manifest、事件页后台和 Sidebar。在 checkout 中构建后，打开 `about:debugging#/runtime/this-firefox`，选择「临时载入附加组件」，再选取 `extensions/dsh-browser/dist-firefox/manifest.json`：
+Firefox 使用事件页后台和 Sidebar。它的 manifest 在构建时由 `manifest.json` 叠加 `manifest.firefox.json` 差异合成，因此各目标之间的共享字段不会漂移。在 checkout 中构建后，打开 `about:debugging#/runtime/this-firefox`，选择「临时载入附加组件」，再选取 `extensions/dsh-browser/dist-firefox/manifest.json`：
 
 ```sh
 pnpm install
@@ -117,6 +120,20 @@ pnpm --filter dsh-browser-extension run build:firefox
 ```
 
 桥地址仍会自动探测。Firefox 的 `moz-extension://` UUID 不能证明扩展身份，因此需要把 `~/.dsh/ext-bridge-token` 中的 bearer token 填入扩展设置（dsh 启动日志会报告该文件路径）。签名发布时可直接使用同一份 `dist-firefox/` 产物。
+
+### Opera 源码构建
+
+Opera 没有 Side Panel API，但会原生渲染旧版 `sidebar_action` manifest 键，因此有独立的构建目标。Chrome 对 `sidebar_action` 会在每次「加载已解压」时报「无法识别的清单键」警告，所以该键只出现在 Opera 的 manifest 里，而不放进共享部分：
+
+```sh
+pnpm install
+pnpm --filter dsh-browser-extension run build:opera
+```
+
+然后打开 `opera://extensions`，开启**开发者模式**，选择**加载已解压的扩展程序**，选取 `extensions/dsh-browser/dist-opera/`。面板会作为独立图标停靠在 Opera 左侧栏。
+
+> [!NOTE]
+> Opera 构建尚未在 Opera 上实测，见 [#34](https://github.com/Lum1104/dsh-browser/issues/34)。
 
 ### 启动与使用
 
@@ -144,7 +161,7 @@ Chrome 本机使用无需配置；Firefox 需要填写上述本地桥 token。�
 
 **点击工具栏图标没有反应**
 
-扩展会在运行时选择面板载体：Chrome 116+ 使用原生侧边面板；Firefox 和 Opera 使用侧栏，由 `sidebar_action` manifest 键完成停靠。在 Opera 上，面板还会作为独立图标出现在左侧栏。两者都不支持的浏览器会收到一条通知说明原因——扩展不会退回到普通窗口，因为 `chrome-extension://` 标签页会与浏览器工具绑定的页面相互干扰。
+扩展会在运行时选择面板载体：Chrome 116+ 使用原生侧边面板，Firefox 和 Opera 使用由 `sidebar_action` manifest 键停靠的侧栏。每个目标只携带自己浏览器认识的那个键，所以请确认加载的是与浏览器匹配的构建（`dist/`、`dist-firefox/` 或 `dist-opera/`）。两者都不支持的浏览器会收到一条通知说明原因——扩展不会退回到普通窗口，因为 `chrome-extension://` 标签页会与浏览器工具绑定的页面相互干扰。
 
 ## 开发
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -132,9 +132,6 @@ pnpm --filter dsh-browser-extension run build:opera
 
 然后打开 `opera://extensions`，开启**开发者模式**，选择**加载已解压的扩展程序**，选取 `extensions/dsh-browser/dist-opera/`。面板会作为独立图标停靠在 Opera 左侧栏。
 
-> [!NOTE]
-> Opera 构建尚未在 Opera 上实测，见 [#34](https://github.com/Lum1104/dsh-browser/issues/34)。
-
 ### 启动与使用
 
 启动托管安装：

--- a/extensions/dsh-browser/manifest.compose.ts
+++ b/extensions/dsh-browser/manifest.compose.ts
@@ -1,0 +1,64 @@
+/**
+ * Per-browser manifests, composed from one base.
+ *
+ * `manifest.json` is both the Chrome manifest and the base: Chrome is the
+ * primary target, and the in-panel update check fetches that exact path from
+ * `main` to read the published version, so it stays a real manifest at a
+ * stable location. Every other browser is a delta on top of it.
+ *
+ * Composition rules, in full: a delta entry replaces that top-level key
+ * outright, and `null` removes it — which is how Firefox and Opera drop
+ * `side_panel`. Nothing merges recursively, deliberately: a nested merge of
+ * Firefox's `background` onto Chrome's produced `service_worker`, `type` and
+ * `scripts` together, which is not a manifest either browser accepts. A key is
+ * either shared verbatim or restated in full.
+ *
+ * Keeping a browser's own keys out of the others is not tidiness: Chrome warns
+ * "Unrecognized manifest key 'sidebar_action'" on every unpacked install, and
+ * this project has no Web Store listing, so every user loads unpacked and would
+ * see it.
+ *
+ * @module
+ */
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+export const EXTENSION_TARGETS = ['chrome', 'firefox', 'opera'] as const
+export type ExtensionTarget = (typeof EXTENSION_TARGETS)[number]
+
+/** The output directory for each target, so the builds can coexist. */
+export const TARGET_OUT_DIR: Record<ExtensionTarget, string> = {
+  chrome: 'dist',
+  firefox: 'dist-firefox',
+  opera: 'dist-opera',
+}
+
+const MANIFEST_ROOT = import.meta.dirname
+
+type JsonObject = Record<string, unknown>
+
+function readManifestJson(name: string): JsonObject {
+  return JSON.parse(readFileSync(resolve(MANIFEST_ROOT, name), 'utf8')) as JsonObject
+}
+
+function applyDelta(base: JsonObject, delta: JsonObject): JsonObject {
+  const merged: JsonObject = { ...base }
+  for (const [key, value] of Object.entries(delta)) {
+    if (value === null) delete merged[key]
+    else merged[key] = value
+  }
+  return merged
+}
+
+/** The manifest a target ships, with no other browser's keys in it. */
+export function composeManifest(target: ExtensionTarget): JsonObject {
+  const base = readManifestJson('manifest.json')
+  if (target === 'chrome') return base
+  return applyDelta(base, readManifestJson(`manifest.${target}.json`))
+}
+
+/** Serialize exactly as the committed manifests are formatted. */
+export function serializeManifest(manifest: JsonObject): string {
+  return `${JSON.stringify(manifest, null, 2)}\n`
+}

--- a/extensions/dsh-browser/manifest.firefox.json
+++ b/extensions/dsh-browser/manifest.firefox.json
@@ -1,9 +1,4 @@
 {
-  "manifest_version": 3,
-  "name": "__MSG_extensionName__",
-  "description": "__MSG_extensionDescription__",
-  "default_locale": "en",
-  "version": "0.1.2",
   "browser_specific_settings": {
     "gecko": {
       "id": "dsh-browser@lum1104.github.io",
@@ -27,21 +22,10 @@
     "alarms",
     "notifications"
   ],
-  "host_permissions": [
-    "http://*/*",
-    "https://*/*"
-  ],
   "background": {
     "scripts": [
       "background.js"
     ]
-  },
-  "action": {
-    "default_title": "__MSG_actionTitle__",
-    "default_icon": {
-      "16": "assets/icons/icon16.png",
-      "32": "assets/icons/icon32.png"
-    }
   },
   "sidebar_action": {
     "default_title": "__MSG_actionTitle__",
@@ -67,13 +51,6 @@
       "match_about_blank": true
     }
   ],
-  "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'; connect-src ws://127.0.0.1:* http://127.0.0.1:* https://raw.githubusercontent.com"
-  },
-  "icons": {
-    "16": "assets/icons/icon16.png",
-    "32": "assets/icons/icon32.png",
-    "48": "assets/icons/icon48.png",
-    "128": "assets/icons/icon128.png"
-  }
+  "minimum_chrome_version": null,
+  "side_panel": null
 }

--- a/extensions/dsh-browser/manifest.json
+++ b/extensions/dsh-browser/manifest.json
@@ -33,6 +33,16 @@
   "side_panel": {
     "default_path": "panel/index.html"
   },
+  "sidebar_action": {
+    "default_title": "__MSG_actionTitle__",
+    "default_panel": "panel/index.html",
+    "open_at_install": false,
+    "default_icon": {
+      "16": "assets/icons/icon16.png",
+      "32": "assets/icons/icon32.png",
+      "48": "assets/icons/icon48.png"
+    }
+  },
   "content_scripts": [
     {
       "matches": [

--- a/extensions/dsh-browser/manifest.json
+++ b/extensions/dsh-browser/manifest.json
@@ -33,16 +33,6 @@
   "side_panel": {
     "default_path": "panel/index.html"
   },
-  "sidebar_action": {
-    "default_title": "__MSG_actionTitle__",
-    "default_panel": "panel/index.html",
-    "open_at_install": false,
-    "default_icon": {
-      "16": "assets/icons/icon16.png",
-      "32": "assets/icons/icon32.png",
-      "48": "assets/icons/icon48.png"
-    }
-  },
   "content_scripts": [
     {
       "matches": [

--- a/extensions/dsh-browser/manifest.opera.json
+++ b/extensions/dsh-browser/manifest.opera.json
@@ -1,0 +1,22 @@
+{
+  "permissions": [
+    "storage",
+    "tabs",
+    "activeTab",
+    "scripting",
+    "webNavigation",
+    "alarms",
+    "notifications"
+  ],
+  "sidebar_action": {
+    "default_title": "__MSG_actionTitle__",
+    "default_panel": "panel/index.html",
+    "open_at_install": false,
+    "default_icon": {
+      "16": "assets/icons/icon16.png",
+      "32": "assets/icons/icon32.png",
+      "48": "assets/icons/icon48.png"
+    }
+  },
+  "side_panel": null
+}

--- a/extensions/dsh-browser/package.json
+++ b/extensions/dsh-browser/package.json
@@ -9,8 +9,10 @@
   "scripts": {
     "build": "node scripts/build.mjs",
     "build:firefox": "node scripts/build.mjs --firefox",
+    "build:opera": "node scripts/build.mjs --opera",
     "dev": "node scripts/build.mjs --watch",
     "dev:firefox": "node scripts/build.mjs --firefox --watch",
+    "dev:opera": "node scripts/build.mjs --opera --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run"
   },

--- a/extensions/dsh-browser/scripts/build.mjs
+++ b/extensions/dsh-browser/scripts/build.mjs
@@ -1,8 +1,9 @@
 /**
- * Build all three extension targets sequentially into dist/ (or dist-firefox/
- * with --firefox):
- * background (es|iife) → content (iife) → panel (React). The first target
- * cleans the output; the later ones append. Pass --watch for dev rebuilds.
+ * Build all three extension bundles sequentially into the target's output
+ * directory (dist/, or dist-firefox/ with --firefox, or dist-opera/ with
+ * --opera): background (es|iife) → content (iife) → panel (React). The first
+ * bundle cleans the output; the later ones append. Pass --watch for dev
+ * rebuilds.
  */
 
 import { spawn, spawnSync } from 'node:child_process'
@@ -11,9 +12,12 @@ import { fileURLToPath } from 'node:url'
 const root = fileURLToPath(new URL('..', import.meta.url))
 const watch = process.argv.includes('--watch')
 
-// --firefox switches the manifest and background bundle for the Firefox build.
+// The target switches the composed manifest, and for Firefox the background
+// bundle format as well.
 if (process.argv.includes('--firefox')) {
   process.env.EXT_TARGET = 'firefox'
+} else if (process.argv.includes('--opera')) {
+  process.env.EXT_TARGET = 'opera'
 }
 
 const configs = [

--- a/extensions/dsh-browser/src/background/index.ts
+++ b/extensions/dsh-browser/src/background/index.ts
@@ -58,15 +58,7 @@ import {
   type TabAffinityDecision,
 } from './tab-affinity.ts'
 import { FocusedWindowTracker } from './focused-window.ts'
-import {
-  forgetPanelWindow,
-  hasPanelWindow,
-  isPanelDocument,
-  isPanelWindow,
-  openAssistantPanel,
-  panelWindowSettled,
-  preferPanelOnActionClick,
-} from './panel-host.ts'
+import { openAssistantPanel, preferPanelOnActionClick } from './panel-host.ts'
 import { ApprovalCoordinator, type ApprovalRequestResult } from './approval-coordinator.ts'
 import {
   RECENT_SESSION_STORAGE_KEY,
@@ -401,98 +393,18 @@ function observeActiveTab(tab: chrome.tabs.Tab): void {
   if (summary !== null) observeActiveSummary(summary)
 }
 
-/**
- * The last window that held a real page. Only consulted where the panel lives
- * in a window of its own: there Chrome's last-focused window is the panel
- * itself while the user types in it, which must never become the tool target.
- *
- * Persisted for the same reason the panel window is: an MV3 restart while the
- * popup is open would otherwise forget which window the user came from, and
- * the popup still answers as the last-focused one.
- */
-const BROWSER_WINDOW_STORAGE_KEY = 'dshBrowserWindow'
-
-let lastBrowserWindowId: number | undefined
-
-/** Whether a live event has named a window since startup, outranking storage. */
-let browserWindowObserved = false
-
-function rememberBrowserWindow(windowId: number | undefined): void {
-  // Set before the equality check: an observation that merely confirms the
-  // current value still outranks a read that is yet to land.
-  browserWindowObserved = true
-  if (lastBrowserWindowId === windowId) return
-  lastBrowserWindowId = windowId
-  try {
-    void (windowId === undefined
-      ? chrome.storage.session.remove(BROWSER_WINDOW_STORAGE_KEY)
-      : chrome.storage.session.set({ [BROWSER_WINDOW_STORAGE_KEY]: windowId })
-    ).catch(() => {})
-  } catch {
-    // Persistence is a convenience; losing it costs a widened query, not correctness.
-  }
-}
-
-async function restoreBrowserWindow(): Promise<void> {
-  try {
-    const stored = await chrome.storage.session.get(BROWSER_WINDOW_STORAGE_KEY)
-    // A toolbar click can start the worker and name its own window while this
-    // read is still in flight; the click is newer than anything stored.
-    if (browserWindowObserved) return
-    const id: unknown = stored[BROWSER_WINDOW_STORAGE_KEY]
-    if (typeof id === 'number' && Number.isInteger(id) && id >= 0) lastBrowserWindowId = id
-  } catch {
-    // Same as above.
-  }
-}
-
-function activeTabQuery(windowId?: number): chrome.tabs.QueryInfo {
-  if (windowId !== undefined) return { active: true, windowId }
-  if (hasPanelWindow() && lastBrowserWindowId !== undefined) {
-    return { active: true, windowId: lastBrowserWindowId }
-  }
-  return { active: true, lastFocusedWindow: true }
-}
-
-/**
- * The active tab, never the panel's own document. A remembered browser window
- * can have closed since it was recorded, so a guess that finds nothing widens
- * to any normal window rather than reporting no active tab while one is open.
- * An explicit `windowId` is the caller's choice and is never widened.
- */
-async function queryActiveBrowserTab(
-  windowId: number | undefined,
-  signal?: AbortSignal,
-): Promise<chrome.tabs.Tab | undefined> {
-  const run = async (query: chrome.tabs.QueryInfo): Promise<chrome.tabs.Tab | undefined> => {
-    const tabs = chrome.tabs.query(query)
-    const resolved = signal === undefined ? await tabs : await abortable(tabs, signal)
-    // Fail closed rather than bind browser tools to the panel's own document.
-    return resolved.find((candidate) => !isPanelDocument(candidate.url))
-  }
-
-  const found = await run(activeTabQuery(windowId))
-  if (found !== undefined || windowId !== undefined) return found
-
-  // Last resort. windowType excludes the panel popup, so this can only answer
-  // with a page, but it answers for every normal window at once. Binding to an
-  // arbitrary one would move browser control silently, which this codebase
-  // never does on an ambiguous signal, so only an unambiguous answer counts.
-  const tabs = chrome.tabs.query({ active: true, windowType: 'normal' })
-  const resolved = signal === undefined ? await tabs : await abortable(tabs, signal)
-  const pages = resolved.filter((candidate) => !isPanelDocument(candidate.url))
-  return pages.length === 1 ? pages[0] : undefined
-}
-
 async function syncActiveTab(windowId?: number, signal?: AbortSignal): Promise<chrome.tabs.Tab | undefined> {
   const queryRevision = focusedWindow.beginQuery()
+  const query = windowId === undefined
+    ? { active: true, lastFocusedWindow: true }
+    : { active: true, windowId }
   try {
-    const tab = await queryActiveBrowserTab(windowId, signal)
+    const tabs = chrome.tabs.query(query)
+    const [tab] = signal === undefined ? await tabs : await abortable(tabs, signal)
     if (signal !== undefined) throwIfRebindAborted(signal)
     if (tab === undefined) return undefined
     if (!focusedWindow.commitQuery(tab.windowId, queryRevision)) return undefined
     if (signal !== undefined) throwIfRebindAborted(signal)
-    rememberBrowserWindow(tab.windowId)
     observeActiveTab(tab)
     return tab
   } catch {
@@ -502,8 +414,6 @@ async function syncActiveTab(windowId?: number, signal?: AbortSignal): Promise<c
 }
 
 async function restoreTabAffinity(): Promise<void> {
-  // Before any sync: the first one runs inside this function.
-  await restoreBrowserWindow()
   let record: StoredTabAffinity | null = null
   try {
     const stored = await chrome.storage.session.get(TAB_AFFINITY_STORAGE_KEY)
@@ -1084,9 +994,6 @@ chrome.notifications.onClicked.addListener((notificationId) => {
 // ---- Tab affinity ----
 
 chrome.tabs.onActivated.addListener(({ tabId, windowId }) => {
-  // The panel window's own tab is never a page to control. acceptActivation
-  // already rejects it while the tracker points elsewhere; this states it.
-  if (isPanelWindow(windowId)) return
   void affinityReady.then(() => {
     const activationRevision = focusedWindow.acceptActivation(windowId)
     if (activationRevision === null) return
@@ -1142,24 +1049,10 @@ chrome.tabs.onRemoved.addListener((tabId) => {
   })
 })
 
-function trackFocusedWindow(windowId: number): void {
-  // Marking the panel's own window focused is what would let its activation
-  // through: tabs.onActivated marks a switch before it has any URL to reject,
-  // so the guard has to be here, where the window is still identifiable.
-  if (isPanelWindow(windowId)) return
-  focusedWindow.markFocused(windowId)
-  void affinityReady.then(() => syncActiveTab(windowId))
-}
-
 chrome.windows.onFocusChanged.addListener((windowId) => {
   if (windowId === chrome.windows.WINDOW_ID_NONE) return
-  // The browser focuses a new panel window before windows.create resolves, so
-  // mid-open this window has no id to compare against yet. Wait for it.
-  if (hasPanelWindow() && !isPanelWindow(windowId)) {
-    void panelWindowSettled().then(() => { trackFocusedWindow(windowId) })
-    return
-  }
-  trackFocusedWindow(windowId)
+  focusedWindow.markFocused(windowId)
+  void affinityReady.then(() => syncActiveTab(windowId))
 })
 
 // ---- Keepalive ----
@@ -1184,17 +1077,7 @@ chrome.alarms.onAlarm.addListener((alarm) => {
 // itself; Firefox and Opera deliver action.onClicked instead, so the listener is
 // registered for every build and openAssistantPanel picks the host at runtime.
 preferPanelOnActionClick()
-chrome.action.onClicked.addListener((tab) => {
-  // Record the window the click came from before any panel window can steal focus.
-  if (tab.windowId !== undefined) rememberBrowserWindow(tab.windowId)
-  void openAssistantPanel(tab.windowId)
-})
-chrome.windows.onRemoved.addListener((windowId) => {
-  forgetPanelWindow(windowId)
-  // A closed window cannot answer an active-tab query; drop it so the next
-  // sync widens instead of targeting a window that is gone.
-  if (lastBrowserWindowId === windowId) rememberBrowserWindow(undefined)
-})
+chrome.action.onClicked.addListener((tab) => { void openAssistantPanel(tab.windowId) })
 
 // Alarms survive some extension/service-worker restarts. Remove any stale
 // schedule left by an older eager-connection build; onConnect re-arms it.

--- a/extensions/dsh-browser/src/background/index.ts
+++ b/extensions/dsh-browser/src/background/index.ts
@@ -405,8 +405,37 @@ function observeActiveTab(tab: chrome.tabs.Tab): void {
  * The last window that held a real page. Only consulted where the panel lives
  * in a window of its own: there Chrome's last-focused window is the panel
  * itself while the user types in it, which must never become the tool target.
+ *
+ * Persisted for the same reason the panel window is: an MV3 restart while the
+ * popup is open would otherwise forget which window the user came from, and
+ * the popup still answers as the last-focused one.
  */
+const BROWSER_WINDOW_STORAGE_KEY = 'dshBrowserWindow'
+
 let lastBrowserWindowId: number | undefined
+
+function rememberBrowserWindow(windowId: number | undefined): void {
+  if (lastBrowserWindowId === windowId) return
+  lastBrowserWindowId = windowId
+  try {
+    void (windowId === undefined
+      ? chrome.storage.session.remove(BROWSER_WINDOW_STORAGE_KEY)
+      : chrome.storage.session.set({ [BROWSER_WINDOW_STORAGE_KEY]: windowId })
+    ).catch(() => {})
+  } catch {
+    // Persistence is a convenience; losing it costs a widened query, not correctness.
+  }
+}
+
+async function restoreBrowserWindow(): Promise<void> {
+  try {
+    const stored = await chrome.storage.session.get(BROWSER_WINDOW_STORAGE_KEY)
+    const id: unknown = stored[BROWSER_WINDOW_STORAGE_KEY]
+    if (typeof id === 'number' && Number.isInteger(id) && id >= 0) lastBrowserWindowId = id
+  } catch {
+    // Same as above.
+  }
+}
 
 function activeTabQuery(windowId?: number): chrome.tabs.QueryInfo {
   if (windowId !== undefined) return { active: true, windowId }
@@ -435,8 +464,15 @@ async function queryActiveBrowserTab(
 
   const found = await run(activeTabQuery(windowId))
   if (found !== undefined || windowId !== undefined) return found
-  // windowType excludes the panel popup, so this can only answer with a page.
-  return run({ active: true, windowType: 'normal' })
+
+  // Last resort. windowType excludes the panel popup, so this can only answer
+  // with a page, but it answers for every normal window at once. Binding to an
+  // arbitrary one would move browser control silently, which this codebase
+  // never does on an ambiguous signal, so only an unambiguous answer counts.
+  const tabs = chrome.tabs.query({ active: true, windowType: 'normal' })
+  const resolved = signal === undefined ? await tabs : await abortable(tabs, signal)
+  const pages = resolved.filter((candidate) => !isPanelDocument(candidate.url))
+  return pages.length === 1 ? pages[0] : undefined
 }
 
 async function syncActiveTab(windowId?: number, signal?: AbortSignal): Promise<chrome.tabs.Tab | undefined> {
@@ -447,7 +483,7 @@ async function syncActiveTab(windowId?: number, signal?: AbortSignal): Promise<c
     if (tab === undefined) return undefined
     if (!focusedWindow.commitQuery(tab.windowId, queryRevision)) return undefined
     if (signal !== undefined) throwIfRebindAborted(signal)
-    lastBrowserWindowId = tab.windowId
+    rememberBrowserWindow(tab.windowId)
     observeActiveTab(tab)
     return tab
   } catch {
@@ -457,6 +493,8 @@ async function syncActiveTab(windowId?: number, signal?: AbortSignal): Promise<c
 }
 
 async function restoreTabAffinity(): Promise<void> {
+  // Before any sync: the first one runs inside this function.
+  await restoreBrowserWindow()
   let record: StoredTabAffinity | null = null
   try {
     const stored = await chrome.storage.session.get(TAB_AFFINITY_STORAGE_KEY)
@@ -1139,14 +1177,14 @@ chrome.alarms.onAlarm.addListener((alarm) => {
 preferPanelOnActionClick()
 chrome.action.onClicked.addListener((tab) => {
   // Record the window the click came from before any panel window can steal focus.
-  if (tab.windowId !== undefined) lastBrowserWindowId = tab.windowId
+  if (tab.windowId !== undefined) rememberBrowserWindow(tab.windowId)
   void openAssistantPanel(tab.windowId)
 })
 chrome.windows.onRemoved.addListener((windowId) => {
   forgetPanelWindow(windowId)
   // A closed window cannot answer an active-tab query; drop it so the next
   // sync widens instead of targeting a window that is gone.
-  if (lastBrowserWindowId === windowId) lastBrowserWindowId = undefined
+  if (lastBrowserWindowId === windowId) rememberBrowserWindow(undefined)
 })
 
 // Alarms survive some extension/service-worker restarts. Remove any stale

--- a/extensions/dsh-browser/src/background/index.ts
+++ b/extensions/dsh-browser/src/background/index.ts
@@ -64,6 +64,7 @@ import {
   isPanelDocument,
   isPanelWindow,
   openAssistantPanel,
+  panelWindowSettled,
   preferPanelOnActionClick,
 } from './panel-host.ts'
 import { ApprovalCoordinator, type ApprovalRequestResult } from './approval-coordinator.ts'
@@ -1017,6 +1018,9 @@ chrome.notifications.onClicked.addListener((notificationId) => {
 // ---- Tab affinity ----
 
 chrome.tabs.onActivated.addListener(({ tabId, windowId }) => {
+  // The panel window's own tab is never a page to control. acceptActivation
+  // already rejects it while the tracker points elsewhere; this states it.
+  if (isPanelWindow(windowId)) return
   void affinityReady.then(() => {
     const activationRevision = focusedWindow.acceptActivation(windowId)
     if (activationRevision === null) return
@@ -1072,13 +1076,24 @@ chrome.tabs.onRemoved.addListener((tabId) => {
   })
 })
 
-chrome.windows.onFocusChanged.addListener((windowId) => {
-  if (windowId === chrome.windows.WINDOW_ID_NONE) return
-  // Focusing the panel's own window is not a tab switch; treating it as one
-  // would hand control to chrome-extension:// or fake a handoff on the session.
+function trackFocusedWindow(windowId: number): void {
+  // Marking the panel's own window focused is what would let its activation
+  // through: tabs.onActivated marks a switch before it has any URL to reject,
+  // so the guard has to be here, where the window is still identifiable.
   if (isPanelWindow(windowId)) return
   focusedWindow.markFocused(windowId)
   void affinityReady.then(() => syncActiveTab(windowId))
+}
+
+chrome.windows.onFocusChanged.addListener((windowId) => {
+  if (windowId === chrome.windows.WINDOW_ID_NONE) return
+  // The browser focuses a new panel window before windows.create resolves, so
+  // mid-open this window has no id to compare against yet. Wait for it.
+  if (hasPanelWindow() && !isPanelWindow(windowId)) {
+    void panelWindowSettled().then(() => { trackFocusedWindow(windowId) })
+    return
+  }
+  trackFocusedWindow(windowId)
 })
 
 // ---- Keepalive ----

--- a/extensions/dsh-browser/src/background/index.ts
+++ b/extensions/dsh-browser/src/background/index.ts
@@ -58,6 +58,7 @@ import {
   type TabAffinityDecision,
 } from './tab-affinity.ts'
 import { FocusedWindowTracker } from './focused-window.ts'
+import { forgetPanelWindow, openAssistantPanel, preferPanelOnActionClick } from './panel-host.ts'
 import { ApprovalCoordinator, type ApprovalRequestResult } from './approval-coordinator.ts'
 import {
   RECENT_SESSION_STORAGE_KEY,
@@ -985,9 +986,9 @@ chrome.notifications.onClicked.addListener((notificationId) => {
   const windowId = approvals.windowId(id)
   if (windowId === undefined) return
   clearApprovalNotification(id)
-  // Notification clicks are extension user gestures; both panel APIs require
+  // Notification clicks are extension user gestures; every panel API requires
   // the call to remain inside this handler.
-  openAssistantPanel(windowId)
+  void openAssistantPanel(windowId)
 })
 
 // ---- Tab affinity ----
@@ -1072,28 +1073,12 @@ chrome.alarms.onAlarm.addListener((alarm) => {
 
 // ---- Boot ----
 
-interface FirefoxSidebarAction {
-  open(): Promise<void> | void
-}
-
-function openAssistantPanel(windowId?: number): void {
-  if (import.meta.env.EXT_TARGET === 'firefox') {
-    const sidebar = (chrome as unknown as { sidebarAction?: FirefoxSidebarAction }).sidebarAction
-    if (sidebar === undefined) return
-    void Promise.resolve(sidebar.open()).catch(() => {})
-    return
-  }
-  if (windowId !== undefined) void chrome.sidePanel.open({ windowId }).catch(() => {})
-}
-
-// Open the side panel when the toolbar icon is clicked.
-// Chrome 116+ uses chrome.sidePanel; Firefox has no sidePanel API, so the
-// action click opens the sidebar via sidebarAction.open() (user gesture).
-if (import.meta.env.EXT_TARGET === 'firefox') {
-  chrome.action.onClicked.addListener(() => { openAssistantPanel() })
-} else {
-  void chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true }).catch(() => {})
-}
+// Open the panel when the toolbar icon is clicked. Chrome opens its side panel
+// itself; Firefox and Opera deliver action.onClicked instead, so the listener is
+// registered for every build and openAssistantPanel picks the host at runtime.
+preferPanelOnActionClick()
+chrome.action.onClicked.addListener((tab) => { void openAssistantPanel(tab.windowId) })
+chrome.windows.onRemoved.addListener((windowId) => { forgetPanelWindow(windowId) })
 
 // Alarms survive some extension/service-worker restarts. Remove any stale
 // schedule left by an older eager-connection build; onConnect re-arms it.

--- a/extensions/dsh-browser/src/background/index.ts
+++ b/extensions/dsh-browser/src/background/index.ts
@@ -416,16 +416,35 @@ function activeTabQuery(windowId?: number): chrome.tabs.QueryInfo {
   return { active: true, lastFocusedWindow: true }
 }
 
+/**
+ * The active tab, never the panel's own document. A remembered browser window
+ * can have closed since it was recorded, so a guess that finds nothing widens
+ * to any normal window rather than reporting no active tab while one is open.
+ * An explicit `windowId` is the caller's choice and is never widened.
+ */
+async function queryActiveBrowserTab(
+  windowId: number | undefined,
+  signal?: AbortSignal,
+): Promise<chrome.tabs.Tab | undefined> {
+  const run = async (query: chrome.tabs.QueryInfo): Promise<chrome.tabs.Tab | undefined> => {
+    const tabs = chrome.tabs.query(query)
+    const resolved = signal === undefined ? await tabs : await abortable(tabs, signal)
+    // Fail closed rather than bind browser tools to the panel's own document.
+    return resolved.find((candidate) => !isPanelDocument(candidate.url))
+  }
+
+  const found = await run(activeTabQuery(windowId))
+  if (found !== undefined || windowId !== undefined) return found
+  // windowType excludes the panel popup, so this can only answer with a page.
+  return run({ active: true, windowType: 'normal' })
+}
+
 async function syncActiveTab(windowId?: number, signal?: AbortSignal): Promise<chrome.tabs.Tab | undefined> {
   const queryRevision = focusedWindow.beginQuery()
-  const query = activeTabQuery(windowId)
   try {
-    const tabs = chrome.tabs.query(query)
-    const [tab] = signal === undefined ? await tabs : await abortable(tabs, signal)
+    const tab = await queryActiveBrowserTab(windowId, signal)
     if (signal !== undefined) throwIfRebindAborted(signal)
     if (tab === undefined) return undefined
-    // Fail closed rather than bind browser tools to the panel's own document.
-    if (isPanelDocument(tab.url)) return undefined
     if (!focusedWindow.commitQuery(tab.windowId, queryRevision)) return undefined
     if (signal !== undefined) throwIfRebindAborted(signal)
     lastBrowserWindowId = tab.windowId
@@ -1123,7 +1142,12 @@ chrome.action.onClicked.addListener((tab) => {
   if (tab.windowId !== undefined) lastBrowserWindowId = tab.windowId
   void openAssistantPanel(tab.windowId)
 })
-chrome.windows.onRemoved.addListener((windowId) => { forgetPanelWindow(windowId) })
+chrome.windows.onRemoved.addListener((windowId) => {
+  forgetPanelWindow(windowId)
+  // A closed window cannot answer an active-tab query; drop it so the next
+  // sync widens instead of targeting a window that is gone.
+  if (lastBrowserWindowId === windowId) lastBrowserWindowId = undefined
+})
 
 // Alarms survive some extension/service-worker restarts. Remove any stale
 // schedule left by an older eager-connection build; onConnect re-arms it.

--- a/extensions/dsh-browser/src/background/index.ts
+++ b/extensions/dsh-browser/src/background/index.ts
@@ -414,7 +414,13 @@ const BROWSER_WINDOW_STORAGE_KEY = 'dshBrowserWindow'
 
 let lastBrowserWindowId: number | undefined
 
+/** Whether a live event has named a window since startup, outranking storage. */
+let browserWindowObserved = false
+
 function rememberBrowserWindow(windowId: number | undefined): void {
+  // Set before the equality check: an observation that merely confirms the
+  // current value still outranks a read that is yet to land.
+  browserWindowObserved = true
   if (lastBrowserWindowId === windowId) return
   lastBrowserWindowId = windowId
   try {
@@ -430,6 +436,9 @@ function rememberBrowserWindow(windowId: number | undefined): void {
 async function restoreBrowserWindow(): Promise<void> {
   try {
     const stored = await chrome.storage.session.get(BROWSER_WINDOW_STORAGE_KEY)
+    // A toolbar click can start the worker and name its own window while this
+    // read is still in flight; the click is newer than anything stored.
+    if (browserWindowObserved) return
     const id: unknown = stored[BROWSER_WINDOW_STORAGE_KEY]
     if (typeof id === 'number' && Number.isInteger(id) && id >= 0) lastBrowserWindowId = id
   } catch {

--- a/extensions/dsh-browser/src/background/index.ts
+++ b/extensions/dsh-browser/src/background/index.ts
@@ -58,7 +58,14 @@ import {
   type TabAffinityDecision,
 } from './tab-affinity.ts'
 import { FocusedWindowTracker } from './focused-window.ts'
-import { forgetPanelWindow, openAssistantPanel, preferPanelOnActionClick } from './panel-host.ts'
+import {
+  forgetPanelWindow,
+  hasPanelWindow,
+  isPanelDocument,
+  isPanelWindow,
+  openAssistantPanel,
+  preferPanelOnActionClick,
+} from './panel-host.ts'
 import { ApprovalCoordinator, type ApprovalRequestResult } from './approval-coordinator.ts'
 import {
   RECENT_SESSION_STORAGE_KEY,
@@ -393,18 +400,34 @@ function observeActiveTab(tab: chrome.tabs.Tab): void {
   if (summary !== null) observeActiveSummary(summary)
 }
 
+/**
+ * The last window that held a real page. Only consulted where the panel lives
+ * in a window of its own: there Chrome's last-focused window is the panel
+ * itself while the user types in it, which must never become the tool target.
+ */
+let lastBrowserWindowId: number | undefined
+
+function activeTabQuery(windowId?: number): chrome.tabs.QueryInfo {
+  if (windowId !== undefined) return { active: true, windowId }
+  if (hasPanelWindow() && lastBrowserWindowId !== undefined) {
+    return { active: true, windowId: lastBrowserWindowId }
+  }
+  return { active: true, lastFocusedWindow: true }
+}
+
 async function syncActiveTab(windowId?: number, signal?: AbortSignal): Promise<chrome.tabs.Tab | undefined> {
   const queryRevision = focusedWindow.beginQuery()
-  const query = windowId === undefined
-    ? { active: true, lastFocusedWindow: true }
-    : { active: true, windowId }
+  const query = activeTabQuery(windowId)
   try {
     const tabs = chrome.tabs.query(query)
     const [tab] = signal === undefined ? await tabs : await abortable(tabs, signal)
     if (signal !== undefined) throwIfRebindAborted(signal)
     if (tab === undefined) return undefined
+    // Fail closed rather than bind browser tools to the panel's own document.
+    if (isPanelDocument(tab.url)) return undefined
     if (!focusedWindow.commitQuery(tab.windowId, queryRevision)) return undefined
     if (signal !== undefined) throwIfRebindAborted(signal)
+    lastBrowserWindowId = tab.windowId
     observeActiveTab(tab)
     return tab
   } catch {
@@ -1051,6 +1074,9 @@ chrome.tabs.onRemoved.addListener((tabId) => {
 
 chrome.windows.onFocusChanged.addListener((windowId) => {
   if (windowId === chrome.windows.WINDOW_ID_NONE) return
+  // Focusing the panel's own window is not a tab switch; treating it as one
+  // would hand control to chrome-extension:// or fake a handoff on the session.
+  if (isPanelWindow(windowId)) return
   focusedWindow.markFocused(windowId)
   void affinityReady.then(() => syncActiveTab(windowId))
 })
@@ -1077,7 +1103,11 @@ chrome.alarms.onAlarm.addListener((alarm) => {
 // itself; Firefox and Opera deliver action.onClicked instead, so the listener is
 // registered for every build and openAssistantPanel picks the host at runtime.
 preferPanelOnActionClick()
-chrome.action.onClicked.addListener((tab) => { void openAssistantPanel(tab.windowId) })
+chrome.action.onClicked.addListener((tab) => {
+  // Record the window the click came from before any panel window can steal focus.
+  if (tab.windowId !== undefined) lastBrowserWindowId = tab.windowId
+  void openAssistantPanel(tab.windowId)
+})
 chrome.windows.onRemoved.addListener((windowId) => { forgetPanelWindow(windowId) })
 
 // Alarms survive some extension/service-worker restarts. Remove any stale

--- a/extensions/dsh-browser/src/background/panel-host.ts
+++ b/extensions/dsh-browser/src/background/panel-host.ts
@@ -1,0 +1,120 @@
+/**
+ * Where the assistant panel opens, which is a per-browser decision.
+ *
+ * Chrome 116+ exposes `chrome.sidePanel`. Firefox and Opera do not: both
+ * render the legacy `sidebar_action` manifest key natively and expose it as
+ * `chrome.sidebarAction`, which Opera additionally mirrors on
+ * `opr.sidebarAction`. A browser with neither API falls back to a narrow popup
+ * window, the one host that always works.
+ *
+ * The choice is made at runtime rather than from the build target because a
+ * single Chrome build is loaded by browsers with different capabilities:
+ * Opera runs the Chrome build but has no Side Panel API.
+ *
+ * @module
+ */
+
+/** Panel window geometry, sized to mirror a docked browser sidebar. */
+const PANEL_WINDOW_WIDTH = 420
+const PANEL_WINDOW_HEIGHT = 760
+
+/** The pre-`sidePanel` sidebar API, as exposed by Firefox and Opera. */
+interface LegacySidebarAction {
+  open?: () => Promise<void> | void
+}
+
+interface SidePanelApi {
+  open: (options: { windowId: number }) => Promise<void>
+}
+
+/** Panel hosts, ordered most native first. */
+export type PanelHost = 'side-panel' | 'sidebar-action' | 'window'
+
+/** The remembered fallback window, so a second click focuses it rather than stacking a duplicate. */
+let panelWindowId: number | undefined
+
+function sidePanelApi(): SidePanelApi | undefined {
+  const api = (chrome as { sidePanel?: SidePanelApi }).sidePanel
+  return typeof api?.open === 'function' ? api : undefined
+}
+
+function legacySidebarApi(): LegacySidebarAction | undefined {
+  const scope = globalThis as { opr?: { sidebarAction?: LegacySidebarAction } }
+  const api = (chrome as { sidebarAction?: LegacySidebarAction }).sidebarAction ?? scope.opr?.sidebarAction
+  return typeof api?.open === 'function' ? api : undefined
+}
+
+/** The most native panel host this browser supports. */
+export function resolvePanelHost(): PanelHost {
+  if (sidePanelApi() !== undefined) return 'side-panel'
+  if (legacySidebarApi() !== undefined) return 'sidebar-action'
+  return 'window'
+}
+
+/**
+ * Chrome opens the side panel itself on toolbar clicks. Browsers without the
+ * API deliver `action.onClicked` instead, which {@link openAssistantPanel}
+ * handles, so this is a no-op there rather than a failure.
+ */
+export function preferPanelOnActionClick(): void {
+  const behavior = (chrome as {
+    sidePanel?: { setPanelBehavior?: (options: { openPanelOnActionClick: boolean }) => Promise<void> }
+  }).sidePanel?.setPanelBehavior
+  if (typeof behavior !== 'function') return
+  void behavior.call(chrome.sidePanel, { openPanelOnActionClick: true }).catch(() => {})
+}
+
+/**
+ * Focus the remembered panel window, or open one. Reusing it matters because a
+ * browser without a sidebar has no other way to show a panel is already up.
+ */
+async function openPanelWindow(): Promise<void> {
+  if (panelWindowId !== undefined) {
+    const focused = await chrome.windows.update(panelWindowId, { focused: true })
+      .then(() => true)
+      .catch(() => false)
+    if (focused) return
+    // The user closed it; fall through and open a replacement.
+    panelWindowId = undefined
+  }
+  const created = await chrome.windows.create({
+    url: chrome.runtime.getURL('panel/index.html'),
+    type: 'popup',
+    width: PANEL_WINDOW_WIDTH,
+    height: PANEL_WINDOW_HEIGHT,
+  }).catch(() => undefined)
+  panelWindowId = created?.id
+}
+
+/**
+ * Open the panel wherever this browser can host it.
+ *
+ * Both sidebar APIs require the call to stay inside the user gesture that
+ * triggered it, so the API lookup and the `open()` call are synchronous;
+ * only the window fallback awaits. `windowId` targets the Chrome side panel —
+ * the other hosts are scoped by the browser itself.
+ */
+export async function openAssistantPanel(windowId?: number): Promise<void> {
+  const sidePanel = sidePanelApi()
+  if (sidePanel !== undefined) {
+    if (windowId === undefined) return
+    await sidePanel.open({ windowId }).catch(() => {})
+    return
+  }
+
+  const sidebar = legacySidebarApi()
+  if (sidebar?.open !== undefined) {
+    try {
+      await sidebar.open()
+      return
+    } catch {
+      // A declared-but-unusable sidebar is still better served by a window.
+    }
+  }
+  await openPanelWindow()
+}
+
+/** Forget the remembered window so the next open creates a fresh one. */
+export function forgetPanelWindow(windowId: number): void {
+  if (panelWindowId === windowId) panelWindowId = undefined
+}

--- a/extensions/dsh-browser/src/background/panel-host.ts
+++ b/extensions/dsh-browser/src/background/panel-host.ts
@@ -108,6 +108,16 @@ export function hasPanelWindow(): boolean {
   return panelWindowOpening !== null || panelWindowId !== undefined
 }
 
+/**
+ * Resolves once any in-flight open has settled, at which point
+ * {@link isPanelWindow} can answer for the window it created. The browser
+ * focuses that window before `windows.create` resolves, so a focus event
+ * arriving mid-open cannot be judged until this settles.
+ */
+export function panelWindowSettled(): Promise<void> {
+  return panelWindowOpening ?? Promise.resolve()
+}
+
 /** Whether a window is the panel's own popup rather than a browser window. */
 export function isPanelWindow(windowId: number): boolean {
   return panelWindowId !== undefined && panelWindowId === windowId

--- a/extensions/dsh-browser/src/background/panel-host.ts
+++ b/extensions/dsh-browser/src/background/panel-host.ts
@@ -32,8 +32,13 @@ export type PanelHost = 'side-panel' | 'sidebar-action' | 'window'
 
 /** The remembered fallback window, so a second click focuses it rather than stacking a duplicate. */
 let panelWindowId: number | undefined
-/** Set before `windows.create` resolves, because the browser focuses the new window first. */
-let panelWindowPending = false
+/**
+ * The in-flight open, held for two reasons: overlapping clicks must share one
+ * window rather than each creating its own, and the browser focuses the new
+ * window before `windows.create` resolves, so the panel has to be claimed
+ * before there is an id to claim it by.
+ */
+let panelWindowOpening: Promise<void> | null = null
 
 function sidePanelApi(): SidePanelApi | undefined {
   const api = (chrome as { sidePanel?: SidePanelApi }).sidePanel
@@ -71,6 +76,17 @@ export function preferPanelOnActionClick(): void {
  * browser without a sidebar has no other way to show a panel is already up.
  */
 async function openPanelWindow(): Promise<void> {
+  // Join an open already in flight instead of racing it to a second window.
+  if (panelWindowOpening !== null) return panelWindowOpening
+  panelWindowOpening = focusOrCreatePanelWindow()
+  try {
+    await panelWindowOpening
+  } finally {
+    panelWindowOpening = null
+  }
+}
+
+async function focusOrCreatePanelWindow(): Promise<void> {
   if (panelWindowId !== undefined) {
     const focused = await chrome.windows.update(panelWindowId, { focused: true })
       .then(() => true)
@@ -79,18 +95,13 @@ async function openPanelWindow(): Promise<void> {
     // The user closed it; fall through and open a replacement.
     panelWindowId = undefined
   }
-  panelWindowPending = true
-  try {
-    const created = await chrome.windows.create({
-      url: chrome.runtime.getURL('panel/index.html'),
-      type: 'popup',
-      width: PANEL_WINDOW_WIDTH,
-      height: PANEL_WINDOW_HEIGHT,
-    }).catch(() => undefined)
-    panelWindowId = created?.id
-  } finally {
-    panelWindowPending = false
-  }
+  const created = await chrome.windows.create({
+    url: chrome.runtime.getURL('panel/index.html'),
+    type: 'popup',
+    width: PANEL_WINDOW_WIDTH,
+    height: PANEL_WINDOW_HEIGHT,
+  }).catch(() => undefined)
+  panelWindowId = created?.id
 }
 
 /**
@@ -99,7 +110,7 @@ async function openPanelWindow(): Promise<void> {
  * this to keep tab affinity pointed at the user's browser window.
  */
 export function hasPanelWindow(): boolean {
-  return panelWindowPending || panelWindowId !== undefined
+  return panelWindowOpening !== null || panelWindowId !== undefined
 }
 
 /** Whether a window is the panel's own popup rather than a browser window. */

--- a/extensions/dsh-browser/src/background/panel-host.ts
+++ b/extensions/dsh-browser/src/background/panel-host.ts
@@ -27,6 +27,14 @@ interface SidePanelApi {
   open: (options: { windowId: number }) => Promise<void>
 }
 
+/**
+ * Session storage outlives a service-worker restart and dies with the browser
+ * session, which is exactly the lifetime of the window it names. Without it an
+ * MV3 restart forgets a popup that is still open, and the next toolbar click
+ * opens a second one.
+ */
+const PANEL_WINDOW_STORAGE_KEY = 'dshPanelWindow'
+
 /** The remembered fallback window, so a second click focuses it rather than stacking a duplicate. */
 let panelWindowId: number | undefined
 /**
@@ -36,6 +44,29 @@ let panelWindowId: number | undefined
  * before there is an id to claim it by.
  */
 let panelWindowOpening: Promise<void> | null = null
+
+/** Rehydrate the remembered window before the first open decides anything. */
+const panelWindowReady: Promise<void> = (async () => {
+  try {
+    const stored = await chrome.storage.session.get(PANEL_WINDOW_STORAGE_KEY)
+    const id: unknown = stored[PANEL_WINDOW_STORAGE_KEY]
+    if (typeof id === 'number' && Number.isInteger(id) && id >= 0) panelWindowId = id
+  } catch {
+    // A forgotten id costs a duplicate popup, not correctness.
+  }
+})()
+
+function rememberPanelWindow(windowId: number | undefined): void {
+  panelWindowId = windowId
+  try {
+    void (windowId === undefined
+      ? chrome.storage.session.remove(PANEL_WINDOW_STORAGE_KEY)
+      : chrome.storage.session.set({ [PANEL_WINDOW_STORAGE_KEY]: windowId })
+    ).catch(() => {})
+  } catch {
+    // Same as above: persistence here is a convenience, not a guarantee.
+  }
+}
 
 function sidePanelApi(): SidePanelApi | undefined {
   const api = (chrome as { sidePanel?: SidePanelApi }).sidePanel
@@ -77,13 +108,15 @@ async function openPanelWindow(): Promise<void> {
 }
 
 async function focusOrCreatePanelWindow(): Promise<void> {
+  // A popup from before a service-worker restart is still open and still ours.
+  await panelWindowReady
   if (panelWindowId !== undefined) {
     const focused = await chrome.windows.update(panelWindowId, { focused: true })
       .then(() => true)
       .catch(() => false)
     if (focused) return
     // The user closed it; fall through and open a replacement.
-    panelWindowId = undefined
+    rememberPanelWindow(undefined)
   }
   try {
     const created = await chrome.windows.create({
@@ -92,10 +125,10 @@ async function focusOrCreatePanelWindow(): Promise<void> {
       width: PANEL_WINDOW_WIDTH,
       height: PANEL_WINDOW_HEIGHT,
     })
-    panelWindowId = created?.id
+    rememberPanelWindow(created?.id)
   } catch {
     // Every caller shares this promise, so a failed open must not reject onto them.
-    panelWindowId = undefined
+    rememberPanelWindow(undefined)
   }
 }
 
@@ -115,7 +148,7 @@ export function hasPanelWindow(): boolean {
  * arriving mid-open cannot be judged until this settles.
  */
 export function panelWindowSettled(): Promise<void> {
-  return panelWindowOpening ?? Promise.resolve()
+  return panelWindowOpening ?? panelWindowReady
 }
 
 /** Whether a window is the panel's own popup rather than a browser window. */
@@ -164,5 +197,5 @@ export async function openAssistantPanel(windowId?: number): Promise<void> {
 
 /** Forget the remembered window so the next open creates a fresh one. */
 export function forgetPanelWindow(windowId: number): void {
-  if (panelWindowId === windowId) panelWindowId = undefined
+  if (panelWindowId === windowId) rememberPanelWindow(undefined)
 }

--- a/extensions/dsh-browser/src/background/panel-host.ts
+++ b/extensions/dsh-browser/src/background/panel-host.ts
@@ -32,6 +32,8 @@ export type PanelHost = 'side-panel' | 'sidebar-action' | 'window'
 
 /** The remembered fallback window, so a second click focuses it rather than stacking a duplicate. */
 let panelWindowId: number | undefined
+/** Set before `windows.create` resolves, because the browser focuses the new window first. */
+let panelWindowPending = false
 
 function sidePanelApi(): SidePanelApi | undefined {
   const api = (chrome as { sidePanel?: SidePanelApi }).sidePanel
@@ -77,13 +79,43 @@ async function openPanelWindow(): Promise<void> {
     // The user closed it; fall through and open a replacement.
     panelWindowId = undefined
   }
-  const created = await chrome.windows.create({
-    url: chrome.runtime.getURL('panel/index.html'),
-    type: 'popup',
-    width: PANEL_WINDOW_WIDTH,
-    height: PANEL_WINDOW_HEIGHT,
-  }).catch(() => undefined)
-  panelWindowId = created?.id
+  panelWindowPending = true
+  try {
+    const created = await chrome.windows.create({
+      url: chrome.runtime.getURL('panel/index.html'),
+      type: 'popup',
+      width: PANEL_WINDOW_WIDTH,
+      height: PANEL_WINDOW_HEIGHT,
+    }).catch(() => undefined)
+    panelWindowId = created?.id
+  } finally {
+    panelWindowPending = false
+  }
+}
+
+/**
+ * Whether this browser hosts the panel in a window of its own. Only then can
+ * Chrome's last-focused window be the panel rather than a page, so callers use
+ * this to keep tab affinity pointed at the user's browser window.
+ */
+export function hasPanelWindow(): boolean {
+  return panelWindowPending || panelWindowId !== undefined
+}
+
+/** Whether a window is the panel's own popup rather than a browser window. */
+export function isPanelWindow(windowId: number): boolean {
+  return panelWindowId !== undefined && panelWindowId === windowId
+}
+
+/**
+ * Whether a tab is showing the panel itself. Content scripts never match
+ * `chrome-extension://`, so binding browser tools to this document would break
+ * every one of them; the URL is authoritative where a window id can still race
+ * the `windows.create` that produced it.
+ */
+export function isPanelDocument(url: string | undefined): boolean {
+  if (url === undefined || url === '') return false
+  return url.startsWith(chrome.runtime.getURL('panel/'))
 }
 
 /**

--- a/extensions/dsh-browser/src/background/panel-host.ts
+++ b/extensions/dsh-browser/src/background/panel-host.ts
@@ -1,22 +1,26 @@
 /**
  * Where the assistant panel opens, which is a per-browser decision.
  *
- * Chrome 116+ exposes `chrome.sidePanel`. Firefox and Opera do not: both
- * render the legacy `sidebar_action` manifest key natively and expose it as
+ * Chrome 116+ exposes `chrome.sidePanel`. Firefox and Opera do not: both render
+ * the legacy `sidebar_action` manifest key natively and expose it as
  * `chrome.sidebarAction`, which Opera additionally mirrors on
- * `opr.sidebarAction`. A browser with neither API falls back to a narrow popup
- * window, the one host that always works.
+ * `opr.sidebarAction`.
  *
  * The choice is made at runtime rather than from the build target because a
- * single Chrome build is loaded by browsers with different capabilities:
- * Opera runs the Chrome build but has no Side Panel API.
+ * single Chrome build is loaded by browsers with different capabilities: Opera
+ * runs the Chrome build but has no Side Panel API.
+ *
+ * A browser with neither API is told so, rather than being given the panel in
+ * a window of its own. Hosting it that way puts a `chrome-extension://`
+ * document where tab affinity expects the user's page, and affinity binds
+ * browser tools to whatever the active tab is; every guard against that is a
+ * guard against this extension's own window, which is a class of bug worth not
+ * having for a browser nobody has reported using.
  *
  * @module
  */
 
-/** Panel window geometry, sized to mirror a docked browser sidebar. */
-const PANEL_WINDOW_WIDTH = 420
-const PANEL_WINDOW_HEIGHT = 760
+import { getUiLocale } from '../i18n.ts'
 
 /** The pre-`sidePanel` sidebar API, as exposed by Firefox and Opera. */
 interface LegacySidebarAction {
@@ -27,46 +31,7 @@ interface SidePanelApi {
   open: (options: { windowId: number }) => Promise<void>
 }
 
-/**
- * Session storage outlives a service-worker restart and dies with the browser
- * session, which is exactly the lifetime of the window it names. Without it an
- * MV3 restart forgets a popup that is still open, and the next toolbar click
- * opens a second one.
- */
-const PANEL_WINDOW_STORAGE_KEY = 'dshPanelWindow'
-
-/** The remembered fallback window, so a second click focuses it rather than stacking a duplicate. */
-let panelWindowId: number | undefined
-/**
- * The in-flight open, held for two reasons: overlapping clicks must share one
- * window rather than each creating its own, and the browser focuses the new
- * window before `windows.create` resolves, so the panel has to be claimed
- * before there is an id to claim it by.
- */
-let panelWindowOpening: Promise<void> | null = null
-
-/** Rehydrate the remembered window before the first open decides anything. */
-const panelWindowReady: Promise<void> = (async () => {
-  try {
-    const stored = await chrome.storage.session.get(PANEL_WINDOW_STORAGE_KEY)
-    const id: unknown = stored[PANEL_WINDOW_STORAGE_KEY]
-    if (typeof id === 'number' && Number.isInteger(id) && id >= 0) panelWindowId = id
-  } catch {
-    // A forgotten id costs a duplicate popup, not correctness.
-  }
-})()
-
-function rememberPanelWindow(windowId: number | undefined): void {
-  panelWindowId = windowId
-  try {
-    void (windowId === undefined
-      ? chrome.storage.session.remove(PANEL_WINDOW_STORAGE_KEY)
-      : chrome.storage.session.set({ [PANEL_WINDOW_STORAGE_KEY]: windowId })
-    ).catch(() => {})
-  } catch {
-    // Same as above: persistence here is a convenience, not a guarantee.
-  }
-}
+const UNSUPPORTED_NOTIFICATION_ID = 'dsh-panel-unsupported'
 
 function sidePanelApi(): SidePanelApi | undefined {
   const api = (chrome as { sidePanel?: SidePanelApi }).sidePanel
@@ -92,88 +57,31 @@ export function preferPanelOnActionClick(): void {
   void behavior.call(chrome.sidePanel, { openPanelOnActionClick: true }).catch(() => {})
 }
 
-/**
- * Focus the remembered panel window, or open one. Reusing it matters because a
- * browser without a sidebar has no other way to show a panel is already up.
- */
-async function openPanelWindow(): Promise<void> {
-  // Join an open already in flight instead of racing it to a second window.
-  if (panelWindowOpening !== null) return panelWindowOpening
-  panelWindowOpening = focusOrCreatePanelWindow()
-  try {
-    await panelWindowOpening
-  } finally {
-    panelWindowOpening = null
-  }
-}
-
-async function focusOrCreatePanelWindow(): Promise<void> {
-  // A popup from before a service-worker restart is still open and still ours.
-  await panelWindowReady
-  if (panelWindowId !== undefined) {
-    const focused = await chrome.windows.update(panelWindowId, { focused: true })
-      .then(() => true)
-      .catch(() => false)
-    if (focused) return
-    // The user closed it; fall through and open a replacement.
-    rememberPanelWindow(undefined)
-  }
-  try {
-    const created = await chrome.windows.create({
-      url: chrome.runtime.getURL('panel/index.html'),
-      type: 'popup',
-      width: PANEL_WINDOW_WIDTH,
-      height: PANEL_WINDOW_HEIGHT,
-    })
-    rememberPanelWindow(created?.id)
-  } catch {
-    // Every caller shares this promise, so a failed open must not reject onto them.
-    rememberPanelWindow(undefined)
-  }
-}
-
-/**
- * Whether this browser hosts the panel in a window of its own. Only then can
- * Chrome's last-focused window be the panel rather than a page, so callers use
- * this to keep tab affinity pointed at the user's browser window.
- */
-export function hasPanelWindow(): boolean {
-  return panelWindowOpening !== null || panelWindowId !== undefined
-}
-
-/**
- * Resolves once any in-flight open has settled, at which point
- * {@link isPanelWindow} can answer for the window it created. The browser
- * focuses that window before `windows.create` resolves, so a focus event
- * arriving mid-open cannot be judged until this settles.
- */
-export function panelWindowSettled(): Promise<void> {
-  return panelWindowOpening ?? panelWindowReady
-}
-
-/** Whether a window is the panel's own popup rather than a browser window. */
-export function isPanelWindow(windowId: number): boolean {
-  return panelWindowId !== undefined && panelWindowId === windowId
-}
-
-/**
- * Whether a tab is showing the panel itself. Content scripts never match
- * `chrome-extension://`, so binding browser tools to this document would break
- * every one of them; the URL is authoritative where a window id can still race
- * the `windows.create` that produced it.
- */
-export function isPanelDocument(url: string | undefined): boolean {
-  if (url === undefined || url === '') return false
-  return url.startsWith(chrome.runtime.getURL('panel/'))
+/** Say why nothing opened, so a dead toolbar click is never the whole answer. */
+function reportUnsupportedBrowser(): void {
+  const copy = getUiLocale() === 'zh'
+    ? {
+      title: '此浏览器无法打开侧栏',
+      message: '该浏览器既没有侧边面板，也没有侧栏扩展接口。请改用 Chrome 116+、Firefox 140+ 或 Opera。',
+    }
+    : {
+      title: 'This browser cannot open the panel',
+      message: 'It has neither a side panel nor a sidebar extension API. Use Chrome 116+, Firefox 140+, or Opera instead.',
+    }
+  void Promise.resolve(chrome.notifications.create(UNSUPPORTED_NOTIFICATION_ID, {
+    type: 'basic',
+    iconUrl: chrome.runtime.getURL('assets/icons/icon128.png'),
+    title: copy.title,
+    message: copy.message,
+  })).catch(() => {})
 }
 
 /**
  * Open the panel wherever this browser can host it.
  *
- * Both sidebar APIs require the call to stay inside the user gesture that
- * triggered it, so the API lookup and the `open()` call are synchronous;
- * only the window fallback awaits. `windowId` targets the Chrome side panel —
- * the other hosts are scoped by the browser itself.
+ * Both APIs require the call to stay inside the user gesture that triggered it,
+ * so the lookup and the `open()` call are synchronous. `windowId` targets the
+ * Chrome side panel — the sidebar is scoped by the browser itself.
  */
 export async function openAssistantPanel(windowId?: number): Promise<void> {
   const sidePanel = sidePanelApi()
@@ -189,13 +97,8 @@ export async function openAssistantPanel(windowId?: number): Promise<void> {
       await sidebar.open()
       return
     } catch {
-      // A declared-but-unusable sidebar is still better served by a window.
+      // A declared-but-unusable sidebar is no different from having none.
     }
   }
-  await openPanelWindow()
-}
-
-/** Forget the remembered window so the next open creates a fresh one. */
-export function forgetPanelWindow(windowId: number): void {
-  if (panelWindowId === windowId) rememberPanelWindow(undefined)
+  reportUnsupportedBrowser()
 }

--- a/extensions/dsh-browser/src/background/panel-host.ts
+++ b/extensions/dsh-browser/src/background/panel-host.ts
@@ -27,9 +27,6 @@ interface SidePanelApi {
   open: (options: { windowId: number }) => Promise<void>
 }
 
-/** Panel hosts, ordered most native first. */
-export type PanelHost = 'side-panel' | 'sidebar-action' | 'window'
-
 /** The remembered fallback window, so a second click focuses it rather than stacking a duplicate. */
 let panelWindowId: number | undefined
 /**
@@ -49,13 +46,6 @@ function legacySidebarApi(): LegacySidebarAction | undefined {
   const scope = globalThis as { opr?: { sidebarAction?: LegacySidebarAction } }
   const api = (chrome as { sidebarAction?: LegacySidebarAction }).sidebarAction ?? scope.opr?.sidebarAction
   return typeof api?.open === 'function' ? api : undefined
-}
-
-/** The most native panel host this browser supports. */
-export function resolvePanelHost(): PanelHost {
-  if (sidePanelApi() !== undefined) return 'side-panel'
-  if (legacySidebarApi() !== undefined) return 'sidebar-action'
-  return 'window'
 }
 
 /**
@@ -95,13 +85,18 @@ async function focusOrCreatePanelWindow(): Promise<void> {
     // The user closed it; fall through and open a replacement.
     panelWindowId = undefined
   }
-  const created = await chrome.windows.create({
-    url: chrome.runtime.getURL('panel/index.html'),
-    type: 'popup',
-    width: PANEL_WINDOW_WIDTH,
-    height: PANEL_WINDOW_HEIGHT,
-  }).catch(() => undefined)
-  panelWindowId = created?.id
+  try {
+    const created = await chrome.windows.create({
+      url: chrome.runtime.getURL('panel/index.html'),
+      type: 'popup',
+      width: PANEL_WINDOW_WIDTH,
+      height: PANEL_WINDOW_HEIGHT,
+    })
+    panelWindowId = created?.id
+  } catch {
+    // Every caller shares this promise, so a failed open must not reject onto them.
+    panelWindowId = undefined
+  }
 }
 
 /**

--- a/extensions/dsh-browser/src/panel/styles.css
+++ b/extensions/dsh-browser/src/panel/styles.css
@@ -1514,6 +1514,13 @@ textarea:focus-visible {
   scrollbar-gutter: stable;
 }
 
+/* Settings cards set overflow:hidden, which resolves their flex min-height to
+   zero and lets a short window compress them instead of scrolling. Holding
+   their natural height keeps "Save & Connect" reachable at any height. */
+.settings > * {
+  flex-shrink: 0;
+}
+
 .settings-heading {
   display: flex;
   align-items: center;

--- a/extensions/dsh-browser/tests/background-bridge-lifecycle.spec.ts
+++ b/extensions/dsh-browser/tests/background-bridge-lifecycle.spec.ts
@@ -104,7 +104,6 @@ function mockChrome(options: {
     windows: {
       WINDOW_ID_NONE: -1,
       onFocusChanged: chromeEvent<[number]>(),
-      onRemoved: chromeEvent<[number]>(),
     },
   } as unknown as typeof chrome)
   return { alarms, onConnect }

--- a/extensions/dsh-browser/tests/background-bridge-lifecycle.spec.ts
+++ b/extensions/dsh-browser/tests/background-bridge-lifecycle.spec.ts
@@ -65,6 +65,9 @@ function mockChrome(options: {
   }
   vi.stubGlobal('chrome', {
     alarms,
+    action: {
+      onClicked: chromeEvent<[chrome.tabs.Tab]>(),
+    },
     notifications: {
       create: vi.fn(async () => ''),
       clear: vi.fn(async () => true),
@@ -101,6 +104,7 @@ function mockChrome(options: {
     windows: {
       WINDOW_ID_NONE: -1,
       onFocusChanged: chromeEvent<[number]>(),
+      onRemoved: chromeEvent<[number]>(),
     },
   } as unknown as typeof chrome)
   return { alarms, onConnect }

--- a/extensions/dsh-browser/tests/background-tab-affinity-rebind.spec.ts
+++ b/extensions/dsh-browser/tests/background-tab-affinity-rebind.spec.ts
@@ -41,8 +41,16 @@ function tab(tabId: number): chrome.tabs.Tab {
   }
 }
 
-function mockChrome(options: { sidePanel?: boolean; session?: Record<string, unknown> } = {}) {
+function mockChrome(options: {
+  sidePanel?: boolean
+  session?: Record<string, unknown>
+  deferBrowserWindowRead?: boolean
+} = {}) {
   const sessionData: Record<string, unknown> = { ...options.session }
+  let releaseBrowserWindowRead: () => void = () => {}
+  const browserWindowRead = options.deferBrowserWindowRead === true
+    ? new Promise<void>((resolve) => { releaseBrowserWindowRead = resolve })
+    : Promise.resolve()
   const onConnect = chromeEvent<[chrome.runtime.Port]>()
   const onFocusChanged = chromeEvent<[number]>()
   const onActivated = chromeEvent<[{ tabId: number; windowId: number }]>()
@@ -82,7 +90,15 @@ function mockChrome(options: { sidePanel?: boolean; session?: Record<string, unk
         set: vi.fn(async () => {}),
       },
       session: {
-        get: vi.fn(async (key: string) => (key in sessionData ? { [key]: sessionData[key] } : {})),
+        // A real read snapshots when it is issued, so capture the value now and
+        // deliver it later; reading after the wait would see writes that
+        // happened in between and hide exactly the staleness under test.
+        get: vi.fn((key: string) => {
+          const snapshot = key in sessionData ? { [key]: sessionData[key] } : {}
+          return key === 'dshBrowserWindow'
+            ? browserWindowRead.then(() => snapshot)
+            : Promise.resolve(snapshot)
+        }),
         set: vi.fn(async (items: Record<string, unknown>) => { Object.assign(sessionData, items) }),
         remove: vi.fn(async (key: string) => { delete sessionData[key] }),
       },
@@ -105,6 +121,7 @@ function mockChrome(options: { sidePanel?: boolean; session?: Record<string, unk
     },
   } as unknown as typeof chrome)
   return {
+    releaseBrowserWindowRead: () => { releaseBrowserWindowRead() },
     sessionData,
     createWindow,
     onActionClicked,
@@ -405,6 +422,48 @@ describe('background tab-affinity rebind protocol', () => {
         error: expect.objectContaining({ code: 'no-active-tab' }),
       }))
     })
+  })
+
+  it('keeps the clicked window when a stored one arrives late', async () => {
+    // A toolbar click can cold-start the worker: the click names its own window
+    // while the restore read is still in flight, and is newer than the store.
+    const chromeMock = mockChrome({
+      sidePanel: false,
+      // No stored panel window, so the click opens one and hasPanelWindow()
+      // becomes true the same way it would in a real fallback session.
+      session: { dshBrowserWindow: 1 },
+      deferBrowserWindowRead: true,
+    })
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(null, { status: 503 })))
+    // Model the real situation: the popup holds focus, so an unfiltered
+    // last-focused query answers with the panel document, and two normal
+    // windows make the widened query ambiguous. Only the remembered window id
+    // can name a page here — which is exactly what the stale read would break.
+    const panelTab = { ...tab(99), windowId: 9, url: 'chrome-extension://test/panel/index.html' }
+    chromeMock.query.mockImplementation(async (info: chrome.tabs.QueryInfo) => {
+      if (info.windowId !== undefined) return [{ ...tab(info.windowId), windowId: info.windowId }]
+      if (info.windowType === 'normal') {
+        return [{ ...tab(1), windowId: 1 }, { ...tab(5), windowId: 5 }]
+      }
+      return [panelTab]
+    })
+    await import('../src/background/index.ts')
+
+    // The click lands first; the stale stored id resolves only afterwards.
+    chromeMock.onActionClicked.emit({ ...tab(5), windowId: 5 })
+    chromeMock.releaseBrowserWindowRead()
+    await vi.waitFor(() => { expect(chromeMock.createWindow).toHaveBeenCalled() })
+    chromeMock.resolveCreate(9)
+
+    const panel = panelPort()
+    chromeMock.onConnect.emit(panel.port)
+    await vi.waitFor(() => {
+      expect(panel.postMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'tab-affinity' }))
+    })
+
+    const targeted = chromeMock.query.mock.calls.map(([info]) => info as chrome.tabs.QueryInfo)
+    expect(targeted.some((info) => info.windowId === 5)).toBe(true)
+    expect(targeted.some((info) => info.windowId === 1)).toBe(false)
   })
 
   it('owns the deadline in the background and ignores a query that resolves after timeout', async () => {

--- a/extensions/dsh-browser/tests/background-tab-affinity-rebind.spec.ts
+++ b/extensions/dsh-browser/tests/background-tab-affinity-rebind.spec.ts
@@ -50,6 +50,9 @@ function mockChrome() {
       clear: vi.fn(async () => true),
       onAlarm: chromeEvent<[chrome.alarms.Alarm]>(),
     },
+    action: {
+      onClicked: chromeEvent<[chrome.tabs.Tab]>(),
+    },
     notifications: {
       create: vi.fn(async () => ''),
       clear: vi.fn(async () => true),
@@ -86,6 +89,7 @@ function mockChrome() {
     windows: {
       WINDOW_ID_NONE: -1,
       onFocusChanged: chromeEvent<[number]>(),
+      onRemoved: chromeEvent<[number]>(),
     },
   } as unknown as typeof chrome)
   return { onConnect, query }

--- a/extensions/dsh-browser/tests/background-tab-affinity-rebind.spec.ts
+++ b/extensions/dsh-browser/tests/background-tab-affinity-rebind.spec.ts
@@ -45,8 +45,9 @@ function mockChrome(options: { sidePanel?: boolean } = {}) {
   const onConnect = chromeEvent<[chrome.runtime.Port]>()
   const onFocusChanged = chromeEvent<[number]>()
   const onActivated = chromeEvent<[{ tabId: number; windowId: number }]>()
+  const onWindowRemoved = chromeEvent<[number]>()
   const onActionClicked = chromeEvent<[chrome.tabs.Tab]>()
-  const query = vi.fn(async () => [tab(1)])
+  const query = vi.fn(async (_info: chrome.tabs.QueryInfo) => [tab(1)])
   // Browsers with no Side Panel API host the panel in a window of its own.
   let resolveCreate: (value: { id: number }) => void = () => {}
   const createWindow = vi.fn(() => new Promise<{ id: number }>((resolve) => { resolveCreate = resolve }))
@@ -97,7 +98,7 @@ function mockChrome(options: { sidePanel?: boolean } = {}) {
     windows: {
       WINDOW_ID_NONE: -1,
       onFocusChanged,
-      onRemoved: chromeEvent<[number]>(),
+      onRemoved: onWindowRemoved,
       create: createWindow,
       update: vi.fn(async () => ({})),
     },
@@ -108,6 +109,7 @@ function mockChrome(options: { sidePanel?: boolean } = {}) {
     onActivated,
     onConnect,
     onFocusChanged,
+    onWindowRemoved,
     query,
     resolveCreate: (id: number) => { resolveCreate({ id }) },
   }
@@ -295,6 +297,66 @@ describe('background tab-affinity rebind protocol', () => {
         status: 'following',
         controlled: expect.objectContaining({ tabId: 1 }),
       }),
+    }))
+  })
+
+  /** Bind to window 1, then open the fallback popup on top of it. */
+  async function bindThenOpenPopup() {
+    const chromeMock = mockChrome({ sidePanel: false })
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(null, { status: 503 })))
+    await import('../src/background/index.ts')
+    await vi.waitFor(() => { expect(chromeMock.query).toHaveBeenCalled() })
+
+    const panel = panelPort()
+    chromeMock.onConnect.emit(panel.port)
+    await vi.waitFor(() => {
+      expect(panel.postMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'tab-affinity' }))
+    })
+
+    chromeMock.onFocusChanged.emit(1)
+    await vi.waitFor(() => {
+      expect(chromeMock.query).toHaveBeenCalledWith(expect.objectContaining({ windowId: 1 }))
+    })
+    chromeMock.onActionClicked.emit(tab(1))
+    await vi.waitFor(() => { expect(chromeMock.createWindow).toHaveBeenCalled() })
+    chromeMock.resolveCreate(9)
+    return { ...chromeMock, panel }
+  }
+
+  it('stops targeting a browser window that has closed', async () => {
+    // The popup keeps focus after the originating window closes, and its own
+    // focus events are ignored, so nothing else would refresh the stale id.
+    const { onWindowRemoved, panel, query } = await bindThenOpenPopup()
+
+    onWindowRemoved.emit(1)
+    query.mockClear()
+
+    panel.onMessage.emit({ type: 'tab-affinity.rebind', id: 'after-close' })
+    await vi.waitFor(() => { expect(query).toHaveBeenCalled() })
+
+    const targeted = query.mock.calls.map(([info]) => info as chrome.tabs.QueryInfo)
+    expect(targeted.some((info) => info.windowId === 1)).toBe(false)
+  })
+
+  it('recovers through another window when the remembered one answers nothing', async () => {
+    const { panel, query } = await bindThenOpenPopup()
+    panel.postMessage.mockClear()
+
+    // Window 1 no longer has an active tab; only a normal-window query finds one.
+    const survivor = { ...tab(2), windowId: 2 }
+    query.mockImplementation(async (info: chrome.tabs.QueryInfo) => (
+      info.windowType === 'normal' ? [survivor] : []
+    ))
+
+    panel.onMessage.emit({ type: 'tab-affinity.rebind', id: 'widen' })
+    await vi.waitFor(() => {
+      expect(panel.postMessage).toHaveBeenCalledWith({
+        type: 'tab-affinity.rebind.result', id: 'widen', ok: true,
+      })
+    })
+    expect(panel.postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'tab-affinity',
+      state: expect.objectContaining({ controlled: expect.objectContaining({ tabId: 2 }) }),
     }))
   })
 

--- a/extensions/dsh-browser/tests/background-tab-affinity-rebind.spec.ts
+++ b/extensions/dsh-browser/tests/background-tab-affinity-rebind.spec.ts
@@ -41,10 +41,15 @@ function tab(tabId: number): chrome.tabs.Tab {
   }
 }
 
-function mockChrome() {
+function mockChrome(options: { sidePanel?: boolean } = {}) {
   const onConnect = chromeEvent<[chrome.runtime.Port]>()
   const onFocusChanged = chromeEvent<[number]>()
+  const onActivated = chromeEvent<[{ tabId: number; windowId: number }]>()
+  const onActionClicked = chromeEvent<[chrome.tabs.Tab]>()
   const query = vi.fn(async () => [tab(1)])
+  // Browsers with no Side Panel API host the panel in a window of its own.
+  let resolveCreate: (value: { id: number }) => void = () => {}
+  const createWindow = vi.fn(() => new Promise<{ id: number }>((resolve) => { resolveCreate = resolve }))
   vi.stubGlobal('chrome', {
     alarms: {
       create: vi.fn(),
@@ -52,7 +57,7 @@ function mockChrome() {
       onAlarm: chromeEvent<[chrome.alarms.Alarm]>(),
     },
     action: {
-      onClicked: chromeEvent<[chrome.tabs.Tab]>(),
+      onClicked: onActionClicked,
     },
     notifications: {
       create: vi.fn(async () => ''),
@@ -63,10 +68,12 @@ function mockChrome() {
       getURL: (path: string) => `chrome-extension://test/${path}`,
       onConnect,
     },
-    sidePanel: {
-      open: vi.fn(async () => {}),
-      setPanelBehavior: vi.fn(async () => {}),
-    },
+    ...(options.sidePanel === false ? {} : {
+      sidePanel: {
+        open: vi.fn(async () => {}),
+        setPanelBehavior: vi.fn(async () => {}),
+      },
+    }),
     storage: {
       local: {
         get: vi.fn(async () => ({})),
@@ -82,7 +89,7 @@ function mockChrome() {
       get: vi.fn(async (tabId: number) => tab(tabId)),
       query,
       sendMessage: vi.fn(async () => {}),
-      onActivated: chromeEvent<[{ tabId: number; windowId: number }]>(),
+      onActivated,
       onUpdated: chromeEvent<[number, chrome.tabs.TabChangeInfo, chrome.tabs.Tab]>(),
       onReplaced: chromeEvent<[number, number]>(),
       onRemoved: chromeEvent<[number]>(),
@@ -91,9 +98,19 @@ function mockChrome() {
       WINDOW_ID_NONE: -1,
       onFocusChanged,
       onRemoved: chromeEvent<[number]>(),
+      create: createWindow,
+      update: vi.fn(async () => ({})),
     },
   } as unknown as typeof chrome)
-  return { onConnect, onFocusChanged, query }
+  return {
+    createWindow,
+    onActionClicked,
+    onActivated,
+    onConnect,
+    onFocusChanged,
+    query,
+    resolveCreate: (id: number) => { resolveCreate({ id }) },
+  }
 }
 
 async function connectPanelForTest() {
@@ -229,6 +246,50 @@ describe('background tab-affinity rebind protocol', () => {
 
     onMessage.emit({ type: 'request-status' })
     expect(postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'tab-affinity',
+      state: expect.objectContaining({
+        status: 'following',
+        controlled: expect.objectContaining({ tabId: 1 }),
+      }),
+    }))
+  })
+
+  it('ignores the popup activation that arrives before windows.create resolves', async () => {
+    // The browser focuses and activates the new panel window before create()
+    // resolves, so its id is still unknown. Marking it focused there would let
+    // tabs.onActivated mark a switch — it has no URL yet to reject — handing
+    // control to the extension page and cancelling pending approvals.
+    const chromeMock = mockChrome({ sidePanel: false })
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(null, { status: 503 })))
+    await import('../src/background/index.ts')
+    await vi.waitFor(() => { expect(chromeMock.query).toHaveBeenCalled() })
+
+    const panel = panelPort()
+    chromeMock.onConnect.emit(panel.port)
+    await vi.waitFor(() => {
+      expect(panel.postMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'tab-affinity' }))
+    })
+    panel.onMessage.emit({ type: 'tab-affinity.rebind', id: 'initial-bind' })
+    await vi.waitFor(() => {
+      expect(panel.postMessage).toHaveBeenCalledWith({
+        type: 'tab-affinity.rebind.result', id: 'initial-bind', ok: true,
+      })
+    })
+    panel.postMessage.mockClear()
+
+    // Toolbar click opens the fallback window; create() stays pending.
+    chromeMock.onActionClicked.emit(tab(1))
+    await vi.waitFor(() => { expect(chromeMock.createWindow).toHaveBeenCalled() })
+
+    // The popup takes focus and activates its own tab, both before create()
+    // resolves and therefore before the window has an id to be matched by.
+    chromeMock.onFocusChanged.emit(9)
+    chromeMock.onActivated.emit({ tabId: 99, windowId: 9 })
+    chromeMock.resolveCreate(9)
+    await vi.waitFor(() => { expect(chromeMock.createWindow).toHaveBeenCalledOnce() })
+
+    panel.onMessage.emit({ type: 'request-status' })
+    expect(panel.postMessage).toHaveBeenCalledWith(expect.objectContaining({
       type: 'tab-affinity',
       state: expect.objectContaining({
         status: 'following',

--- a/extensions/dsh-browser/tests/background-tab-affinity-rebind.spec.ts
+++ b/extensions/dsh-browser/tests/background-tab-affinity-rebind.spec.ts
@@ -41,25 +41,9 @@ function tab(tabId: number): chrome.tabs.Tab {
   }
 }
 
-function mockChrome(options: {
-  sidePanel?: boolean
-  session?: Record<string, unknown>
-  deferBrowserWindowRead?: boolean
-} = {}) {
-  const sessionData: Record<string, unknown> = { ...options.session }
-  let releaseBrowserWindowRead: () => void = () => {}
-  const browserWindowRead = options.deferBrowserWindowRead === true
-    ? new Promise<void>((resolve) => { releaseBrowserWindowRead = resolve })
-    : Promise.resolve()
+function mockChrome() {
   const onConnect = chromeEvent<[chrome.runtime.Port]>()
-  const onFocusChanged = chromeEvent<[number]>()
-  const onActivated = chromeEvent<[{ tabId: number; windowId: number }]>()
-  const onWindowRemoved = chromeEvent<[number]>()
-  const onActionClicked = chromeEvent<[chrome.tabs.Tab]>()
-  const query = vi.fn(async (_info: chrome.tabs.QueryInfo) => [tab(1)])
-  // Browsers with no Side Panel API host the panel in a window of its own.
-  let resolveCreate: (value: { id: number }) => void = () => {}
-  const createWindow = vi.fn(() => new Promise<{ id: number }>((resolve) => { resolveCreate = resolve }))
+  const query = vi.fn(async () => [tab(1)])
   vi.stubGlobal('chrome', {
     alarms: {
       create: vi.fn(),
@@ -67,7 +51,7 @@ function mockChrome(options: {
       onAlarm: chromeEvent<[chrome.alarms.Alarm]>(),
     },
     action: {
-      onClicked: onActionClicked,
+      onClicked: chromeEvent<[chrome.tabs.Tab]>(),
     },
     notifications: {
       create: vi.fn(async () => ''),
@@ -78,60 +62,36 @@ function mockChrome(options: {
       getURL: (path: string) => `chrome-extension://test/${path}`,
       onConnect,
     },
-    ...(options.sidePanel === false ? {} : {
-      sidePanel: {
-        open: vi.fn(async () => {}),
-        setPanelBehavior: vi.fn(async () => {}),
-      },
-    }),
+    sidePanel: {
+      open: vi.fn(async () => {}),
+      setPanelBehavior: vi.fn(async () => {}),
+    },
     storage: {
       local: {
         get: vi.fn(async () => ({})),
         set: vi.fn(async () => {}),
       },
       session: {
-        // A real read snapshots when it is issued, so capture the value now and
-        // deliver it later; reading after the wait would see writes that
-        // happened in between and hide exactly the staleness under test.
-        get: vi.fn((key: string) => {
-          const snapshot = key in sessionData ? { [key]: sessionData[key] } : {}
-          return key === 'dshBrowserWindow'
-            ? browserWindowRead.then(() => snapshot)
-            : Promise.resolve(snapshot)
-        }),
-        set: vi.fn(async (items: Record<string, unknown>) => { Object.assign(sessionData, items) }),
-        remove: vi.fn(async (key: string) => { delete sessionData[key] }),
+        get: vi.fn(async () => ({})),
+        set: vi.fn(async () => {}),
+        remove: vi.fn(async () => {}),
       },
     },
     tabs: {
       get: vi.fn(async (tabId: number) => tab(tabId)),
       query,
       sendMessage: vi.fn(async () => {}),
-      onActivated,
+      onActivated: chromeEvent<[{ tabId: number; windowId: number }]>(),
       onUpdated: chromeEvent<[number, chrome.tabs.TabChangeInfo, chrome.tabs.Tab]>(),
       onReplaced: chromeEvent<[number, number]>(),
       onRemoved: chromeEvent<[number]>(),
     },
     windows: {
       WINDOW_ID_NONE: -1,
-      onFocusChanged,
-      onRemoved: onWindowRemoved,
-      create: createWindow,
-      update: vi.fn(async () => ({})),
+      onFocusChanged: chromeEvent<[number]>(),
     },
   } as unknown as typeof chrome)
-  return {
-    releaseBrowserWindowRead: () => { releaseBrowserWindowRead() },
-    sessionData,
-    createWindow,
-    onActionClicked,
-    onActivated,
-    onConnect,
-    onFocusChanged,
-    onWindowRemoved,
-    query,
-    resolveCreate: (id: number) => { resolveCreate({ id }) },
-  }
+  return { onConnect, query }
 }
 
 async function connectPanelForTest() {
@@ -140,7 +100,6 @@ async function connectPanelForTest() {
   await import('../src/background/index.ts')
   await vi.waitFor(() => { expect(chromeMock.query).toHaveBeenCalled() })
 
-  onFocusChanged = chromeMock.onFocusChanged
   const panel = panelPort()
   chromeMock.onConnect.emit(panel.port)
   await vi.waitFor(() => {
@@ -155,8 +114,6 @@ afterEach(() => {
   vi.resetModules()
   vi.unstubAllGlobals()
 })
-
-let onFocusChanged: ReturnType<typeof chromeEvent<[number]>>
 
 describe('background tab-affinity rebind protocol', () => {
   it('acknowledges only after control has moved to the freshly queried active tab', async () => {
@@ -206,264 +163,6 @@ describe('background tab-affinity rebind protocol', () => {
       type: 'tab-affinity',
       state: expect.objectContaining({ status: 'following', controlled: expect.objectContaining({ tabId: 1 }) }),
     }))
-  })
-
-  it('never binds browser control to the panel document itself', async () => {
-    // Browsers with no side-panel API host the panel in a window of its own,
-    // whose tab is the active tab while the user types in it. Content scripts
-    // never match chrome-extension://, so binding here breaks every tool.
-    const { onMessage, postMessage, query } = await connectPanelForTest()
-    onMessage.emit({ type: 'tab-affinity.rebind', id: 'initial-bind' })
-    await vi.waitFor(() => {
-      expect(postMessage).toHaveBeenCalledWith({ type: 'tab-affinity.rebind.result', id: 'initial-bind', ok: true })
-    })
-    postMessage.mockClear()
-
-    query.mockResolvedValue([{
-      ...tab(99),
-      windowId: 9,
-      title: 'dsh Browser Assistant',
-      url: 'chrome-extension://test/panel/index.html',
-    }])
-    onMessage.emit({ type: 'tab-affinity.rebind', id: 'panel-rebind' })
-
-    await vi.waitFor(() => {
-      expect(postMessage).toHaveBeenCalledWith(expect.objectContaining({
-        type: 'tab-affinity.rebind.result',
-        id: 'panel-rebind',
-        ok: false,
-        error: expect.objectContaining({ code: 'no-active-tab' }),
-      }))
-    })
-
-    onMessage.emit({ type: 'request-status' })
-    expect(postMessage).toHaveBeenCalledWith(expect.objectContaining({
-      type: 'tab-affinity',
-      state: expect.objectContaining({
-        status: 'following',
-        controlled: expect.objectContaining({ tabId: 1 }),
-      }),
-    }))
-  })
-
-  it('does not treat focusing the panel window as a tab switch', async () => {
-    const { onMessage, postMessage, query } = await connectPanelForTest()
-    onMessage.emit({ type: 'tab-affinity.rebind', id: 'initial-bind' })
-    await vi.waitFor(() => {
-      expect(postMessage).toHaveBeenCalledWith({ type: 'tab-affinity.rebind.result', id: 'initial-bind', ok: true })
-    })
-    postMessage.mockClear()
-    query.mockClear()
-
-    // A focus event carrying the panel's own document must not enter handoff.
-    query.mockResolvedValue([{
-      ...tab(99),
-      windowId: 9,
-      title: 'dsh Browser Assistant',
-      url: 'chrome-extension://test/panel/index.html',
-    }])
-    onFocusChanged.emit(9)
-    await vi.waitFor(() => { expect(query).toHaveBeenCalled() })
-
-    onMessage.emit({ type: 'request-status' })
-    expect(postMessage).toHaveBeenCalledWith(expect.objectContaining({
-      type: 'tab-affinity',
-      state: expect.objectContaining({
-        status: 'following',
-        controlled: expect.objectContaining({ tabId: 1 }),
-      }),
-    }))
-  })
-
-  it('ignores the popup activation that arrives before windows.create resolves', async () => {
-    // The browser focuses and activates the new panel window before create()
-    // resolves, so its id is still unknown. Marking it focused there would let
-    // tabs.onActivated mark a switch — it has no URL yet to reject — handing
-    // control to the extension page and cancelling pending approvals.
-    const chromeMock = mockChrome({ sidePanel: false })
-    vi.stubGlobal('fetch', vi.fn(async () => new Response(null, { status: 503 })))
-    await import('../src/background/index.ts')
-    await vi.waitFor(() => { expect(chromeMock.query).toHaveBeenCalled() })
-
-    const panel = panelPort()
-    chromeMock.onConnect.emit(panel.port)
-    await vi.waitFor(() => {
-      expect(panel.postMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'tab-affinity' }))
-    })
-    panel.onMessage.emit({ type: 'tab-affinity.rebind', id: 'initial-bind' })
-    await vi.waitFor(() => {
-      expect(panel.postMessage).toHaveBeenCalledWith({
-        type: 'tab-affinity.rebind.result', id: 'initial-bind', ok: true,
-      })
-    })
-    panel.postMessage.mockClear()
-
-    // Toolbar click opens the fallback window; create() stays pending.
-    chromeMock.onActionClicked.emit(tab(1))
-    await vi.waitFor(() => { expect(chromeMock.createWindow).toHaveBeenCalled() })
-
-    // The popup takes focus and activates its own tab, both before create()
-    // resolves and therefore before the window has an id to be matched by.
-    chromeMock.onFocusChanged.emit(9)
-    chromeMock.onActivated.emit({ tabId: 99, windowId: 9 })
-    chromeMock.resolveCreate(9)
-    await vi.waitFor(() => { expect(chromeMock.createWindow).toHaveBeenCalledOnce() })
-
-    panel.onMessage.emit({ type: 'request-status' })
-    expect(panel.postMessage).toHaveBeenCalledWith(expect.objectContaining({
-      type: 'tab-affinity',
-      state: expect.objectContaining({
-        status: 'following',
-        controlled: expect.objectContaining({ tabId: 1 }),
-      }),
-    }))
-  })
-
-  /** Bind to window 1, then open the fallback popup on top of it. */
-  async function bindThenOpenPopup() {
-    const chromeMock = mockChrome({ sidePanel: false })
-    vi.stubGlobal('fetch', vi.fn(async () => new Response(null, { status: 503 })))
-    await import('../src/background/index.ts')
-    await vi.waitFor(() => { expect(chromeMock.query).toHaveBeenCalled() })
-
-    const panel = panelPort()
-    chromeMock.onConnect.emit(panel.port)
-    await vi.waitFor(() => {
-      expect(panel.postMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'tab-affinity' }))
-    })
-
-    chromeMock.onFocusChanged.emit(1)
-    await vi.waitFor(() => {
-      expect(chromeMock.query).toHaveBeenCalledWith(expect.objectContaining({ windowId: 1 }))
-    })
-    chromeMock.onActionClicked.emit(tab(1))
-    await vi.waitFor(() => { expect(chromeMock.createWindow).toHaveBeenCalled() })
-    chromeMock.resolveCreate(9)
-    return { ...chromeMock, panel }
-  }
-
-  it('stops targeting a browser window that has closed', async () => {
-    // The popup keeps focus after the originating window closes, and its own
-    // focus events are ignored, so nothing else would refresh the stale id.
-    const { onWindowRemoved, panel, query } = await bindThenOpenPopup()
-
-    onWindowRemoved.emit(1)
-    query.mockClear()
-
-    panel.onMessage.emit({ type: 'tab-affinity.rebind', id: 'after-close' })
-    await vi.waitFor(() => { expect(query).toHaveBeenCalled() })
-
-    const targeted = query.mock.calls.map(([info]) => info as chrome.tabs.QueryInfo)
-    expect(targeted.some((info) => info.windowId === 1)).toBe(false)
-  })
-
-  it('recovers through another window when the remembered one answers nothing', async () => {
-    const { panel, query } = await bindThenOpenPopup()
-    panel.postMessage.mockClear()
-
-    // Window 1 no longer has an active tab; only a normal-window query finds one.
-    const survivor = { ...tab(2), windowId: 2 }
-    query.mockImplementation(async (info: chrome.tabs.QueryInfo) => (
-      info.windowType === 'normal' ? [survivor] : []
-    ))
-
-    panel.onMessage.emit({ type: 'tab-affinity.rebind', id: 'widen' })
-    await vi.waitFor(() => {
-      expect(panel.postMessage).toHaveBeenCalledWith({
-        type: 'tab-affinity.rebind.result', id: 'widen', ok: true,
-      })
-    })
-    expect(panel.postMessage).toHaveBeenCalledWith(expect.objectContaining({
-      type: 'tab-affinity',
-      state: expect.objectContaining({ controlled: expect.objectContaining({ tabId: 2 }) }),
-    }))
-  })
-
-  it('remembers the originating window across a service-worker restart', async () => {
-    // The popup survives an MV3 restart and still answers as lastFocusedWindow,
-    // so without the stored id every no-argument sync would have to guess.
-    const chromeMock = mockChrome({
-      sidePanel: false,
-      session: { dshPanelWindow: 9, dshBrowserWindow: 1 },
-    })
-    vi.stubGlobal('fetch', vi.fn(async () => new Response(null, { status: 503 })))
-    await import('../src/background/index.ts')
-
-    await vi.waitFor(() => {
-      expect(chromeMock.query).toHaveBeenCalledWith(expect.objectContaining({ windowId: 1 }))
-    })
-  })
-
-  it('refuses to guess between several browser windows', async () => {
-    // windowType: 'normal' answers for every window at once. Picking one would
-    // move browser control silently, so an ambiguous answer binds nothing.
-    const chromeMock = mockChrome({ sidePanel: false })
-    vi.stubGlobal('fetch', vi.fn(async () => new Response(null, { status: 503 })))
-    await import('../src/background/index.ts')
-    await vi.waitFor(() => { expect(chromeMock.query).toHaveBeenCalled() })
-
-    const panel = panelPort()
-    chromeMock.onConnect.emit(panel.port)
-    await vi.waitFor(() => {
-      expect(panel.postMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'tab-affinity' }))
-    })
-    panel.postMessage.mockClear()
-
-    chromeMock.query.mockImplementation(async (info: chrome.tabs.QueryInfo) => (
-      info.windowType === 'normal' ? [{ ...tab(2), windowId: 2 }, { ...tab(3), windowId: 3 }] : []
-    ))
-
-    panel.onMessage.emit({ type: 'tab-affinity.rebind', id: 'ambiguous' })
-    await vi.waitFor(() => {
-      expect(panel.postMessage).toHaveBeenCalledWith(expect.objectContaining({
-        type: 'tab-affinity.rebind.result',
-        id: 'ambiguous',
-        ok: false,
-        error: expect.objectContaining({ code: 'no-active-tab' }),
-      }))
-    })
-  })
-
-  it('keeps the clicked window when a stored one arrives late', async () => {
-    // A toolbar click can cold-start the worker: the click names its own window
-    // while the restore read is still in flight, and is newer than the store.
-    const chromeMock = mockChrome({
-      sidePanel: false,
-      // No stored panel window, so the click opens one and hasPanelWindow()
-      // becomes true the same way it would in a real fallback session.
-      session: { dshBrowserWindow: 1 },
-      deferBrowserWindowRead: true,
-    })
-    vi.stubGlobal('fetch', vi.fn(async () => new Response(null, { status: 503 })))
-    // Model the real situation: the popup holds focus, so an unfiltered
-    // last-focused query answers with the panel document, and two normal
-    // windows make the widened query ambiguous. Only the remembered window id
-    // can name a page here — which is exactly what the stale read would break.
-    const panelTab = { ...tab(99), windowId: 9, url: 'chrome-extension://test/panel/index.html' }
-    chromeMock.query.mockImplementation(async (info: chrome.tabs.QueryInfo) => {
-      if (info.windowId !== undefined) return [{ ...tab(info.windowId), windowId: info.windowId }]
-      if (info.windowType === 'normal') {
-        return [{ ...tab(1), windowId: 1 }, { ...tab(5), windowId: 5 }]
-      }
-      return [panelTab]
-    })
-    await import('../src/background/index.ts')
-
-    // The click lands first; the stale stored id resolves only afterwards.
-    chromeMock.onActionClicked.emit({ ...tab(5), windowId: 5 })
-    chromeMock.releaseBrowserWindowRead()
-    await vi.waitFor(() => { expect(chromeMock.createWindow).toHaveBeenCalled() })
-    chromeMock.resolveCreate(9)
-
-    const panel = panelPort()
-    chromeMock.onConnect.emit(panel.port)
-    await vi.waitFor(() => {
-      expect(panel.postMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'tab-affinity' }))
-    })
-
-    const targeted = chromeMock.query.mock.calls.map(([info]) => info as chrome.tabs.QueryInfo)
-    expect(targeted.some((info) => info.windowId === 5)).toBe(true)
-    expect(targeted.some((info) => info.windowId === 1)).toBe(false)
   })
 
   it('owns the deadline in the background and ignores a query that resolves after timeout', async () => {

--- a/extensions/dsh-browser/tests/background-tab-affinity-rebind.spec.ts
+++ b/extensions/dsh-browser/tests/background-tab-affinity-rebind.spec.ts
@@ -43,6 +43,7 @@ function tab(tabId: number): chrome.tabs.Tab {
 
 function mockChrome() {
   const onConnect = chromeEvent<[chrome.runtime.Port]>()
+  const onFocusChanged = chromeEvent<[number]>()
   const query = vi.fn(async () => [tab(1)])
   vi.stubGlobal('chrome', {
     alarms: {
@@ -88,11 +89,11 @@ function mockChrome() {
     },
     windows: {
       WINDOW_ID_NONE: -1,
-      onFocusChanged: chromeEvent<[number]>(),
+      onFocusChanged,
       onRemoved: chromeEvent<[number]>(),
     },
   } as unknown as typeof chrome)
-  return { onConnect, query }
+  return { onConnect, onFocusChanged, query }
 }
 
 async function connectPanelForTest() {
@@ -101,6 +102,7 @@ async function connectPanelForTest() {
   await import('../src/background/index.ts')
   await vi.waitFor(() => { expect(chromeMock.query).toHaveBeenCalled() })
 
+  onFocusChanged = chromeMock.onFocusChanged
   const panel = panelPort()
   chromeMock.onConnect.emit(panel.port)
   await vi.waitFor(() => {
@@ -115,6 +117,8 @@ afterEach(() => {
   vi.resetModules()
   vi.unstubAllGlobals()
 })
+
+let onFocusChanged: ReturnType<typeof chromeEvent<[number]>>
 
 describe('background tab-affinity rebind protocol', () => {
   it('acknowledges only after control has moved to the freshly queried active tab', async () => {
@@ -163,6 +167,73 @@ describe('background tab-affinity rebind protocol', () => {
     expect(postMessage).toHaveBeenCalledWith(expect.objectContaining({
       type: 'tab-affinity',
       state: expect.objectContaining({ status: 'following', controlled: expect.objectContaining({ tabId: 1 }) }),
+    }))
+  })
+
+  it('never binds browser control to the panel document itself', async () => {
+    // Browsers with no side-panel API host the panel in a window of its own,
+    // whose tab is the active tab while the user types in it. Content scripts
+    // never match chrome-extension://, so binding here breaks every tool.
+    const { onMessage, postMessage, query } = await connectPanelForTest()
+    onMessage.emit({ type: 'tab-affinity.rebind', id: 'initial-bind' })
+    await vi.waitFor(() => {
+      expect(postMessage).toHaveBeenCalledWith({ type: 'tab-affinity.rebind.result', id: 'initial-bind', ok: true })
+    })
+    postMessage.mockClear()
+
+    query.mockResolvedValue([{
+      ...tab(99),
+      windowId: 9,
+      title: 'dsh Browser Assistant',
+      url: 'chrome-extension://test/panel/index.html',
+    }])
+    onMessage.emit({ type: 'tab-affinity.rebind', id: 'panel-rebind' })
+
+    await vi.waitFor(() => {
+      expect(postMessage).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'tab-affinity.rebind.result',
+        id: 'panel-rebind',
+        ok: false,
+        error: expect.objectContaining({ code: 'no-active-tab' }),
+      }))
+    })
+
+    onMessage.emit({ type: 'request-status' })
+    expect(postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'tab-affinity',
+      state: expect.objectContaining({
+        status: 'following',
+        controlled: expect.objectContaining({ tabId: 1 }),
+      }),
+    }))
+  })
+
+  it('does not treat focusing the panel window as a tab switch', async () => {
+    const { onMessage, postMessage, query } = await connectPanelForTest()
+    onMessage.emit({ type: 'tab-affinity.rebind', id: 'initial-bind' })
+    await vi.waitFor(() => {
+      expect(postMessage).toHaveBeenCalledWith({ type: 'tab-affinity.rebind.result', id: 'initial-bind', ok: true })
+    })
+    postMessage.mockClear()
+    query.mockClear()
+
+    // A focus event carrying the panel's own document must not enter handoff.
+    query.mockResolvedValue([{
+      ...tab(99),
+      windowId: 9,
+      title: 'dsh Browser Assistant',
+      url: 'chrome-extension://test/panel/index.html',
+    }])
+    onFocusChanged.emit(9)
+    await vi.waitFor(() => { expect(query).toHaveBeenCalled() })
+
+    onMessage.emit({ type: 'request-status' })
+    expect(postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'tab-affinity',
+      state: expect.objectContaining({
+        status: 'following',
+        controlled: expect.objectContaining({ tabId: 1 }),
+      }),
     }))
   })
 

--- a/extensions/dsh-browser/tests/background-tab-affinity-rebind.spec.ts
+++ b/extensions/dsh-browser/tests/background-tab-affinity-rebind.spec.ts
@@ -41,7 +41,8 @@ function tab(tabId: number): chrome.tabs.Tab {
   }
 }
 
-function mockChrome(options: { sidePanel?: boolean } = {}) {
+function mockChrome(options: { sidePanel?: boolean; session?: Record<string, unknown> } = {}) {
+  const sessionData: Record<string, unknown> = { ...options.session }
   const onConnect = chromeEvent<[chrome.runtime.Port]>()
   const onFocusChanged = chromeEvent<[number]>()
   const onActivated = chromeEvent<[{ tabId: number; windowId: number }]>()
@@ -81,9 +82,9 @@ function mockChrome(options: { sidePanel?: boolean } = {}) {
         set: vi.fn(async () => {}),
       },
       session: {
-        get: vi.fn(async () => ({})),
-        set: vi.fn(async () => {}),
-        remove: vi.fn(async () => {}),
+        get: vi.fn(async (key: string) => (key in sessionData ? { [key]: sessionData[key] } : {})),
+        set: vi.fn(async (items: Record<string, unknown>) => { Object.assign(sessionData, items) }),
+        remove: vi.fn(async (key: string) => { delete sessionData[key] }),
       },
     },
     tabs: {
@@ -104,6 +105,7 @@ function mockChrome(options: { sidePanel?: boolean } = {}) {
     },
   } as unknown as typeof chrome)
   return {
+    sessionData,
     createWindow,
     onActionClicked,
     onActivated,
@@ -358,6 +360,51 @@ describe('background tab-affinity rebind protocol', () => {
       type: 'tab-affinity',
       state: expect.objectContaining({ controlled: expect.objectContaining({ tabId: 2 }) }),
     }))
+  })
+
+  it('remembers the originating window across a service-worker restart', async () => {
+    // The popup survives an MV3 restart and still answers as lastFocusedWindow,
+    // so without the stored id every no-argument sync would have to guess.
+    const chromeMock = mockChrome({
+      sidePanel: false,
+      session: { dshPanelWindow: 9, dshBrowserWindow: 1 },
+    })
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(null, { status: 503 })))
+    await import('../src/background/index.ts')
+
+    await vi.waitFor(() => {
+      expect(chromeMock.query).toHaveBeenCalledWith(expect.objectContaining({ windowId: 1 }))
+    })
+  })
+
+  it('refuses to guess between several browser windows', async () => {
+    // windowType: 'normal' answers for every window at once. Picking one would
+    // move browser control silently, so an ambiguous answer binds nothing.
+    const chromeMock = mockChrome({ sidePanel: false })
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(null, { status: 503 })))
+    await import('../src/background/index.ts')
+    await vi.waitFor(() => { expect(chromeMock.query).toHaveBeenCalled() })
+
+    const panel = panelPort()
+    chromeMock.onConnect.emit(panel.port)
+    await vi.waitFor(() => {
+      expect(panel.postMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'tab-affinity' }))
+    })
+    panel.postMessage.mockClear()
+
+    chromeMock.query.mockImplementation(async (info: chrome.tabs.QueryInfo) => (
+      info.windowType === 'normal' ? [{ ...tab(2), windowId: 2 }, { ...tab(3), windowId: 3 }] : []
+    ))
+
+    panel.onMessage.emit({ type: 'tab-affinity.rebind', id: 'ambiguous' })
+    await vi.waitFor(() => {
+      expect(panel.postMessage).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'tab-affinity.rebind.result',
+        id: 'ambiguous',
+        ok: false,
+        error: expect.objectContaining({ code: 'no-active-tab' }),
+      }))
+    })
   })
 
   it('owns the deadline in the background and ignores a query that resolves after timeout', async () => {

--- a/extensions/dsh-browser/tests/firefox-build.spec.ts
+++ b/extensions/dsh-browser/tests/firefox-build.spec.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { readFile } from 'node:fs/promises'
 import { describe, expect, it } from 'vitest'
+import { composeManifest } from '../manifest.compose.ts'
 
 interface ExtensionManifest {
   version: string
@@ -20,13 +21,16 @@ async function readJson<T>(relativePath: string): Promise<T> {
   return JSON.parse(await readFile(new URL(relativePath, import.meta.url), 'utf8')) as T
 }
 
+/** manifest.firefox.json is a delta now; the shipped manifest is composed. */
+function shipped(target: 'chrome' | 'firefox'): ExtensionManifest {
+  return composeManifest(target) as unknown as ExtensionManifest
+}
+
 describe('Firefox build contract', () => {
   it('keeps release metadata and shared capabilities aligned with Chrome', async () => {
-    const [chromeManifest, firefoxManifest, packageManifest] = await Promise.all([
-      readJson<ExtensionManifest>('../manifest.json'),
-      readJson<ExtensionManifest>('../manifest.firefox.json'),
-      readJson<{ version: string }>('../package.json'),
-    ])
+    const chromeManifest = shipped('chrome')
+    const firefoxManifest = shipped('firefox')
+    const packageManifest = await readJson<{ version: string }>('../package.json')
 
     expect(firefoxManifest.version).toBe(packageManifest.version)
     expect(firefoxManifest.version).toBe(chromeManifest.version)
@@ -35,7 +39,7 @@ describe('Firefox build contract', () => {
   })
 
   it('uses a Firefox event page, sidebar, and AMO data-transmission declaration', async () => {
-    const manifest = await readJson<ExtensionManifest>('../manifest.firefox.json')
+    const manifest = shipped('firefox')
 
     expect(manifest.background).toEqual({ scripts: ['background.js'] })
     expect(manifest.sidebar_action).toMatchObject({

--- a/extensions/dsh-browser/tests/manifest-compose.spec.ts
+++ b/extensions/dsh-browser/tests/manifest-compose.spec.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import {
+  composeManifest,
+  EXTENSION_TARGETS,
+  TARGET_OUT_DIR,
+  type ExtensionTarget,
+} from '../manifest.compose.ts'
+
+interface ComposedManifest {
+  version: string
+  name: string
+  permissions: string[]
+  background: Record<string, unknown>
+  content_security_policy: { extension_pages: string }
+  icons: Record<string, string>
+  side_panel?: unknown
+  sidebar_action?: { default_panel?: string }
+  minimum_chrome_version?: string
+  browser_specific_settings?: Record<string, unknown>
+}
+
+function compose(target: ExtensionTarget): ComposedManifest {
+  return composeManifest(target) as unknown as ComposedManifest
+}
+
+describe('composed per-browser manifests', () => {
+  it('gives every target its own output directory', () => {
+    expect(new Set(Object.values(TARGET_OUT_DIR)).size).toBe(EXTENSION_TARGETS.length)
+  })
+
+  it('ships each browser only the panel key it understands', () => {
+    // Chrome warns "Unrecognized manifest key 'sidebar_action'" on every
+    // unpacked install, and this project is only ever loaded unpacked, so a
+    // foreign key here is visible to every single user.
+    const chrome = compose('chrome')
+    expect(chrome.side_panel).toBeDefined()
+    expect(chrome.sidebar_action).toBeUndefined()
+
+    for (const target of ['firefox', 'opera'] as const) {
+      const manifest = compose(target)
+      expect(manifest.sidebar_action?.default_panel).toBe('panel/index.html')
+      expect(manifest.side_panel).toBeUndefined()
+    }
+  })
+
+  it('asks for the sidePanel permission only where the API exists', () => {
+    expect(compose('chrome').permissions).toContain('sidePanel')
+    expect(compose('firefox').permissions).not.toContain('sidePanel')
+    expect(compose('opera').permissions).not.toContain('sidePanel')
+  })
+
+  it('keeps shared metadata identical across targets by construction', () => {
+    const packageVersion = (JSON.parse(
+      readFileSync(`${process.cwd()}/package.json`, 'utf8'),
+    ) as { version: string }).version
+    const composed = EXTENSION_TARGETS.map((target) => compose(target))
+
+    for (const manifest of composed) {
+      expect(manifest.version).toBe(packageVersion)
+      expect(manifest.name).toBe(composed[0].name)
+      expect(manifest.icons).toEqual(composed[0].icons)
+      expect(manifest.content_security_policy).toEqual(composed[0].content_security_policy)
+      expect(manifest.permissions).toContain('notifications')
+    }
+  })
+
+  it('gives each engine the background form it accepts', () => {
+    // A recursive merge produced service_worker, type and scripts together,
+    // which is not a manifest either engine accepts.
+    expect(compose('chrome').background).toEqual({ service_worker: 'background.js', type: 'module' })
+    expect(compose('opera').background).toEqual({ service_worker: 'background.js', type: 'module' })
+    expect(compose('firefox').background).toEqual({ scripts: ['background.js'] })
+  })
+
+  it('keeps Chrome-only keys out of Firefox', () => {
+    const firefox = compose('firefox')
+    expect(firefox.minimum_chrome_version).toBeUndefined()
+    expect(firefox.browser_specific_settings).toBeDefined()
+    expect(compose('chrome').browser_specific_settings).toBeUndefined()
+  })
+
+  it('keeps the committed Chrome manifest as the composed base', () => {
+    // The in-panel update check fetches this exact path from main to read the
+    // published version, so it has to stay a real manifest, not a delta.
+    const committed = JSON.parse(readFileSync(`${process.cwd()}/manifest.json`, 'utf8')) as ComposedManifest
+    expect(committed).toEqual(compose('chrome'))
+  })
+})

--- a/extensions/dsh-browser/tests/panel-host.spec.ts
+++ b/extensions/dsh-browser/tests/panel-host.spec.ts
@@ -1,0 +1,215 @@
+// @vitest-environment jsdom
+import { readFileSync } from 'node:fs'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface ChromeStub {
+  sidePanel?: {
+    open?: (options: { windowId: number }) => Promise<void>
+    setPanelBehavior?: (options: { openPanelOnActionClick: boolean }) => Promise<void>
+  }
+  sidebarAction?: { open?: () => Promise<void> | void }
+  runtime: { getURL: (path: string) => string }
+  windows: {
+    create: (options: Record<string, unknown>) => Promise<{ id?: number }>
+    update: (windowId: number, options: Record<string, unknown>) => Promise<unknown>
+  }
+}
+
+function stubChrome(overrides: Partial<ChromeStub> = {}): ChromeStub {
+  const chromeStub: ChromeStub = {
+    runtime: { getURL: (path) => `chrome-extension://test-id/${path}` },
+    windows: {
+      create: vi.fn(async () => ({ id: 7 })),
+      update: vi.fn(async () => ({})),
+    },
+    ...overrides,
+  }
+  vi.stubGlobal('chrome', chromeStub)
+  return chromeStub
+}
+
+/** The module keeps the remembered window in module state, so reload it per test. */
+async function loadPanelHost(): Promise<typeof import('../src/background/panel-host.ts')> {
+  vi.resetModules()
+  return import('../src/background/panel-host.ts')
+}
+
+describe('panel host selection', () => {
+  beforeEach(() => { vi.unstubAllGlobals() })
+  afterEach(() => { vi.unstubAllGlobals() })
+
+  it('prefers the Chrome side panel when the API is present', async () => {
+    const open = vi.fn(async () => {})
+    stubChrome({ sidePanel: { open } })
+    const { resolvePanelHost, openAssistantPanel } = await loadPanelHost()
+
+    expect(resolvePanelHost()).toBe('side-panel')
+    await openAssistantPanel(3)
+    expect(open).toHaveBeenCalledWith({ windowId: 3 })
+  })
+
+  it('uses the legacy sidebar API when there is no Side Panel API', async () => {
+    const open = vi.fn(async () => {})
+    stubChrome({ sidebarAction: { open } })
+    const { resolvePanelHost, openAssistantPanel } = await loadPanelHost()
+
+    expect(resolvePanelHost()).toBe('sidebar-action')
+    await openAssistantPanel()
+    expect(open).toHaveBeenCalledOnce()
+  })
+
+  it('finds the sidebar API Opera exposes on opr', async () => {
+    const open = vi.fn(async () => {})
+    const chromeStub = stubChrome()
+    vi.stubGlobal('opr', { sidebarAction: { open } })
+    // Re-stub chrome: stubGlobal('opr') does not disturb it, but make the order explicit.
+    vi.stubGlobal('chrome', chromeStub)
+    const { resolvePanelHost, openAssistantPanel } = await loadPanelHost()
+
+    expect(resolvePanelHost()).toBe('sidebar-action')
+    await openAssistantPanel()
+    expect(open).toHaveBeenCalledOnce()
+  })
+
+  it('ignores a sidebar namespace that exposes no open()', async () => {
+    stubChrome({ sidebarAction: {} })
+    const { resolvePanelHost } = await loadPanelHost()
+
+    expect(resolvePanelHost()).toBe('window')
+  })
+
+  it('opens a popup window when the browser has neither sidebar API', async () => {
+    const chromeStub = stubChrome()
+    const { resolvePanelHost, openAssistantPanel } = await loadPanelHost()
+
+    expect(resolvePanelHost()).toBe('window')
+    await openAssistantPanel()
+    expect(chromeStub.windows.create).toHaveBeenCalledWith(expect.objectContaining({
+      url: 'chrome-extension://test-id/panel/index.html',
+      type: 'popup',
+    }))
+  })
+
+  it('focuses the existing panel window instead of stacking duplicates', async () => {
+    const chromeStub = stubChrome()
+    const { openAssistantPanel } = await loadPanelHost()
+
+    await openAssistantPanel()
+    await openAssistantPanel()
+
+    expect(chromeStub.windows.create).toHaveBeenCalledOnce()
+    expect(chromeStub.windows.update).toHaveBeenCalledWith(7, { focused: true })
+  })
+
+  it('reopens a panel window the user closed', async () => {
+    const chromeStub = stubChrome({
+      windows: {
+        create: vi.fn(async () => ({ id: 7 })),
+        update: vi.fn(async () => { throw new Error('No window with id: 7.') }),
+      },
+    })
+    const { openAssistantPanel } = await loadPanelHost()
+
+    await openAssistantPanel()
+    await openAssistantPanel()
+
+    expect(chromeStub.windows.create).toHaveBeenCalledTimes(2)
+  })
+
+  it('forgets a closed window so the next open does not probe a dead id', async () => {
+    const chromeStub = stubChrome()
+    const { openAssistantPanel, forgetPanelWindow } = await loadPanelHost()
+
+    await openAssistantPanel()
+    forgetPanelWindow(7)
+    await openAssistantPanel()
+
+    expect(chromeStub.windows.update).not.toHaveBeenCalled()
+    expect(chromeStub.windows.create).toHaveBeenCalledTimes(2)
+  })
+
+  it('falls back to a window when a declared sidebar refuses to open', async () => {
+    const chromeStub = stubChrome({
+      sidebarAction: { open: vi.fn(async () => { throw new Error('not supported') }) },
+    })
+    const { openAssistantPanel } = await loadPanelHost()
+
+    await openAssistantPanel()
+    expect(chromeStub.windows.create).toHaveBeenCalledOnce()
+  })
+
+  it('never calls the side panel without a window to target it at', async () => {
+    const open = vi.fn(async () => {})
+    const chromeStub = stubChrome({ sidePanel: { open } })
+    const { openAssistantPanel } = await loadPanelHost()
+
+    await openAssistantPanel(undefined)
+    expect(open).not.toHaveBeenCalled()
+    expect(chromeStub.windows.create).not.toHaveBeenCalled()
+  })
+
+  it('survives a side panel that rejects, without falling through to a window', async () => {
+    const chromeStub = stubChrome({
+      sidePanel: { open: vi.fn(async () => { throw new Error('user gesture required') }) },
+    })
+    const { openAssistantPanel } = await loadPanelHost()
+
+    await expect(openAssistantPanel(1)).resolves.toBeUndefined()
+    expect(chromeStub.windows.create).not.toHaveBeenCalled()
+  })
+
+  it('requests Chrome open-on-click only where the API exists', async () => {
+    const setPanelBehavior = vi.fn(async () => {})
+    stubChrome({ sidePanel: { open: vi.fn(async () => {}), setPanelBehavior } })
+    const { preferPanelOnActionClick } = await loadPanelHost()
+
+    preferPanelOnActionClick()
+    expect(setPanelBehavior).toHaveBeenCalledWith({ openPanelOnActionClick: true })
+  })
+
+  it('is a no-op on browsers with no Side Panel API', async () => {
+    stubChrome({ sidebarAction: { open: vi.fn(async () => {}) } })
+    const { preferPanelOnActionClick } = await loadPanelHost()
+
+    expect(() => { preferPanelOnActionClick() }).not.toThrow()
+  })
+
+  it('tolerates setPanelBehavior rejecting', async () => {
+    stubChrome({
+      sidePanel: {
+        open: vi.fn(async () => {}),
+        setPanelBehavior: vi.fn(async () => { throw new Error('unsupported') }),
+      },
+    })
+    const { preferPanelOnActionClick } = await loadPanelHost()
+
+    expect(() => { preferPanelOnActionClick() }).not.toThrow()
+  })
+})
+
+describe('Chrome manifest panel hosts', () => {
+  it('declares both panel keys so Opera docks the panel natively', () => {
+    const manifest = JSON.parse(
+      readFileSync(`${process.cwd()}/manifest.json`, 'utf8'),
+    ) as {
+      side_panel?: { default_path?: string }
+      sidebar_action?: { default_panel?: string; default_icon?: Record<string, string> }
+    }
+
+    // Chrome reads side_panel and ignores sidebar_action; Opera does the
+    // reverse, and both point at the same panel document.
+    expect(manifest.side_panel?.default_path).toBe('panel/index.html')
+    expect(manifest.sidebar_action?.default_panel).toBe('panel/index.html')
+    expect(manifest.sidebar_action?.default_icon).toBeDefined()
+  })
+
+  it('needs no extra permission for the legacy sidebar', () => {
+    const manifest = JSON.parse(
+      readFileSync(`${process.cwd()}/manifest.json`, 'utf8'),
+    ) as { permissions: string[] }
+
+    // Opera-store extensions declare sidebar_action without a "sidebar"
+    // permission; requesting one would add an install-time prompt for nothing.
+    expect(manifest.permissions).not.toContain('sidebar')
+  })
+})

--- a/extensions/dsh-browser/tests/panel-host.spec.ts
+++ b/extensions/dsh-browser/tests/panel-host.spec.ts
@@ -159,30 +159,3 @@ describe('panel host selection', () => {
     expect(() => { preferPanelOnActionClick() }).not.toThrow()
   })
 })
-
-describe('Chrome manifest panel hosts', () => {
-  it('declares both panel keys so Opera docks the panel natively', () => {
-    const manifest = JSON.parse(
-      readFileSync(`${process.cwd()}/manifest.json`, 'utf8'),
-    ) as {
-      side_panel?: { default_path?: string }
-      sidebar_action?: { default_panel?: string; default_icon?: Record<string, string> }
-    }
-
-    // Chrome reads side_panel and ignores sidebar_action; Opera does the
-    // reverse, and both point at the same panel document.
-    expect(manifest.side_panel?.default_path).toBe('panel/index.html')
-    expect(manifest.sidebar_action?.default_panel).toBe('panel/index.html')
-    expect(manifest.sidebar_action?.default_icon).toBeDefined()
-  })
-
-  it('needs no extra permission for the legacy sidebar', () => {
-    const manifest = JSON.parse(
-      readFileSync(`${process.cwd()}/manifest.json`, 'utf8'),
-    ) as { permissions: string[] }
-
-    // Opera-store extensions declare sidebar_action without a "sidebar"
-    // permission; requesting one would add an install-time prompt for nothing.
-    expect(manifest.permissions).not.toContain('sidebar')
-  })
-})

--- a/extensions/dsh-browser/tests/panel-host.spec.ts
+++ b/extensions/dsh-browser/tests/panel-host.spec.ts
@@ -101,6 +101,26 @@ describe('panel host selection', () => {
     expect(chromeStub.windows.update).toHaveBeenCalledWith(7, { focused: true })
   })
 
+  it('opens one window for overlapping clicks', async () => {
+    // Two toolbar clicks land before windows.create resolves; without
+    // serializing, both see no window id yet and each opens a popup.
+    let resolveCreate: (value: { id: number }) => void = () => {}
+    const chromeStub = stubChrome({
+      windows: {
+        create: vi.fn(() => new Promise<{ id: number }>((resolve) => { resolveCreate = resolve })),
+        update: vi.fn(async () => ({})),
+      },
+    })
+    const { openAssistantPanel } = await loadPanelHost()
+
+    const first = openAssistantPanel()
+    const second = openAssistantPanel()
+    resolveCreate({ id: 7 })
+    await Promise.all([first, second])
+
+    expect(chromeStub.windows.create).toHaveBeenCalledOnce()
+  })
+
   it('reopens a panel window the user closed', async () => {
     const chromeStub = stubChrome({
       windows: {

--- a/extensions/dsh-browser/tests/panel-host.spec.ts
+++ b/extensions/dsh-browser/tests/panel-host.spec.ts
@@ -116,6 +116,54 @@ describe('panel host selection', () => {
     expect(chromeStub.windows.create).toHaveBeenCalledTimes(2)
   })
 
+  it('identifies its own window and document so tab affinity can skip them', async () => {
+    stubChrome()
+    const { openAssistantPanel, hasPanelWindow, isPanelWindow, isPanelDocument } = await loadPanelHost()
+
+    expect(hasPanelWindow()).toBe(false)
+    expect(isPanelWindow(7)).toBe(false)
+
+    await openAssistantPanel()
+
+    expect(hasPanelWindow()).toBe(true)
+    expect(isPanelWindow(7)).toBe(true)
+    expect(isPanelWindow(8)).toBe(false)
+    expect(isPanelDocument('chrome-extension://test-id/panel/index.html')).toBe(true)
+    expect(isPanelDocument('chrome-extension://test-id/panel/index.html#settings')).toBe(true)
+    expect(isPanelDocument('https://example.com/')).toBe(false)
+    expect(isPanelDocument(undefined)).toBe(false)
+    expect(isPanelDocument('')).toBe(false)
+  })
+
+  it('claims the panel window before windows.create resolves', async () => {
+    // The browser focuses the new window before create() resolves, so a
+    // window-id check alone would miss the very first focus event.
+    let resolveCreate: (value: { id: number }) => void = () => {}
+    stubChrome({
+      windows: {
+        create: vi.fn(() => new Promise<{ id: number }>((resolve) => { resolveCreate = resolve })),
+        update: vi.fn(async () => ({})),
+      },
+    })
+    const { openAssistantPanel, hasPanelWindow } = await loadPanelHost()
+
+    const opening = openAssistantPanel()
+    expect(hasPanelWindow()).toBe(true)
+
+    resolveCreate({ id: 7 })
+    await opening
+    expect(hasPanelWindow()).toBe(true)
+  })
+
+  it('reports no panel window on browsers that never open one', async () => {
+    stubChrome({ sidePanel: { open: vi.fn(async () => {}) } })
+    const { openAssistantPanel, hasPanelWindow, isPanelWindow } = await loadPanelHost()
+
+    await openAssistantPanel(1)
+    expect(hasPanelWindow()).toBe(false)
+    expect(isPanelWindow(1)).toBe(false)
+  })
+
   it('forgets a closed window so the next open does not probe a dead id', async () => {
     const chromeStub = stubChrome()
     const { openAssistantPanel, forgetPanelWindow } = await loadPanelHost()
@@ -126,6 +174,17 @@ describe('panel host selection', () => {
 
     expect(chromeStub.windows.update).not.toHaveBeenCalled()
     expect(chromeStub.windows.create).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops claiming a panel window once the user closes it', async () => {
+    stubChrome()
+    const { openAssistantPanel, forgetPanelWindow, hasPanelWindow, isPanelWindow } = await loadPanelHost()
+
+    await openAssistantPanel()
+    forgetPanelWindow(7)
+
+    expect(hasPanelWindow()).toBe(false)
+    expect(isPanelWindow(7)).toBe(false)
   })
 
   it('falls back to a window when a declared sidebar refuses to open', async () => {

--- a/extensions/dsh-browser/tests/panel-host.spec.ts
+++ b/extensions/dsh-browser/tests/panel-host.spec.ts
@@ -41,9 +41,8 @@ describe('panel host selection', () => {
   it('prefers the Chrome side panel when the API is present', async () => {
     const open = vi.fn(async () => {})
     stubChrome({ sidePanel: { open } })
-    const { resolvePanelHost, openAssistantPanel } = await loadPanelHost()
+    const { openAssistantPanel } = await loadPanelHost()
 
-    expect(resolvePanelHost()).toBe('side-panel')
     await openAssistantPanel(3)
     expect(open).toHaveBeenCalledWith({ windowId: 3 })
   })
@@ -51,9 +50,8 @@ describe('panel host selection', () => {
   it('uses the legacy sidebar API when there is no Side Panel API', async () => {
     const open = vi.fn(async () => {})
     stubChrome({ sidebarAction: { open } })
-    const { resolvePanelHost, openAssistantPanel } = await loadPanelHost()
+    const { openAssistantPanel } = await loadPanelHost()
 
-    expect(resolvePanelHost()).toBe('sidebar-action')
     await openAssistantPanel()
     expect(open).toHaveBeenCalledOnce()
   })
@@ -64,25 +62,24 @@ describe('panel host selection', () => {
     vi.stubGlobal('opr', { sidebarAction: { open } })
     // Re-stub chrome: stubGlobal('opr') does not disturb it, but make the order explicit.
     vi.stubGlobal('chrome', chromeStub)
-    const { resolvePanelHost, openAssistantPanel } = await loadPanelHost()
+    const { openAssistantPanel } = await loadPanelHost()
 
-    expect(resolvePanelHost()).toBe('sidebar-action')
     await openAssistantPanel()
     expect(open).toHaveBeenCalledOnce()
   })
 
   it('ignores a sidebar namespace that exposes no open()', async () => {
-    stubChrome({ sidebarAction: {} })
-    const { resolvePanelHost } = await loadPanelHost()
+    const chromeStub = stubChrome({ sidebarAction: {} })
+    const { openAssistantPanel } = await loadPanelHost()
 
-    expect(resolvePanelHost()).toBe('window')
+    await openAssistantPanel()
+    expect(chromeStub.windows.create).toHaveBeenCalledOnce()
   })
 
   it('opens a popup window when the browser has neither sidebar API', async () => {
     const chromeStub = stubChrome()
-    const { resolvePanelHost, openAssistantPanel } = await loadPanelHost()
+    const { openAssistantPanel } = await loadPanelHost()
 
-    expect(resolvePanelHost()).toBe('window')
     await openAssistantPanel()
     expect(chromeStub.windows.create).toHaveBeenCalledWith(expect.objectContaining({
       url: 'chrome-extension://test-id/panel/index.html',
@@ -119,6 +116,19 @@ describe('panel host selection', () => {
     await Promise.all([first, second])
 
     expect(chromeStub.windows.create).toHaveBeenCalledOnce()
+  })
+
+  it('does not reject onto callers when the window cannot be created', async () => {
+    stubChrome({
+      windows: {
+        create: vi.fn(async () => { throw new Error('cannot create window') }),
+        update: vi.fn(async () => ({})),
+      },
+    })
+    const { openAssistantPanel, hasPanelWindow } = await loadPanelHost()
+
+    await expect(openAssistantPanel()).resolves.toBeUndefined()
+    expect(hasPanelWindow()).toBe(false)
   })
 
   it('reopens a panel window the user closed', async () => {

--- a/extensions/dsh-browser/tests/panel-host.spec.ts
+++ b/extensions/dsh-browser/tests/panel-host.spec.ts
@@ -9,15 +9,36 @@ interface ChromeStub {
   }
   sidebarAction?: { open?: () => Promise<void> | void }
   runtime: { getURL: (path: string) => string }
+  storage: {
+    session: {
+      get: (key: string) => Promise<Record<string, unknown>>
+      set: (items: Record<string, unknown>) => Promise<void>
+      remove: (key: string) => Promise<void>
+    }
+  }
   windows: {
     create: (options: Record<string, unknown>) => Promise<{ id?: number }>
     update: (windowId: number, options: Record<string, unknown>) => Promise<unknown>
   }
 }
 
+/** Stands in for chrome.storage.session, which survives a service-worker restart. */
+function sessionStore(seed: Record<string, unknown> = {}) {
+  const data = { ...seed }
+  return {
+    data,
+    session: {
+      get: vi.fn(async (key: string) => (key in data ? { [key]: data[key] } : {})),
+      set: vi.fn(async (items: Record<string, unknown>) => { Object.assign(data, items) }),
+      remove: vi.fn(async (key: string) => { delete data[key] }),
+    },
+  }
+}
+
 function stubChrome(overrides: Partial<ChromeStub> = {}): ChromeStub {
   const chromeStub: ChromeStub = {
     runtime: { getURL: (path) => `chrome-extension://test-id/${path}` },
+    storage: sessionStore(),
     windows: {
       create: vi.fn(async () => ({ id: 7 })),
       update: vi.fn(async () => ({})),
@@ -112,9 +133,80 @@ describe('panel host selection', () => {
 
     const first = openAssistantPanel()
     const second = openAssistantPanel()
+    // The remembered id is rehydrated before create() is reached, so wait for
+    // the call rather than assuming it has already happened.
+    await vi.waitFor(() => { expect(chromeStub.windows.create).toHaveBeenCalled() })
     resolveCreate({ id: 7 })
     await Promise.all([first, second])
 
+    expect(chromeStub.windows.create).toHaveBeenCalledOnce()
+  })
+
+  it('focuses the popup left open by a restarted service worker', async () => {
+    // MV3 restarts the worker while the popup stays open, wiping module state.
+    const store = sessionStore({ dshPanelWindow: 7 })
+    const chromeStub = stubChrome({ storage: { session: store.session } })
+    const { openAssistantPanel } = await loadPanelHost()
+
+    await openAssistantPanel()
+
+    expect(chromeStub.windows.update).toHaveBeenCalledWith(7, { focused: true })
+    expect(chromeStub.windows.create).not.toHaveBeenCalled()
+  })
+
+  it('recognizes the restored window so affinity keeps skipping it', async () => {
+    const store = sessionStore({ dshPanelWindow: 7 })
+    stubChrome({ storage: { session: store.session } })
+    const { panelWindowSettled, isPanelWindow, hasPanelWindow } = await loadPanelHost()
+
+    await panelWindowSettled()
+
+    expect(hasPanelWindow()).toBe(true)
+    expect(isPanelWindow(7)).toBe(true)
+  })
+
+  it('persists the window it opens and clears it when the user closes it', async () => {
+    const store = sessionStore()
+    stubChrome({ storage: { session: store.session } })
+    const { openAssistantPanel, forgetPanelWindow } = await loadPanelHost()
+
+    await openAssistantPanel()
+    expect(store.data.dshPanelWindow).toBe(7)
+
+    forgetPanelWindow(7)
+    await vi.waitFor(() => { expect(store.data.dshPanelWindow).toBeUndefined() })
+  })
+
+  it('opens a fresh popup when the remembered one is already gone', async () => {
+    const store = sessionStore({ dshPanelWindow: 7 })
+    const chromeStub = stubChrome({
+      storage: { session: store.session },
+      windows: {
+        create: vi.fn(async () => ({ id: 8 })),
+        update: vi.fn(async () => { throw new Error('No window with id: 7.') }),
+      },
+    })
+    const { openAssistantPanel } = await loadPanelHost()
+
+    await openAssistantPanel()
+
+    expect(chromeStub.windows.create).toHaveBeenCalledOnce()
+    expect(store.data.dshPanelWindow).toBe(8)
+  })
+
+  it('survives session storage being unavailable', async () => {
+    const chromeStub = stubChrome({
+      storage: {
+        session: {
+          get: vi.fn(async () => { throw new Error('no storage') }),
+          set: vi.fn(async () => { throw new Error('no storage') }),
+          remove: vi.fn(async () => { throw new Error('no storage') }),
+        },
+      },
+    })
+    const { openAssistantPanel } = await loadPanelHost()
+
+    await expect(openAssistantPanel()).resolves.toBeUndefined()
     expect(chromeStub.windows.create).toHaveBeenCalledOnce()
   })
 
@@ -169,7 +261,7 @@ describe('panel host selection', () => {
     // The browser focuses the new window before create() resolves, so a
     // window-id check alone would miss the very first focus event.
     let resolveCreate: (value: { id: number }) => void = () => {}
-    stubChrome({
+    const chromeStub = stubChrome({
       windows: {
         create: vi.fn(() => new Promise<{ id: number }>((resolve) => { resolveCreate = resolve })),
         update: vi.fn(async () => ({})),
@@ -180,6 +272,7 @@ describe('panel host selection', () => {
     const opening = openAssistantPanel()
     expect(hasPanelWindow()).toBe(true)
 
+    await vi.waitFor(() => { expect(chromeStub.windows.create).toHaveBeenCalled() })
     resolveCreate({ id: 7 })
     await opening
     expect(hasPanelWindow()).toBe(true)

--- a/extensions/dsh-browser/tests/panel-host.spec.ts
+++ b/extensions/dsh-browser/tests/panel-host.spec.ts
@@ -8,48 +8,20 @@ interface ChromeStub {
     setPanelBehavior?: (options: { openPanelOnActionClick: boolean }) => Promise<void>
   }
   sidebarAction?: { open?: () => Promise<void> | void }
+  notifications: { create: (id: string, options: Record<string, unknown>) => Promise<string> }
   runtime: { getURL: (path: string) => string }
-  storage: {
-    session: {
-      get: (key: string) => Promise<Record<string, unknown>>
-      set: (items: Record<string, unknown>) => Promise<void>
-      remove: (key: string) => Promise<void>
-    }
-  }
-  windows: {
-    create: (options: Record<string, unknown>) => Promise<{ id?: number }>
-    update: (windowId: number, options: Record<string, unknown>) => Promise<unknown>
-  }
-}
-
-/** Stands in for chrome.storage.session, which survives a service-worker restart. */
-function sessionStore(seed: Record<string, unknown> = {}) {
-  const data = { ...seed }
-  return {
-    data,
-    session: {
-      get: vi.fn(async (key: string) => (key in data ? { [key]: data[key] } : {})),
-      set: vi.fn(async (items: Record<string, unknown>) => { Object.assign(data, items) }),
-      remove: vi.fn(async (key: string) => { delete data[key] }),
-    },
-  }
 }
 
 function stubChrome(overrides: Partial<ChromeStub> = {}): ChromeStub {
   const chromeStub: ChromeStub = {
+    notifications: { create: vi.fn(async () => 'dsh-panel-unsupported') },
     runtime: { getURL: (path) => `chrome-extension://test-id/${path}` },
-    storage: sessionStore(),
-    windows: {
-      create: vi.fn(async () => ({ id: 7 })),
-      update: vi.fn(async () => ({})),
-    },
     ...overrides,
   }
   vi.stubGlobal('chrome', chromeStub)
   return chromeStub
 }
 
-/** The module keeps the remembered window in module state, so reload it per test. */
 async function loadPanelHost(): Promise<typeof import('../src/background/panel-host.ts')> {
   vi.resetModules()
   return import('../src/background/panel-host.ts')
@@ -61,263 +33,37 @@ describe('panel host selection', () => {
 
   it('prefers the Chrome side panel when the API is present', async () => {
     const open = vi.fn(async () => {})
-    stubChrome({ sidePanel: { open } })
+    const chromeStub = stubChrome({ sidePanel: { open } })
     const { openAssistantPanel } = await loadPanelHost()
 
     await openAssistantPanel(3)
+
     expect(open).toHaveBeenCalledWith({ windowId: 3 })
+    expect(chromeStub.notifications.create).not.toHaveBeenCalled()
   })
 
   it('uses the legacy sidebar API when there is no Side Panel API', async () => {
     const open = vi.fn(async () => {})
-    stubChrome({ sidebarAction: { open } })
+    const chromeStub = stubChrome({ sidebarAction: { open } })
     const { openAssistantPanel } = await loadPanelHost()
 
     await openAssistantPanel()
+
     expect(open).toHaveBeenCalledOnce()
+    expect(chromeStub.notifications.create).not.toHaveBeenCalled()
   })
 
   it('finds the sidebar API Opera exposes on opr', async () => {
     const open = vi.fn(async () => {})
     const chromeStub = stubChrome()
     vi.stubGlobal('opr', { sidebarAction: { open } })
-    // Re-stub chrome: stubGlobal('opr') does not disturb it, but make the order explicit.
     vi.stubGlobal('chrome', chromeStub)
     const { openAssistantPanel } = await loadPanelHost()
 
     await openAssistantPanel()
+
     expect(open).toHaveBeenCalledOnce()
-  })
-
-  it('ignores a sidebar namespace that exposes no open()', async () => {
-    const chromeStub = stubChrome({ sidebarAction: {} })
-    const { openAssistantPanel } = await loadPanelHost()
-
-    await openAssistantPanel()
-    expect(chromeStub.windows.create).toHaveBeenCalledOnce()
-  })
-
-  it('opens a popup window when the browser has neither sidebar API', async () => {
-    const chromeStub = stubChrome()
-    const { openAssistantPanel } = await loadPanelHost()
-
-    await openAssistantPanel()
-    expect(chromeStub.windows.create).toHaveBeenCalledWith(expect.objectContaining({
-      url: 'chrome-extension://test-id/panel/index.html',
-      type: 'popup',
-    }))
-  })
-
-  it('focuses the existing panel window instead of stacking duplicates', async () => {
-    const chromeStub = stubChrome()
-    const { openAssistantPanel } = await loadPanelHost()
-
-    await openAssistantPanel()
-    await openAssistantPanel()
-
-    expect(chromeStub.windows.create).toHaveBeenCalledOnce()
-    expect(chromeStub.windows.update).toHaveBeenCalledWith(7, { focused: true })
-  })
-
-  it('opens one window for overlapping clicks', async () => {
-    // Two toolbar clicks land before windows.create resolves; without
-    // serializing, both see no window id yet and each opens a popup.
-    let resolveCreate: (value: { id: number }) => void = () => {}
-    const chromeStub = stubChrome({
-      windows: {
-        create: vi.fn(() => new Promise<{ id: number }>((resolve) => { resolveCreate = resolve })),
-        update: vi.fn(async () => ({})),
-      },
-    })
-    const { openAssistantPanel } = await loadPanelHost()
-
-    const first = openAssistantPanel()
-    const second = openAssistantPanel()
-    // The remembered id is rehydrated before create() is reached, so wait for
-    // the call rather than assuming it has already happened.
-    await vi.waitFor(() => { expect(chromeStub.windows.create).toHaveBeenCalled() })
-    resolveCreate({ id: 7 })
-    await Promise.all([first, second])
-
-    expect(chromeStub.windows.create).toHaveBeenCalledOnce()
-  })
-
-  it('focuses the popup left open by a restarted service worker', async () => {
-    // MV3 restarts the worker while the popup stays open, wiping module state.
-    const store = sessionStore({ dshPanelWindow: 7 })
-    const chromeStub = stubChrome({ storage: { session: store.session } })
-    const { openAssistantPanel } = await loadPanelHost()
-
-    await openAssistantPanel()
-
-    expect(chromeStub.windows.update).toHaveBeenCalledWith(7, { focused: true })
-    expect(chromeStub.windows.create).not.toHaveBeenCalled()
-  })
-
-  it('recognizes the restored window so affinity keeps skipping it', async () => {
-    const store = sessionStore({ dshPanelWindow: 7 })
-    stubChrome({ storage: { session: store.session } })
-    const { panelWindowSettled, isPanelWindow, hasPanelWindow } = await loadPanelHost()
-
-    await panelWindowSettled()
-
-    expect(hasPanelWindow()).toBe(true)
-    expect(isPanelWindow(7)).toBe(true)
-  })
-
-  it('persists the window it opens and clears it when the user closes it', async () => {
-    const store = sessionStore()
-    stubChrome({ storage: { session: store.session } })
-    const { openAssistantPanel, forgetPanelWindow } = await loadPanelHost()
-
-    await openAssistantPanel()
-    expect(store.data.dshPanelWindow).toBe(7)
-
-    forgetPanelWindow(7)
-    await vi.waitFor(() => { expect(store.data.dshPanelWindow).toBeUndefined() })
-  })
-
-  it('opens a fresh popup when the remembered one is already gone', async () => {
-    const store = sessionStore({ dshPanelWindow: 7 })
-    const chromeStub = stubChrome({
-      storage: { session: store.session },
-      windows: {
-        create: vi.fn(async () => ({ id: 8 })),
-        update: vi.fn(async () => { throw new Error('No window with id: 7.') }),
-      },
-    })
-    const { openAssistantPanel } = await loadPanelHost()
-
-    await openAssistantPanel()
-
-    expect(chromeStub.windows.create).toHaveBeenCalledOnce()
-    expect(store.data.dshPanelWindow).toBe(8)
-  })
-
-  it('survives session storage being unavailable', async () => {
-    const chromeStub = stubChrome({
-      storage: {
-        session: {
-          get: vi.fn(async () => { throw new Error('no storage') }),
-          set: vi.fn(async () => { throw new Error('no storage') }),
-          remove: vi.fn(async () => { throw new Error('no storage') }),
-        },
-      },
-    })
-    const { openAssistantPanel } = await loadPanelHost()
-
-    await expect(openAssistantPanel()).resolves.toBeUndefined()
-    expect(chromeStub.windows.create).toHaveBeenCalledOnce()
-  })
-
-  it('does not reject onto callers when the window cannot be created', async () => {
-    stubChrome({
-      windows: {
-        create: vi.fn(async () => { throw new Error('cannot create window') }),
-        update: vi.fn(async () => ({})),
-      },
-    })
-    const { openAssistantPanel, hasPanelWindow } = await loadPanelHost()
-
-    await expect(openAssistantPanel()).resolves.toBeUndefined()
-    expect(hasPanelWindow()).toBe(false)
-  })
-
-  it('reopens a panel window the user closed', async () => {
-    const chromeStub = stubChrome({
-      windows: {
-        create: vi.fn(async () => ({ id: 7 })),
-        update: vi.fn(async () => { throw new Error('No window with id: 7.') }),
-      },
-    })
-    const { openAssistantPanel } = await loadPanelHost()
-
-    await openAssistantPanel()
-    await openAssistantPanel()
-
-    expect(chromeStub.windows.create).toHaveBeenCalledTimes(2)
-  })
-
-  it('identifies its own window and document so tab affinity can skip them', async () => {
-    stubChrome()
-    const { openAssistantPanel, hasPanelWindow, isPanelWindow, isPanelDocument } = await loadPanelHost()
-
-    expect(hasPanelWindow()).toBe(false)
-    expect(isPanelWindow(7)).toBe(false)
-
-    await openAssistantPanel()
-
-    expect(hasPanelWindow()).toBe(true)
-    expect(isPanelWindow(7)).toBe(true)
-    expect(isPanelWindow(8)).toBe(false)
-    expect(isPanelDocument('chrome-extension://test-id/panel/index.html')).toBe(true)
-    expect(isPanelDocument('chrome-extension://test-id/panel/index.html#settings')).toBe(true)
-    expect(isPanelDocument('https://example.com/')).toBe(false)
-    expect(isPanelDocument(undefined)).toBe(false)
-    expect(isPanelDocument('')).toBe(false)
-  })
-
-  it('claims the panel window before windows.create resolves', async () => {
-    // The browser focuses the new window before create() resolves, so a
-    // window-id check alone would miss the very first focus event.
-    let resolveCreate: (value: { id: number }) => void = () => {}
-    const chromeStub = stubChrome({
-      windows: {
-        create: vi.fn(() => new Promise<{ id: number }>((resolve) => { resolveCreate = resolve })),
-        update: vi.fn(async () => ({})),
-      },
-    })
-    const { openAssistantPanel, hasPanelWindow } = await loadPanelHost()
-
-    const opening = openAssistantPanel()
-    expect(hasPanelWindow()).toBe(true)
-
-    await vi.waitFor(() => { expect(chromeStub.windows.create).toHaveBeenCalled() })
-    resolveCreate({ id: 7 })
-    await opening
-    expect(hasPanelWindow()).toBe(true)
-  })
-
-  it('reports no panel window on browsers that never open one', async () => {
-    stubChrome({ sidePanel: { open: vi.fn(async () => {}) } })
-    const { openAssistantPanel, hasPanelWindow, isPanelWindow } = await loadPanelHost()
-
-    await openAssistantPanel(1)
-    expect(hasPanelWindow()).toBe(false)
-    expect(isPanelWindow(1)).toBe(false)
-  })
-
-  it('forgets a closed window so the next open does not probe a dead id', async () => {
-    const chromeStub = stubChrome()
-    const { openAssistantPanel, forgetPanelWindow } = await loadPanelHost()
-
-    await openAssistantPanel()
-    forgetPanelWindow(7)
-    await openAssistantPanel()
-
-    expect(chromeStub.windows.update).not.toHaveBeenCalled()
-    expect(chromeStub.windows.create).toHaveBeenCalledTimes(2)
-  })
-
-  it('stops claiming a panel window once the user closes it', async () => {
-    stubChrome()
-    const { openAssistantPanel, forgetPanelWindow, hasPanelWindow, isPanelWindow } = await loadPanelHost()
-
-    await openAssistantPanel()
-    forgetPanelWindow(7)
-
-    expect(hasPanelWindow()).toBe(false)
-    expect(isPanelWindow(7)).toBe(false)
-  })
-
-  it('falls back to a window when a declared sidebar refuses to open', async () => {
-    const chromeStub = stubChrome({
-      sidebarAction: { open: vi.fn(async () => { throw new Error('not supported') }) },
-    })
-    const { openAssistantPanel } = await loadPanelHost()
-
-    await openAssistantPanel()
-    expect(chromeStub.windows.create).toHaveBeenCalledOnce()
+    expect(chromeStub.notifications.create).not.toHaveBeenCalled()
   })
 
   it('never calls the side panel without a window to target it at', async () => {
@@ -326,18 +72,62 @@ describe('panel host selection', () => {
     const { openAssistantPanel } = await loadPanelHost()
 
     await openAssistantPanel(undefined)
+
     expect(open).not.toHaveBeenCalled()
-    expect(chromeStub.windows.create).not.toHaveBeenCalled()
+    // A side-panel browser is supported; a missing window is not a reason to
+    // tell the user their browser cannot host the panel.
+    expect(chromeStub.notifications.create).not.toHaveBeenCalled()
   })
 
-  it('survives a side panel that rejects, without falling through to a window', async () => {
+  it('survives a side panel that rejects', async () => {
     const chromeStub = stubChrome({
       sidePanel: { open: vi.fn(async () => { throw new Error('user gesture required') }) },
     })
     const { openAssistantPanel } = await loadPanelHost()
 
     await expect(openAssistantPanel(1)).resolves.toBeUndefined()
-    expect(chromeStub.windows.create).not.toHaveBeenCalled()
+    expect(chromeStub.notifications.create).not.toHaveBeenCalled()
+  })
+
+  it('tells the user when the browser hosts neither panel', async () => {
+    const chromeStub = stubChrome()
+    const { openAssistantPanel } = await loadPanelHost()
+
+    await openAssistantPanel()
+
+    expect(chromeStub.notifications.create).toHaveBeenCalledWith(
+      'dsh-panel-unsupported',
+      expect.objectContaining({ type: 'basic', message: expect.stringContaining('Chrome 116+') }),
+    )
+  })
+
+  it('treats a sidebar namespace with no open() as no sidebar at all', async () => {
+    const chromeStub = stubChrome({ sidebarAction: {} })
+    const { openAssistantPanel } = await loadPanelHost()
+
+    await openAssistantPanel()
+
+    expect(chromeStub.notifications.create).toHaveBeenCalledOnce()
+  })
+
+  it('reports the browser when a declared sidebar refuses to open', async () => {
+    const chromeStub = stubChrome({
+      sidebarAction: { open: vi.fn(async () => { throw new Error('not supported') }) },
+    })
+    const { openAssistantPanel } = await loadPanelHost()
+
+    await openAssistantPanel()
+
+    expect(chromeStub.notifications.create).toHaveBeenCalledOnce()
+  })
+
+  it('never opens a window or a tab of its own', async () => {
+    // Hosting the panel in an ordinary window would put a chrome-extension://
+    // document where tab affinity expects the user's page.
+    const source = readFileSync(`${process.cwd()}/src/background/panel-host.ts`, 'utf8')
+
+    expect(source).not.toMatch(/chrome\.windows\.create/)
+    expect(source).not.toMatch(/chrome\.tabs\.create/)
   })
 
   it('requests Chrome open-on-click only where the API exists', async () => {
@@ -346,6 +136,7 @@ describe('panel host selection', () => {
     const { preferPanelOnActionClick } = await loadPanelHost()
 
     preferPanelOnActionClick()
+
     expect(setPanelBehavior).toHaveBeenCalledWith({ openPanelOnActionClick: true })
   })
 

--- a/extensions/dsh-browser/tests/panel-styles.spec.ts
+++ b/extensions/dsh-browser/tests/panel-styles.spec.ts
@@ -13,4 +13,15 @@ describe('panel layout styles', () => {
     expect(settingsRule).toMatch(/(?:^|\n)\s*overflow-y:\s*auto;/)
     expect(settingsRule).toMatch(/(?:^|\n)\s*overscroll-behavior:\s*contain;/)
   })
+
+  it('keeps settings cards at their natural height so a short window scrolls', () => {
+    const styles = readFileSync(`${process.cwd()}/src/panel/styles.css`, 'utf8')
+    const childRule = styles.match(/\.settings\s*>\s*\*\s*\{([^}]*)\}/)?.[1]
+
+    // The cards set overflow:hidden, which zeroes their flex min-height; without
+    // this they compress instead of scrolling and "Save & Connect" goes
+    // out of reach, which is the only way to persist bridge settings.
+    expect(childRule).toBeDefined()
+    expect(childRule).toMatch(/(?:^|\n)\s*flex-shrink:\s*0;/)
+  })
 })

--- a/extensions/dsh-browser/vite.shared.ts
+++ b/extensions/dsh-browser/vite.shared.ts
@@ -1,7 +1,14 @@
-import { copyFileSync, cpSync, mkdirSync } from 'node:fs'
+import { cpSync, mkdirSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig } from 'vite'
+import {
+  composeManifest,
+  EXTENSION_TARGETS,
+  serializeManifest,
+  TARGET_OUT_DIR,
+  type ExtensionTarget,
+} from './manifest.compose.ts'
 
 /**
  * Shared build plumbing for the extension's three targets (background ES
@@ -10,21 +17,25 @@ import { defineConfig } from 'vite'
  */
 
 /**
- * Build target: `chrome` (default) or `firefox` (set EXT_TARGET=firefox or
- * pass --firefox to scripts/build.mjs). Each target gets its own manifest and
- * output directory so both builds can coexist.
+ * Build target: `chrome` (default), `firefox`, or `opera` (set EXT_TARGET or
+ * pass --firefox / --opera to scripts/build.mjs). Each target gets its own
+ * composed manifest and output directory so the builds can coexist.
  */
-export const browserTarget = process.env.EXT_TARGET === 'firefox' ? 'firefox' : 'chrome'
-export const targetManifest = browserTarget === 'firefox' ? 'manifest.firefox.json' : 'manifest.json'
+function resolveTarget(): ExtensionTarget {
+  const requested = process.env.EXT_TARGET
+  return EXTENSION_TARGETS.find((target) => target === requested) ?? 'chrome'
+}
 
-export const outDir = resolve(import.meta.dirname, browserTarget === 'firefox' ? 'dist-firefox' : 'dist')
+export const browserTarget = resolveTarget()
 
-/** Copy manifest, locale catalogs, and icons into the target's outDir. */
+export const outDir = resolve(import.meta.dirname, TARGET_OUT_DIR[browserTarget])
+
+/** Write the composed manifest, locale catalogs, and icons into the target's outDir. */
 export const copyManifest = {
   name: 'copy-manifest',
   closeBundle(): void {
     mkdirSync(outDir, { recursive: true })
-    copyFileSync(resolve(import.meta.dirname, targetManifest), resolve(outDir, 'manifest.json'))
+    writeFileSync(resolve(outDir, 'manifest.json'), serializeManifest(composeManifest(browserTarget)))
     cpSync(resolve(import.meta.dirname, '_locales'), resolve(outDir, '_locales'), { recursive: true })
     cpSync(resolve(import.meta.dirname, 'assets'), resolve(outDir, 'assets'), { recursive: true })
   },


### PR DESCRIPTION
## 概述 / Summary

让 Opera 也能打开助手面板：面板载体改为运行时按能力选择，并把 `sidebar_action` 放进 Opera 专属的 manifest。顺带修复设置页在窗口高度较小时被压扁的问题。

Open the assistant panel on Opera by choosing the panel host at runtime and shipping `sidebar_action` in an Opera-specific manifest. Also fixes the settings screen compressing at low window heights.

Fixes #34.

## 动机 / Motivation

`openAssistantPanel` 依据构建目标 `EXT_TARGET` 分支，这对 Opera 无效：Opera 加载的是 **Chrome 构建**，却没有 `chrome.sidePanel`。结果是点击工具栏图标毫无反应，未加保护的 `sidePanel.open()` 还会抛 `TypeError`。Opera 原生渲染旧版 `sidebar_action` manifest 键——Firefox 用的也是它。

`openAssistantPanel` branched on the build-time `EXT_TARGET`, which cannot work for Opera: Opera loads the **Chrome build** yet has no `chrome.sidePanel`. Clicking the toolbar icon did nothing, and an unguarded `sidePanel.open()` threw a `TypeError`. Opera does render the legacy `sidebar_action` manifest key natively — the same key Firefox uses.

设置页是另一个问题：卡片设置了 `overflow:hidden`，这会把它们的 flex `min-height` 解析为 0，于是窗口一矮就压缩内容而不是滚动，唯一能保存桥接设置的 **Save & Connect** 被挤出可视范围。

Separately, the settings cards set `overflow:hidden`, which resolves their flex `min-height` to zero: a short window compressed them instead of scrolling, putting **Save & Connect** — the only way to persist bridge settings — out of reach.

## 改动内容 / Changes

### 1. 运行时选择面板载体 / Runtime panel host

新增 `src/background/panel-host.ts`，按**运行时**能力而非构建目标选择：

New `src/background/panel-host.ts` picks the host by **runtime** capability rather than build target:

- `chrome.sidePanel` 存在 → 原生侧边面板（Chrome 116+）/ native side panel where `chrome.sidePanel` exists
- 否则 → 旧版 `chrome.sidebarAction`，Opera 还会镜像到 `opr.sidebarAction` / otherwise the legacy `chrome.sidebarAction`, which Opera also mirrors on `opr.sidebarAction`
- 都没有 → 发通知说明原因 / a notification explaining why, when the browser has neither

这取代了构建期 `EXT_TARGET` 分支，Firefox 经由同一条路径保留侧栏。面板**不会**退回到普通窗口：那会把 `chrome-extension://` 文档放到 tab affinity 期望「用户页面」的位置，而 affinity 会把浏览器工具绑定到当前活动标签页。

This replaces the build-time `EXT_TARGET` branch, so Firefox keeps its sidebar through the same path. The panel is **not** hosted in an ordinary window: that would put a `chrome-extension://` document where tab affinity expects the user's page, and affinity binds browser tools to whatever the active tab is.

### 2. 每个浏览器的 manifest 由同一份 base 合成 / Manifests composed from one base

Chrome 对 `sidebar_action` 会报 "Unrecognized manifest key"，而本项目没有上架 Web Store，所有人都是「加载已解压」，因此每个用户都会看到这条警告。Opera 需要这个键，Chrome 不能带它——一份 manifest 无法同时满足两者。

Chrome reports `Unrecognized manifest key 'sidebar_action'` for every unpacked install, and this project has no Web Store listing, so every user loads unpacked and would see it. Opera needs the key; Chrome must not carry it. One manifest cannot satisfy both.

直接再手写一份 Opera manifest 会让真正的问题恶化：Chrome 与 Firefox 两份 manifest 有 **54% 的字节完全重复**，`firefox-build.spec` 的存在就是为了人工盯住这份重复。

Hand-writing a third manifest would have made the real problem worse: **54% of the Chrome manifest was byte-identical** to the Firefox one, and `firefox-build.spec` exists to police that duplication by hand.

```
manifest.json          Chrome，同时是 base / Chrome, and the base
manifest.firefox.json  delta
manifest.opera.json    delta —— 三个键 / three keys
manifest.compose.ts    构建与测试共用 / shared by the build and the tests
```

规则只有两条：delta 条目**整键替换**，`null` **删除该键**。不做递归合并——递归把 Firefox 的 `background` 合成了 `service_worker` + `type` + `scripts` 三键并存，哪个引擎都不接受。

Two rules only: a delta entry **replaces** that top-level key, and `null` **removes** it. Nothing merges recursively — a recursive merge produced `service_worker`, `type` and `scripts` together in Firefox's `background`, which is not a manifest either engine accepts.

`manifest.json` 保持 Chrome manifest 并充当 base，因为面板内的更新检查会从 `main` 拉取这个确切路径读版本号。

`manifest.json` stays the Chrome manifest and doubles as the base: the in-panel update check fetches that exact path from `main` to read the published version.

### 3. 设置页滚动 / Settings scroll

`.settings > * { flex-shrink: 0 }` 让卡片保持自然高度，整页滚动。

## 测试 / Testing

- **现有构建逐字节不变**：Chrome 与 Firefox 的合成产物与 `main` 上被替换掉的两份 manifest 做 JSON 深比较，完全一致 / **Existing builds are byte-identical**: the composed Chrome and Firefox manifests deep-compare equal to the ones this branch replaces on `main`
- **真实 Chromium**：加载扩展 → service worker 无报错 → 连上真实 bridge → 面板显示已连接（仓库自带 e2e，未走跳过分支）/ **Real Chromium**: extension loads, service worker clean, connects to a real bridge, panel shows connected (the repo's own e2e, not the self-skip path)
- **CSS 结论实测**：400×300 视口下，未修复时 220px 的卡片被压到 **44px** 且容器不可滚动；修复后卡片保持原高且可滚动 / **The CSS claim measured**: at a 400×300 viewport a 220px card compresses to **44px** and the container does not scroll; with the fix, cards keep their height and it scrolls
- `manifest-compose.spec.ts`：每个目标只带自己认识的键、只申请自己用得上的权限、拿到本引擎接受的 `background` 形态、共享字段结构上无法漂移 / each target ships only the key its browser understands, requests only the permission it can use, gets the `background` form its engine accepts, and shared metadata cannot drift
- `panel-host.spec.ts`：三条路径与各自的失败分支 / all three paths and their failure branches
- 全量 **336 通过**（100 bridge + 236 extension）、`pnpm run typecheck` 通过、三个目标均可构建 / **336 passing**, typecheck clean, all three targets build

## 影响范围 / Impact

- **Chrome/Edge**：行为不变，仍走原生侧边面板；`sidebar_action` 警告消失 / unchanged, still the native side panel; the `sidebar_action` warning is gone
- **Firefox**：产物不变，侧栏改由运行时探测驱动 / output unchanged, its sidebar is now driven by runtime detection
- **Opera**：`pnpm --filter dsh-browser-extension run build:opera` → 加载 `dist-opera/`，面板停靠在左侧栏 / build and load `dist-opera/`; the panel docks in the left sidebar
- 所有平台：设置页在矮窗口下可滚动 / all platforms: the settings screen scrolls in a short window

## Checklist

- [x] 已在相关平台实测通过 / Tested on the relevant platforms
- [x] 已通过 `pnpm run build` / `pnpm test` / `pnpm run typecheck` 等基础检查 / Passed basic checks
- [x] 文档已同步更新（两份 README 新增 Opera 构建说明，i18n 哈希已刷新）/ Docs updated (an Opera build section in both READMEs; i18n hashes refreshed)
- [x] 不包含无关改动 / No unrelated changes included

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces build-time panel-host selection with runtime capability detection, adds composed browser-specific manifests and an Opera build, and prevents settings cards from shrinking in short viewports.
- Uses the native Side Panel API when available and falls back to the legacy sidebar API.
- Removes the ordinary-window fallback that caused the previously reported popup race.
- Adds Chrome, Firefox, and Opera manifest composition with separate output directories.
- Keeps settings cards at their natural height so the panel can scroll vertically.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| extensions/dsh-browser/src/background/panel-host.ts | Selects the available panel host at runtime and removes the popup-window fallback and its concurrency state. |
| extensions/dsh-browser/src/background/index.ts | Routes toolbar and notification interactions through the shared runtime panel-host implementation. |
| extensions/dsh-browser/manifest.compose.ts | Composes browser manifests using top-level replacement and explicit key removal. |
| extensions/dsh-browser/manifest.opera.json | Defines Opera’s legacy sidebar host and removes the unsupported Side Panel manifest entry. |
| extensions/dsh-browser/scripts/build.mjs | Adds Opera as a selectable build target with its own output directory. |
| extensions/dsh-browser/src/panel/styles.css | Prevents settings cards from shrinking so short viewports scroll rather than compress their contents. |
| extensions/dsh-browser/tests/panel-host.spec.ts | Covers runtime host selection, failure reporting, and the absence of window or tab creation. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User requests assistant panel] --> B{Side Panel API available?}
    B -->|Yes| C[Open native side panel]
    B -->|No| D{Legacy sidebar API available?}
    D -->|Yes| E[Open browser sidebar]
    D -->|No| F[Show unsupported-browser notification]
```
</details>

<sub>Reviews (11): Last reviewed commit: ["docs: drop the unverified-on-Opera note"](https://github.com/lum1104/dsh-browser/commit/c46b8d116d5ff8bceb1a83afa2ca34e3f3d9e364) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55953217)</sub>

<!-- /greptile_comment -->