### PR TITLE
feat(panel/bridge): session deletion and API relay profiles for the side panel

### DIFF
--- a/extensions/dsh-browser/src/panel/App.tsx
+++ b/extensions/dsh-browser/src/panel/App.tsx
@@ -836,6 +836,19 @@ export function App(): React.JSX.Element {
     applyHistory(created.sessionId, await readHistory(created.sessionId))
   }
 
+  /** 拉取会话列表并排除已归档条目：上游 session.list 不做归档过滤，已删除会话会以冷/附着形态残留。 */
+  async function loadVisibleSessions(): Promise<SessionPickerEntry[]> {
+    const [listed, workspaces] = await Promise.all([
+      api.rpc<{ items: SessionPickerEntry[] }>('session.list', {}),
+      api.rpc<{ archivedSessionIds?: string[] }>('workspace.list', {}).catch(() => ({ archivedSessionIds: [] as string[] })),
+    ])
+    const archived = new Set(workspaces.archivedSessionIds ?? [])
+    for (const entry of listed.items ?? []) {
+      sessionRuntimeRef.current.seedRunning(entry.sessionId, entry.running)
+    }
+    return resumableSessions(listed.items ?? []).filter((entry) => !archived.has(entry.sessionId))
+  }
+
   /** Restore the last browser conversation, then the latest durable one, before creating a chat. */
   async function initializeSession(): Promise<void> {
     if (sessionInitializationRef.current || sessionChangingRef.current || sessionRef.current !== null) return
@@ -845,8 +858,7 @@ export function App(): React.JSX.Element {
       if (settings?.autoResumeSession === true) {
         let entries: SessionPickerEntry[] = []
         try {
-          const listed = await api.rpc<{ items: SessionPickerEntry[] }>('session.list', {})
-          entries = resumableSessions(listed.items ?? [])
+          entries = await loadVisibleSessions()
         } catch {
           // The direct resume hint may still identify a live provisional session.
         }
@@ -890,11 +902,7 @@ export function App(): React.JSX.Element {
     setShowSessionPicker(true)
     setLoadingSessions(true)
     try {
-      const result = await api.rpc<{ items: SessionPickerEntry[] }>('session.list', {})
-      for (const entry of result.items ?? []) {
-        sessionRuntimeRef.current.seedRunning(entry.sessionId, entry.running)
-      }
-      const items = resumableSessions(result.items ?? [])
+      const items = await loadVisibleSessions()
       const current = items.find((entry) => entry.sessionId === sessionRef.current)
       const currentTitle = current === undefined ? undefined : projectedSessionTitle(current)
       if (currentTitle !== undefined) setSessionTitle(currentTitle)
@@ -934,12 +942,17 @@ export function App(): React.JSX.Element {
     if (!window.confirm(copy.app.deleteSessionConfirm(title))) return
     try {
       await api.rpc('workspace.archiveSession', { sessionId: entry.sessionId })
+      let purgeFailure: string | null = null
       try {
         await api.rpc(BRIDGE_SESSION_PURGE_METHOD, { sessionId: entry.sessionId })
-      } catch {
-        // 文件清理是尽力而为：索引已移除，残留文件不影响列表。
+      } catch (cause) {
+        purgeFailure = cause instanceof Error ? cause.message : String(cause)
       }
       setSessionList((prev) => prev.filter((item) => item.sessionId !== entry.sessionId))
+      if (purgeFailure !== null) {
+        // 归档已生效（列表不再显示），但磁盘清理失败需要用户知道。
+        setError(copy.app.deletePurgeFailed(purgeFailure))
+      }
       if (sessionRef.current === entry.sessionId) {
         setShowSessionPicker(false)
         await startNewSession()

--- a/extensions/dsh-browser/src/panel/App.tsx
+++ b/extensions/dsh-browser/src/panel/App.tsx
@@ -8,12 +8,12 @@
  */
 
 import { memo, useEffect, useMemo, useRef, useState } from 'react'
-import { DEFAULT_SNAPSHOT_MAX_CHARS } from '@yuxianglin/dsh-bridge-browser/src/protocol.ts'
+import { BRIDGE_SESSION_PURGE_METHOD, DEFAULT_SNAPSHOT_MAX_CHARS } from '@yuxianglin/dsh-bridge-browser/src/protocol.ts'
 import type { BridgeCaps } from '@yuxianglin/dsh-bridge-browser/src/protocol.ts'
 import type { ServerFrame } from '@yuxianglin/dsh-bridge-browser/src/protocol.ts'
 import type { BridgeState } from '../background/bridge.ts'
 import type { AffinityTab, TabAffinityDecision, TabAffinityState } from '../background/tab-affinity.ts'
-import { connectPanel, type PanelApi, type PanelSettings } from './api.ts'
+import { connectPanel, PanelRpcError, type PanelApi, type PanelSettings } from './api.ts'
 import { renderMarkdown } from './markdown.ts'
 import whaleUrl from '../../assets/icons/deepseek-256.png'
 import type { ApprovalDecision, ApprovalRequest } from '../security/approval.ts'
@@ -78,6 +78,138 @@ function normalizeWebOrigin(value: string): string | null {
   return normalizeTrustedOrigin(value) ?? null
 }
 
+/** One editable API-relay profile in the settings view. */
+interface RelayProfileDraft {
+  /** Stable llm-pi-ai provider-route key; empty until first save mints it. */
+  key: string
+  name: string
+  protocol: 'anthropic-messages' | 'openai-completions' | 'openai-codex-responses'
+  baseUrl: string
+  /** Typed token; empty means keep whatever is already stored. */
+  token: string
+  tokenConfigured: boolean
+  modelsText: string
+  setDefault: boolean
+}
+
+/** Route keys managed by the relay editor; core-owned routes are never touched. */
+const RELAY_ROUTE_PREFIX = 'relay-'
+
+/**
+ * Display names are free-form (CJK included); the route key needs the
+ * ASCII shape the wire and credential refs expect, so CJK-heavy names
+ * collapse to a stable name hash instead of being rejected.
+ */
+function relayRouteKey(name: string): string {
+  const slug = name.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+  if (slug !== '') return `${RELAY_ROUTE_PREFIX}${slug}`
+  let hash = 5381
+  for (let index = 0; index < name.length; index += 1) {
+    hash = ((hash << 5) + hash + name.charCodeAt(index)) | 0
+  }
+  return `${RELAY_ROUTE_PREFIX}n${(hash >>> 0).toString(36)}`
+}
+
+function relayTokenRef(routeKey: string): string {
+  const suffix = routeKey.slice(RELAY_ROUTE_PREFIX.length).replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()
+  return `DSH_RELAY_${suffix}_TOKEN`
+}
+
+function parseRelayModels(text: string): Array<{ id: string; contextWindow?: number }> {
+  return text.split('\n').map((line) => line.trim()).filter((line) => line !== '').map((line) => {
+    const [id, contextWindow] = line.split(',').map((part) => part.trim())
+    const parsed = contextWindow === undefined || contextWindow === '' ? undefined : Number(contextWindow)
+    return {
+      id,
+      ...(parsed !== undefined && Number.isFinite(parsed) && parsed > 0 ? { contextWindow: parsed } : {}),
+    }
+  }).filter((model) => model.id !== '')
+}
+
+/** Gateways report failures with the endpoint named; surface everything we got. */
+function relayErrorText(cause: unknown): string {
+  if (cause instanceof PanelRpcError) {
+    const detailKeys = Object.keys(cause.details ?? {})
+    const details = detailKeys.length > 0 ? ` ${JSON.stringify(cause.details).slice(0, 220)}` : ''
+    return `${cause.message}${details}`
+  }
+  return cause instanceof Error ? cause.message : String(cause)
+}
+
+type DiscoveredModel = { id: string; contextWindow?: number }
+
+/**
+ * Anthropic-protocol routes have no native listing; the gateway still fails
+ * them with a "no model listing" message whose wording varies, so match the
+ * known phrasings instead of one brittle code.
+ */
+function isManualOnlyDiscovery(cause: unknown): boolean {
+  if (!(cause instanceof PanelRpcError)) return false
+  return cause.code.includes('unsupported')
+    || /no model listing|models by hand/i.test(cause.message)
+}
+
+function isAuthFailure(cause: unknown): boolean {
+  return cause instanceof PanelRpcError
+    && (cause.code.includes('credential') || /\b401\b|\b403\b|invalid[ _-]?key/i.test(cause.message))
+}
+
+async function discoverOnce(
+  api: PanelApi,
+  profile: RelayProfileDraft,
+  attempt: { api: string; baseURL: string },
+): Promise<DiscoveredModel[]> {
+  const result = await api.rpc<{ models?: DiscoveredModel[] }>('llm.discoverModels', {
+    settingsNs: 'llm-pi-ai',
+    provider: profile.key !== '' ? profile.key : relayRouteKey(profile.name),
+    api: attempt.api,
+    baseURL: attempt.baseURL,
+    ...(profile.token.trim() === '' ? {} : { apiKey: profile.token.trim() }),
+  })
+  return result.models ?? []
+}
+
+/**
+ * Build the ordered discovery attempts for one draft. Anthropic-protocol
+ * profiles have no native listing, so fall back to the relay's own
+ * OpenAI-compatible listing endpoint (`<base>/v1/models`) — New API / One API
+ * style stations serve it with the same token, and the returned ids are the
+ * ones the Anthropic route accepts.
+ */
+async function discoverWithFallback(
+  api: PanelApi,
+  profile: RelayProfileDraft,
+): Promise<{ models: DiscoveredModel[]; viaOpenaiListing: boolean }> {
+  const base = profile.baseUrl.trim().replace(/\/+$/, '')
+  const attempts: Array<{ api: string; baseURL: string; viaOpenaiListing: boolean }> = []
+  if (profile.protocol === 'anthropic-messages') {
+    attempts.push({ api: 'openai-completions', baseURL: `${base}/v1`, viaOpenaiListing: true })
+    attempts.push({ api: 'openai-completions', baseURL: base, viaOpenaiListing: true })
+  } else {
+    attempts.push({ api: profile.protocol, baseURL: base, viaOpenaiListing: false })
+    if (!base.includes('/v1')) {
+      attempts.push({ api: profile.protocol, baseURL: `${base}/v1`, viaOpenaiListing: false })
+    }
+  }
+
+  let lastCause: unknown
+  for (const attempt of attempts) {
+    try {
+      const models = await discoverOnce(api, profile, attempt)
+      if (models.length > 0) {
+        return { models, viaOpenaiListing: attempt.viaOpenaiListing }
+      }
+      lastCause = new PanelRpcError('model-discovery-failed', 'the endpoint listed no models', {
+        baseURL: attempt.baseURL,
+      })
+    } catch (cause) {
+      lastCause = cause
+      if (isAuthFailure(cause)) break
+    }
+  }
+  throw lastCause ?? new PanelRpcError('model-discovery-failed', 'model discovery failed', {})
+}
+
 function SettingsIcon(): React.JSX.Element {
   return (
     <svg viewBox="0 0 20 20" aria-hidden="true">
@@ -91,6 +223,14 @@ function PlusIcon(): React.JSX.Element {
   return (
     <svg viewBox="0 0 20 20" aria-hidden="true">
       <path d="M10 4.5v11M4.5 10h11" />
+    </svg>
+  )
+}
+
+function TrashIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 20 20" aria-hidden="true">
+      <path d="M4 6h12M8 6V4.5A1.5 1.5 0 0 1 9.5 3h1A1.5 1.5 0 0 1 12 4.5V6m-7 0 .7 9.1A2 2 0 0 0 7.7 17h4.6a2 2 0 0 0 2-1.9L15 6M8.25 9v4.5M11.75 9v4.5" />
     </svg>
   )
 }
@@ -350,6 +490,10 @@ export function App(): React.JSX.Element {
   const [loadingSessions, setLoadingSessions] = useState(false)
   const [sessionChanging, setSessionChanging] = useState(false)
   const [sessionList, setSessionList] = useState<SessionPickerEntry[]>([])
+  const [relayProfiles, setRelayProfiles] = useState<RelayProfileDraft[]>([])
+  const [relayLoaded, setRelayLoaded] = useState(false)
+  const [relayNotice, setRelayNotice] = useState<string | null>(null)
+  const [relayBusy, setRelayBusy] = useState(false)
   const [sessionTitle, setSessionTitle] = useState<string | null>(null)
   const [resumeHint, setResumeHint] = useState<{ ready: boolean; sessionId: string | null }>({ ready: false, sessionId: null })
   const [questions, setQuestions] = useState<PendingQuestion[]>([])
@@ -783,6 +927,28 @@ export function App(): React.JSX.Element {
     }
   }
 
+  /** 删除历史会话：先走官方归档更新索引，再经桥接清理磁盘文件。 */
+  async function deleteSession(entry: SessionPickerEntry): Promise<void> {
+    if (entry.running || sessionSwitchBlocked || sessionChangingRef.current) return
+    const title = projectedSessionTitle(entry) ?? sessionDisplayTitle(entry)
+    if (!window.confirm(copy.app.deleteSessionConfirm(title))) return
+    try {
+      await api.rpc('workspace.archiveSession', { sessionId: entry.sessionId })
+      try {
+        await api.rpc(BRIDGE_SESSION_PURGE_METHOD, { sessionId: entry.sessionId })
+      } catch {
+        // 文件清理是尽力而为：索引已移除，残留文件不影响列表。
+      }
+      setSessionList((prev) => prev.filter((item) => item.sessionId !== entry.sessionId))
+      if (sessionRef.current === entry.sessionId) {
+        setShowSessionPicker(false)
+        await startNewSession()
+      }
+    } catch (cause) {
+      setError(copy.app.deleteSessionFailed(cause instanceof Error ? cause.message : String(cause)))
+    }
+  }
+
   /** Load the session that owns an approval before exposing its decision UI. */
   async function focusApprovalSession(request: ApprovalRequest): Promise<void> {
     const sessionId = request.sessionId
@@ -943,10 +1109,242 @@ export function App(): React.JSX.Element {
   async function saveSettings(): Promise<void> {
     if (settings === null) return
     try {
+      const relaySaved = await saveRelayProfiles()
+      if (!relaySaved) return
       await api.updateSettings(settings)
       setShowSettings(false)
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause))
+    }
+  }
+
+  /** Load relay profiles from the llm-pi-ai settings namespace once per settings visit. */
+  useEffect(() => {
+    if (!showSettings || relayLoaded) return
+    let cancelled = false
+    void (async () => {
+      try {
+        const described = await api.rpc<{
+          namespaces?: Array<{ ns: string; value?: Record<string, unknown> }>
+        }>('settings.describe', {})
+        const ns = described.namespaces?.find((candidate) => candidate.ns === 'llm-pi-ai')
+        const providers = (ns?.value?.providers ?? {}) as Record<string, {
+          displayName?: string
+          api?: string
+          baseURL?: string
+          apiKeyEnv?: string
+          models?: Array<{ id: string; contextWindow?: number }>
+        }>
+        const defaults = (described.namespaces?.find((candidate) => candidate.ns === 'agent-default-model')
+          ?.value ?? {}) as { provider?: unknown }
+        const refs = Object.entries(providers)
+          .filter(([key]) => key.startsWith(RELAY_ROUTE_PREFIX))
+          .map(([, route]) => typeof route.apiKeyEnv === 'string' ? route.apiKeyEnv : '')
+          .filter((ref) => ref !== '')
+        let configuredRefs = new Set<string>()
+        if (refs.length > 0) {
+          try {
+            const creds = await api.rpc<{ credentials?: Record<string, { configured?: boolean }> }>(
+              'credentials.describe',
+              { refs },
+            )
+            configuredRefs = new Set(
+              Object.entries(creds.credentials ?? {})
+                .filter(([, view]) => view.configured === true)
+                .map(([ref]) => ref),
+            )
+          } catch {
+            // Credential visibility is cosmetic here; treat every token as unconfigured.
+          }
+        }
+        const drafts = Object.entries(providers)
+          .filter(([key]) => key.startsWith(RELAY_ROUTE_PREFIX))
+          .map(([key, route]) => ({
+            key,
+            name: typeof route.displayName === 'string' && route.displayName !== '' ? route.displayName : key,
+            protocol: (route.api === 'anthropic-messages' || route.api === 'openai-codex-responses'
+              ? route.api
+              : 'openai-completions') as RelayProfileDraft['protocol'],
+            baseUrl: typeof route.baseURL === 'string' ? route.baseURL : '',
+            token: '',
+            tokenConfigured: route.apiKeyEnv !== undefined && configuredRefs.has(route.apiKeyEnv),
+            modelsText: (route.models ?? []).map((model) => [
+              model.id,
+              model.contextWindow === undefined ? '' : String(model.contextWindow),
+            ].filter((part) => part !== '').join(', ')).join('\n'),
+            setDefault: defaults.provider === key,
+          }))
+        if (!cancelled) setRelayProfiles(drafts)
+      } catch {
+        // The namespace may not exist yet; an empty list still allows creating profiles.
+      }
+      if (!cancelled) setRelayLoaded(true)
+    })()
+    return () => { cancelled = true }
+  }, [api, showSettings, relayLoaded])
+
+  function updateRelayProfile(index: number, patch: Partial<RelayProfileDraft>): void {
+    setRelayProfiles((current) => current.map((profile, at) => at === index ? { ...profile, ...patch } : profile))
+  }
+
+  function addRelayProfile(): void {
+    setRelayNotice(null)
+    setRelayProfiles((current) => [...current, {
+      key: '',
+      name: '',
+      protocol: 'openai-completions',
+      baseUrl: '',
+      token: '',
+      tokenConfigured: false,
+      modelsText: '',
+      setDefault: false,
+    }])
+  }
+
+  async function removeRelayProfile(index: number): Promise<void> {
+    const profile = relayProfiles[index]
+    setRelayProfiles((current) => current.filter((_, at) => at !== index))
+    setRelayNotice(null)
+    if (profile === undefined || profile.key === '') return
+    try {
+      await api.rpc('settings.mutate', {
+        ns: 'llm-pi-ai',
+        ops: [{ op: 'unset', path: ['providers', profile.key] }],
+      })
+      try {
+        await api.rpc('credentials.unset', { ref: relayTokenRef(profile.key) })
+      } catch {
+        // The route is gone either way; a stale credential reference harms nothing.
+      }
+    } catch (cause) {
+      setRelayNotice(copy.settings.relaySaveFailed(cause instanceof Error ? cause.message : String(cause)))
+    }
+  }
+
+  async function testRelayConnection(index: number): Promise<void> {
+    const profile = relayProfiles[index]
+    if (profile === undefined || relayBusy) return
+    setRelayBusy(true)
+    setRelayNotice(copy.settings.relayTesting)
+    try {
+      const { models, viaOpenaiListing } = await discoverWithFallback(api, profile)
+      const ids = models.map((model) => model.id)
+      if (ids.length === 0) {
+        setRelayNotice(copy.settings.relayTestManualOnly)
+        return
+      }
+      setRelayNotice(copy.settings.relayTestOk(ids.length, ids.slice(0, 4).join(', ')
+        + (ids.length > 4 ? ' …' : ''))
+        + (viaOpenaiListing ? copy.settings.relayOpenaiListingNote : ''))
+    } catch (cause) {
+      setRelayNotice(isManualOnlyDiscovery(cause)
+        ? copy.settings.relayTestManualOnly
+        : copy.settings.relayTestFailed(relayErrorText(cause)))
+    } finally {
+      setRelayBusy(false)
+    }
+  }
+
+  /** Discover models from the drafted endpoint and fill the textarea in place. */
+  async function fetchRelayModels(index: number): Promise<void> {
+    const profile = relayProfiles[index]
+    if (profile === undefined || relayBusy) return
+    if (profile.baseUrl.trim() === '') {
+      setRelayNotice(copy.settings.relayNeedBaseUrl)
+      return
+    }
+    setRelayBusy(true)
+    setRelayNotice(copy.settings.relayFetching)
+    try {
+      const { models, viaOpenaiListing } = await discoverWithFallback(api, profile)
+      if (models.length === 0) {
+        setRelayNotice(copy.settings.relayTestManualOnly)
+        return
+      }
+      updateRelayProfile(index, {
+        modelsText: models.map((model) => [
+          model.id,
+          model.contextWindow === undefined ? '' : String(model.contextWindow),
+        ].filter((part) => part !== '').join(', ')).join('\n'),
+      })
+      setRelayNotice(copy.settings.relayFetchOk(models.length)
+        + (viaOpenaiListing ? copy.settings.relayOpenaiListingNote : ''))
+    } catch (cause) {
+      setRelayNotice(isManualOnlyDiscovery(cause)
+        ? copy.settings.relayTestManualOnly
+        : copy.settings.relayTestFailed(relayErrorText(cause)))
+    } finally {
+      setRelayBusy(false)
+    }
+  }
+
+  /**
+   * Persist every relay draft: token to the credential store, route to the
+   * llm-pi-ai namespace, optional default to agent-default-model.
+   * @returns false when validation failed and the outer save must abort.
+   */
+  async function saveRelayProfiles(): Promise<boolean> {
+    for (const profile of relayProfiles) {
+      if (profile.name.trim() === '') {
+        setRelayNotice(copy.settings.relayInvalidName)
+        return false
+      }
+    }
+    try {
+      const usedKeys = new Set<string>()
+      let defaultApplied = false
+      for (const profile of relayProfiles) {
+        let key = profile.key !== '' ? profile.key : relayRouteKey(profile.name)
+        while (usedKeys.has(key)) key += '-x'
+        usedKeys.add(key)
+        const ref = relayTokenRef(key)
+        if (profile.token.trim() !== '') {
+          await api.rpc('credentials.set', { ref, value: profile.token.trim() })
+        }
+        const models = parseRelayModels(profile.modelsText)
+        const firstModel = models[0]
+        const routeValue: Record<string, unknown> = {
+          displayName: profile.name.trim(),
+          apiKeyEnv: ref,
+          baseURL: profile.baseUrl.trim(),
+          models,
+          api: profile.protocol,
+        }
+        await api.rpc('settings.mutate', {
+          ns: 'llm-pi-ai',
+          ops: [{ op: 'set', path: ['providers', key], value: routeValue }],
+        })
+        if (profile.setDefault && !defaultApplied && models.length > 0) {
+          await api.rpc('settings.mutate', {
+            ns: 'agent-default-model',
+            ops: [
+              { op: 'set', path: ['provider'], value: key },
+              { op: 'set', path: ['model'], value: firstModel?.id ?? '' },
+              { op: 'unset', path: ['reasoningEffort'] },
+            ],
+          })
+          defaultApplied = true
+          // Model selection is remembered per session; the active one would
+          // otherwise stay on its old provider until a new chat is started.
+          const activeSessionId = sessionRef.current
+          if (activeSessionId !== null && firstModel?.id !== undefined) {
+            try {
+              await api.rpc('session.selectModel', {
+                sessionId: activeSessionId,
+                provider: key,
+                model: firstModel.id,
+              })
+            } catch {
+              // Best effort: the default still applies to every new session.
+            }
+          }
+        }
+      }
+      if (relayProfiles.length > 0) setRelayNotice(copy.settings.relaySavedOk)
+      return true
+    } catch (cause) {
+      setRelayNotice(copy.settings.relaySaveFailed(cause instanceof Error ? cause.message : String(cause)))
+      return false
     }
   }
 
@@ -1071,6 +1469,102 @@ export function App(): React.JSX.Element {
             <span className="setting-toggle-control" aria-hidden="true"><span /></span>
           </label>
         </div>
+        <section className="relay-config" aria-labelledby="relay-title">
+          <div className="relay-heading">
+            <span id="relay-title">
+              <strong>{copy.settings.relaySection}</strong>
+              <small>{copy.settings.relayHelp}</small>
+            </span>
+            <button className="secondary" onClick={addRelayProfile}>{copy.settings.relayAdd}</button>
+          </div>
+          {relayProfiles.length === 0 && <p>{copy.settings.relayEmpty}</p>}
+          {relayProfiles.map((profile, index) => (
+            <div className="relay-profile" key={profile.key === '' ? `new-${index}` : profile.key}>
+              <label>
+                <span>{copy.settings.relayName}</span>
+                <input
+                  value={profile.name}
+                  onChange={(event) => updateRelayProfile(index, { name: event.target.value })}
+                  placeholder={copy.settings.relayNamePlaceholder}
+                />
+              </label>
+              <label>
+                <span>{copy.settings.relayProtocol}</span>
+                <select
+                  value={profile.protocol}
+                  onChange={(event) => updateRelayProfile(index, {
+                    protocol: event.target.value as RelayProfileDraft['protocol'],
+                  })}
+                >
+                  <option value="openai-completions">{copy.settings.relayProtocolOpenai}</option>
+                  <option value="openai-codex-responses">{copy.settings.relayProtocolCodex}</option>
+                  <option value="anthropic-messages">{copy.settings.relayProtocolClaude}</option>
+                </select>
+              </label>
+              <label>
+                <span>{copy.settings.relayBaseUrl}</span>
+                <input
+                  value={profile.baseUrl}
+                  onChange={(event) => updateRelayProfile(index, { baseUrl: event.target.value })}
+                  placeholder="https://api.example.com/v1"
+                />
+              </label>
+              <label>
+                <span>{copy.settings.relayToken}</span>
+                <input
+                  type="password"
+                  value={profile.token}
+                  onChange={(event) => updateRelayProfile(index, { token: event.target.value })}
+                  placeholder={copy.settings.relayTokenPlaceholder(profile.tokenConfigured)}
+                />
+              </label>
+              <div className="relay-models">
+                <div className="relay-label-row">
+                  <span>{copy.settings.relayModels}</span>
+                  <button className="relay-fetch" disabled={profile.baseUrl.trim() === '' || relayBusy}
+                    onClick={() => { void fetchRelayModels(index) }}>
+                    {copy.settings.relayFetchModels}
+                  </button>
+                </div>
+                <small>{copy.settings.relayModelsHelp}</small>
+                <textarea
+                  rows={3}
+                  aria-label={copy.settings.relayModels}
+                  value={profile.modelsText}
+                  onChange={(event) => updateRelayProfile(index, { modelsText: event.target.value })}
+                  placeholder={copy.settings.relayModelsPlaceholder}
+                />
+              </div>
+              <label className="setting-toggle">
+                <span className="setting-toggle-copy">
+                  <strong>{copy.settings.relaySetDefault}</strong>
+                  <small>{copy.settings.relaySetDefaultHelp}</small>
+                </span>
+                <input
+                  className="setting-toggle-input"
+                  type="checkbox"
+                  checked={profile.setDefault}
+                  onChange={(event) => setRelayProfiles((current) => current.map((candidate, at) => at === index
+                    ? { ...candidate, setDefault: event.target.checked }
+                    : candidate))}
+                />
+                <span className="setting-toggle-control" aria-hidden="true"><span /></span>
+              </label>
+              <div className="relay-profile-actions">
+                <button
+                  disabled={profile.name.trim() === '' || profile.baseUrl.trim() === ''}
+                  onClick={() => { void testRelayConnection(index) }}
+                >
+                  {copy.settings.relayTest}
+                </button>
+                <button className="secondary" onClick={() => { void removeRelayProfile(index) }}>
+                  {copy.settings.relayRemove}
+                </button>
+              </div>
+            </div>
+          ))}
+          {relayNotice !== null && <p className="hint">{relayNotice}</p>}
+        </section>
         <section className="trusted-origins" aria-labelledby="trusted-origins-title">
           <div>
             <span id="trusted-origins-title">{copy.settings.trustedOrigins}</span>
@@ -1158,6 +1652,13 @@ export function App(): React.JSX.Element {
                             {entry.cwd !== undefined && <span className="session-cwd" title={entry.cwd}>{entry.cwd}</span>}
                           </span>
                         </button>
+                        {!entry.running && (
+                          <button className="icon-button session-delete" disabled={sessionSwitchBlocked}
+                            aria-label={copy.app.deleteSession} title={copy.app.deleteSession}
+                            onClick={() => { void deleteSession(entry) }}>
+                            <TrashIcon />
+                          </button>
+                        )}
                       </li>
                     )
                   })}

--- a/extensions/dsh-browser/src/panel/strings.ts
+++ b/extensions/dsh-browser/src/panel/strings.ts
@@ -155,6 +155,7 @@ export interface PanelCopy {
     deleteSession: string
     deleteSessionConfirm: (title: string) => string
     deleteSessionFailed: (reason: string) => string
+    deletePurgeFailed: (reason: string) => string
     emptyTitle: string
     emptyDescription: string
     overviewPage: string
@@ -363,6 +364,7 @@ const EN: PanelCopy = {
     deleteSession: 'Delete session',
     deleteSessionConfirm: (title) => `Delete “${title}”? Its conversation history will be removed permanently.`,
     deleteSessionFailed: (reason) => `Delete failed: ${reason}`,
+    deletePurgeFailed: (reason) => `Removed from the list, but file cleanup failed (it may reappear after dsh restarts): ${reason}`,
     emptyTitle: 'Hand me the current page',
     emptyDescription: 'I can read the page, find information, and click, fill, or navigate for you.',
     overviewPage: 'Give me an overview',
@@ -571,6 +573,7 @@ const ZH: PanelCopy = {
     deleteSession: '删除会话',
     deleteSessionConfirm: (title) => `确定删除「${title}」吗？对话历史将被永久移除。`,
     deleteSessionFailed: (reason) => `删除失败：${reason}`,
+    deletePurgeFailed: (reason) => `已从列表移除，但文件清理失败（dsh 重启后可能再次出现）：${reason}`,
     emptyTitle: '把当前页面交给我',
     emptyDescription: '我可以阅读页面、查找信息，也可以替你点击、填写和导航。',
     overviewPage: '先概览这个页面',

--- a/extensions/dsh-browser/src/panel/strings.ts
+++ b/extensions/dsh-browser/src/panel/strings.ts
@@ -84,6 +84,38 @@ export interface PanelCopy {
     save: string
     cancel: string
     snapshotHint: (maxChars: number) => string
+    relaySection: string
+    relayHelp: string
+    relayName: string
+    relayNamePlaceholder: string
+    relayProtocol: string
+    relayProtocolClaude: string
+    relayProtocolOpenai: string
+    relayProtocolCodex: string
+    relayBaseUrl: string
+    relayToken: string
+    relayTokenPlaceholder: (configured: boolean) => string
+    relayModels: string
+    relayModelsHelp: string
+    relayModelsPlaceholder: string
+    relayAdd: string
+    relayRemove: string
+    relaySetDefault: string
+    relaySetDefaultHelp: string
+    relayFetchModels: string
+    relayFetching: string
+    relayFetchOk: (count: number) => string
+    relayNeedBaseUrl: string
+    relayOpenaiListingNote: string
+    relayTest: string
+    relayTesting: string
+    relayTestOk: (count: number, names: string) => string
+    relayTestFailed: (reason: string) => string
+    relayTestManualOnly: string
+    relaySavedOk: string
+    relaySaveFailed: (reason: string) => string
+    relayEmpty: string
+    relayInvalidName: string
   }
   update: {
     eyebrow: string
@@ -120,6 +152,9 @@ export interface PanelCopy {
     newSession: string
     sessionPickerLoading: string
     sessionPickerEmpty: string
+    deleteSession: string
+    deleteSessionConfirm: (title: string) => string
+    deleteSessionFailed: (reason: string) => string
     emptyTitle: string
     emptyDescription: string
     overviewPage: string
@@ -257,6 +292,38 @@ const EN: PanelCopy = {
     save: 'Save & Connect',
     cancel: 'Cancel',
     snapshotHint: (maxChars) => `Page snapshots are limited to ${maxChars} characters and longer content is truncated. Change snapshotMaxChars in the dsh plugin to adjust this limit.`,
+    relaySection: 'Models & API relay',
+    relayHelp: 'Point the assistant at your own API relay. Each profile becomes one provider route; changes take effect on the next message without a restart.',
+    relayName: 'Profile name',
+    relayNamePlaceholder: 'e.g. my-relay',
+    relayProtocol: 'API format',
+    relayProtocolClaude: 'Claude (Anthropic Messages)',
+    relayProtocolOpenai: 'OpenAI (Chat Completions)',
+    relayProtocolCodex: 'Codex (OpenAI Responses)',
+    relayBaseUrl: 'Base URL',
+    relayToken: 'Token',
+    relayTokenPlaceholder: (configured) => configured ? 'Saved — type to replace' : 'API token for the relay',
+    relayModels: 'Models',
+    relayModelsHelp: 'One model per line as `id, context window` — e.g. `claude-sonnet-4-5, 200000`. The context window is optional.',
+    relayModelsPlaceholder: 'model-id, 128000',
+    relayFetchModels: 'Fetch models',
+    relayFetching: 'Fetching models…',
+    relayFetchOk: (count) => `Filled in ${count} models from the relay.`,
+    relayNeedBaseUrl: 'Enter a base URL first.',
+    relayOpenaiListingNote: ' (listed via the relay\'s OpenAI-compatible endpoint)',
+    relayAdd: 'Add profile',
+    relayRemove: 'Remove profile',
+    relaySetDefault: 'Use as default model',
+    relaySetDefaultHelp: 'New conversations start with the first model of this profile',
+    relayTest: 'Test connection',
+    relayTesting: 'Testing…',
+    relayTestOk: (count, names) => `OK — ${count} model(s): ${names}`,
+    relayTestFailed: (reason) => `Failed: ${reason}`,
+    relayTestManualOnly: 'This protocol does not support listing models; fill them in manually.',
+    relaySavedOk: 'Relay profiles saved.',
+    relaySaveFailed: (reason) => `Saving failed: ${reason}`,
+    relayEmpty: 'No relay profiles yet.',
+    relayInvalidName: 'Enter a profile name.',
   },
   update: {
     eyebrow: 'Release channel',
@@ -293,6 +360,9 @@ const EN: PanelCopy = {
     newSession: 'New chat',
     sessionPickerLoading: 'Loading…',
     sessionPickerEmpty: 'No past sessions yet',
+    deleteSession: 'Delete session',
+    deleteSessionConfirm: (title) => `Delete “${title}”? Its conversation history will be removed permanently.`,
+    deleteSessionFailed: (reason) => `Delete failed: ${reason}`,
     emptyTitle: 'Hand me the current page',
     emptyDescription: 'I can read the page, find information, and click, fill, or navigate for you.',
     overviewPage: 'Give me an overview',
@@ -430,6 +500,38 @@ const ZH: PanelCopy = {
     save: '保存并连接',
     cancel: '取消',
     snapshotHint: (maxChars) => `页面快照上限为 ${maxChars} 字符，超出内容会被截断。可在 dsh 插件中调整 snapshotMaxChars。`,
+    relaySection: '模型与中转服务',
+    relayHelp: '把助手接到你自己的 API 中转站。每个档案对应一条提供方路由，保存后下一条消息即生效，无需重启。',
+    relayName: '档案名称',
+    relayNamePlaceholder: '例如 my-relay',
+    relayProtocol: '接口格式',
+    relayProtocolClaude: 'Claude（Anthropic Messages）',
+    relayProtocolOpenai: 'OpenAI（Chat Completions）',
+    relayProtocolCodex: 'Codex（OpenAI Responses）',
+    relayBaseUrl: '中转地址 Base URL',
+    relayToken: '令牌 Token',
+    relayTokenPlaceholder: (configured) => configured ? '已保存 — 输入可替换' : '中转站的 API 令牌',
+    relayModels: '模型列表',
+    relayModelsHelp: '每行一个模型，格式 `模型ID, 上下文窗口` — 如 `claude-sonnet-4-5, 200000`。上下文窗口可省略。',
+    relayModelsPlaceholder: 'model-id, 128000',
+    relayFetchModels: '获取模型列表',
+    relayFetching: '正在获取模型列表…',
+    relayFetchOk: (count) => `已从中转站填入 ${count} 个模型。`,
+    relayNeedBaseUrl: '请先填写中转地址 Base URL。',
+    relayOpenaiListingNote: '（经中转站的 OpenAI 兼容接口列出）',
+    relayAdd: '添加档案',
+    relayRemove: '删除档案',
+    relaySetDefault: '设为默认模型',
+    relaySetDefaultHelp: '新会话将默认使用该档案的第一个模型',
+    relayTest: '测试连接',
+    relayTesting: '测试中…',
+    relayTestOk: (count, names) => `连接成功 — ${count} 个模型：${names}`,
+    relayTestFailed: (reason) => `连接失败：${reason}`,
+    relayTestManualOnly: '该协议不支持在线列出模型，请手动填写模型列表。',
+    relaySavedOk: '中转配置已保存。',
+    relaySaveFailed: (reason) => `保存失败：${reason}`,
+    relayEmpty: '还没有中转档案。',
+    relayInvalidName: '请填写档案名称。',
   },
   update: {
     eyebrow: '发布通道',
@@ -466,6 +568,9 @@ const ZH: PanelCopy = {
     newSession: '新对话',
     sessionPickerLoading: '加载中…',
     sessionPickerEmpty: '暂无历史会话',
+    deleteSession: '删除会话',
+    deleteSessionConfirm: (title) => `确定删除「${title}」吗？对话历史将被永久移除。`,
+    deleteSessionFailed: (reason) => `删除失败：${reason}`,
     emptyTitle: '把当前页面交给我',
     emptyDescription: '我可以阅读页面、查找信息，也可以替你点击、填写和导航。',
     overviewPage: '先概览这个页面',

--- a/extensions/dsh-browser/src/panel/styles.css
+++ b/extensions/dsh-browser/src/panel/styles.css
@@ -2468,3 +2468,179 @@ textarea:focus-visible {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+.session-list li {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.session-list li > button:not(.session-delete) {
+  min-width: 0;
+  flex: 1;
+}
+
+.session-list .session-delete {
+  flex: 0 0 auto;
+  align-self: center;
+  width: 26px;
+  height: 26px;
+  margin-right: 4px;
+  color: var(--faint);
+  opacity: .75;
+}
+
+.session-list .session-delete:hover {
+  color: var(--danger);
+  opacity: 1;
+}
+
+.relay-config {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 13px;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: var(--surface);
+  box-shadow: 0 6px 18px rgba(23, 32, 51, 0.05);
+}
+
+.relay-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.relay-heading > span {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.relay-heading strong {
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 680;
+}
+
+.relay-heading small {
+  color: var(--faint);
+  font-size: 9.5px;
+  line-height: 1.45;
+}
+
+.relay-config > p {
+  margin: 0;
+  color: var(--faint);
+  font-size: 9.5px;
+}
+
+.relay-profile {
+  display: grid;
+  gap: 8px;
+  padding: 11px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--canvas);
+}
+
+.relay-profile label {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.relay-profile label > span {
+  color: var(--ink);
+  font-size: 10.5px;
+  font-weight: 640;
+}
+
+.relay-profile label > small {
+  color: var(--faint);
+  font-size: 9px;
+  line-height: 1.45;
+}
+
+.relay-profile input,
+.relay-profile select,
+.relay-profile textarea {
+  padding: 6px 8px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--ink);
+  font: inherit;
+  font-size: 11px;
+}
+
+.relay-profile textarea {
+  resize: vertical;
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 10px;
+}
+
+.relay-profile-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.relay-profile-actions button {
+  padding: 5px 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--ink);
+  cursor: pointer;
+  font-size: 10.5px;
+}
+
+.relay-profile-actions button:hover:not(:disabled) {
+  border-color: var(--blue);
+  color: var(--blue);
+}
+
+.relay-profile-actions button:disabled {
+  cursor: default;
+  opacity: .55;
+}
+
+.relay-models {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.relay-label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.relay-label-row > span {
+  color: var(--ink);
+  font-size: 10.5px;
+  font-weight: 640;
+}
+
+.relay-fetch {
+  padding: 2px 8px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: var(--surface);
+  color: var(--blue);
+  cursor: pointer;
+  font-size: 9.5px;
+}
+
+.relay-fetch:hover:not(:disabled) {
+  border-color: var(--blue);
+}
+
+.relay-fetch:disabled {
+  cursor: default;
+  opacity: .55;
+}

--- a/extensions/dsh-browser/tests/panel-session-transition.spec.ts
+++ b/extensions/dsh-browser/tests/panel-session-transition.spec.ts
@@ -88,10 +88,10 @@ describe('panel session transitions', () => {
     const originalSessionTitle = sessionMenu.textContent
     await act(async () => { sessionMenu.click() })
     await vi.waitFor(() => {
-      expect(document.querySelectorAll('.session-list button')).toHaveLength(2)
+      expect(document.querySelectorAll('.session-list li > button:not(.session-delete)')).toHaveLength(2)
     })
 
-    const savedSession = document.querySelectorAll<HTMLButtonElement>('.session-list button')[1]
+    const savedSession = document.querySelectorAll<HTMLButtonElement>('.session-list li > button:not(.session-delete)')[1]
     await act(async () => { savedSession.click() })
     await vi.waitFor(() => {
       expect(document.querySelector('.error')?.textContent).toBe('runtime port unavailable')

--- a/packages/browser/bridge-browser/src/index.ts
+++ b/packages/browser/bridge-browser/src/index.ts
@@ -39,6 +39,7 @@ import {
 } from './protocol.ts'
 import { withSessionDeferral } from './session-deferral.ts'
 import { withSessionWorkspace } from './session-workspace.ts'
+import { purgeSessionFiles, type SessionPurgeDeps } from './session-purge.ts'
 import { resolveToken } from './token.ts'
 
 /** Cordis plugin name used by loader diagnostics. */
@@ -55,6 +56,9 @@ const DEFAULT_MAX_INTERACTIVE_ITEMS = 60
 
 /** Default directory backing the browser extension's session group. */
 const DEFAULT_SESSION_WORKSPACE_PATH = dshHomePath('browser-sessions')
+
+/** Durable session storage root written by the JSONL persistence plugin. */
+const SESSIONS_ROOT = dshHomePath('sessions')
 
 /** Default: sessions materialize only on the first message (open-and-close leaves no trace). */
 const DEFAULT_DEFER_SESSION_CREATE = true
@@ -141,6 +145,24 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
   )
   const browserContext = new BrowserContextInjector(ctx.agents)
   ctx.on('agent/session-start', ({ agent }) => { browserContext.activate(agent) })
+
+  const purgeSession = async (sessionId: string): Promise<void> => {
+    const runningSessionIds = new Set<string>()
+    try {
+      const listed = await api.sessions.list({ rpcId: RpcId(randomUUID()), payload: {} })
+      if (listed.result.ok) {
+        for (const entry of listed.result.value.items) {
+          if (entry.running) runningSessionIds.add(entry.sessionId)
+        }
+      }
+    } catch {
+      // Guard is best-effort: an unavailable listing must not block deletion,
+      // because the panel already refuses running rows and archives first.
+    }
+    const deps: SessionPurgeDeps = { sessionsRoot: SESSIONS_ROOT, runningSessionIds }
+    await purgeSessionFiles(deps, sessionId)
+  }
+
   const server = new BridgeServer({
     token: tokenRes.token,
     apiHandler: toFetchHandler(api),
@@ -152,6 +174,7 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
       maxInteractiveItems: resolved.maxInteractiveItems,
     },
     injectBrowserSnapshot: (sessionId, snapshot) => { browserContext.inject(sessionId, snapshot) },
+    purgeSession,
   })
 
   const route: WebUpgradeRoute = {

--- a/packages/browser/bridge-browser/src/protocol.ts
+++ b/packages/browser/bridge-browser/src/protocol.ts
@@ -21,6 +21,9 @@ export const BRIDGE_CONFIG_PATH = '/ext/bridge-config'
 /** Internal RPC used after an explicit tab handoff to seed the Agent's next step. */
 export const BRIDGE_INJECT_BROWSER_SNAPSHOT_METHOD = 'bridge.injectBrowserSnapshot'
 
+/** Internal RPC used by the panel to permanently delete one session's durable storage. */
+export const BRIDGE_SESSION_PURGE_METHOD = 'bridge.session.purge'
+
 /** Seconds a fresh socket may take to present `hello` before it is closed. */
 export const HELLO_TIMEOUT_MS = 5_000
 

--- a/packages/browser/bridge-browser/src/server.ts
+++ b/packages/browser/bridge-browser/src/server.ts
@@ -26,6 +26,7 @@ import { WebSocket, WebSocketServer } from 'ws'
 import type { MuxFrame, RpcRequest } from '@deepseek-ai/dsh-host-apiproxy/api'
 import {
   BRIDGE_INJECT_BROWSER_SNAPSHOT_METHOD,
+  BRIDGE_SESSION_PURGE_METHOD,
   HELLO_TIMEOUT_MS,
   PING_INTERVAL_MS,
   parseBridgeFrame,
@@ -34,6 +35,7 @@ import {
   type ClientFrame,
   type ToolErrorCode,
 } from './protocol.ts'
+import { SessionPurgeError } from './session-purge.ts'
 import { verifyToken } from './token.ts'
 
 /**
@@ -92,6 +94,11 @@ export interface BridgeServerDeps {
   caps: BridgeCaps
   /** Seed a followed-page snapshot into a live or deferred Agent session. */
   injectBrowserSnapshot: (sessionId: string, snapshot: string) => void | Promise<void>
+  /**
+   * Permanently delete one session's durable storage. Callers archive the
+   * session through the gateway first; this only removes files.
+   */
+  purgeSession: (sessionId: string) => Promise<void>
   /**
    * Test seam: force the remote address seen by the privilege gate. The
    * sandbox cannot bind arbitrary loopback literals, so the non-loopback
@@ -432,6 +439,27 @@ export class BridgeServer {
       }
       return
     }
+    if (frame.method === BRIDGE_SESSION_PURGE_METHOD) {
+      const sessionId = purgeSessionPayload(frame.payload)
+      if (sessionId === undefined) {
+        sendFrame(conn.ws, {
+          t: 'rpc.result',
+          id: frame.id,
+          ok: false,
+          error: { code: 'bad-request', message: 'sessionId must be a non-empty string' },
+        })
+        return
+      }
+      try {
+        await this.deps.purgeSession(sessionId)
+        sendFrame(conn.ws, { t: 'rpc.result', id: frame.id, ok: true, result: { purged: true } })
+      } catch (error: unknown) {
+        const code = error instanceof SessionPurgeError ? error.code : 'internal'
+        const message = error instanceof Error ? error.message : String(error)
+        sendFrame(conn.ws, { t: 'rpc.result', id: frame.id, ok: false, error: { code, message } })
+      }
+      return
+    }
     const body = JSON.stringify({ type: 'client-request', rpcId: frame.id, method: frame.method, payload: frame.payload })
     const request = new Request(new URL(`/api/${frame.method}`, 'http://dsh.internal'), {
       method: 'POST',
@@ -519,6 +547,13 @@ function browserSnapshotPayload(payload: unknown): { sessionId: string; snapshot
   if (typeof sessionId !== 'string' || sessionId.trim() === '') return undefined
   if (typeof snapshot !== 'string' || snapshot.trim() === '') return undefined
   return { sessionId, snapshot }
+}
+
+function purgeSessionPayload(payload: unknown): string | undefined {
+  if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) return undefined
+  const { sessionId } = payload as Record<string, unknown>
+  if (typeof sessionId !== 'string' || sessionId.trim() === '') return undefined
+  return sessionId
 }
 
 function orderedSessionId(frame: Extract<ClientFrame, { t: 'rpc' }>): string | undefined {

--- a/packages/browser/bridge-browser/src/session-purge.ts
+++ b/packages/browser/bridge-browser/src/session-purge.ts
@@ -1,0 +1,102 @@
+/**
+ * File-level removal of one session's durable storage under the dsh home.
+ *
+ * The gateway exposes no session.delete, so the bridge performs the removal
+ * itself: archive first (index update via `workspace.archiveSession`, done by
+ * the caller), then this module deletes the session directories. Strictly
+ * defensive: session ids are validated against the persisted shape, only
+ * exact-name directories two levels below the sessions root are removed, and
+ * running sessions are refused before anything touches the disk.
+ *
+ * @module @yuxianglin/dsh-bridge-browser/src/session-purge
+ */
+
+import { readdir, rm } from 'node:fs/promises'
+import path from 'node:path'
+
+/** Stable failure codes surfaced to the panel. Open set: callers must tolerate growth. */
+export type SessionPurgeErrorCode = 'not-found' | 'running' | 'invalid-id' | 'internal'
+
+/** Error thrown by {@link purgeSessionFiles}; the server turns it into a wire error. */
+export class SessionPurgeError extends Error {
+  constructor(
+    readonly code: SessionPurgeErrorCode,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'SessionPurgeError'
+  }
+}
+
+/** Persisted session ids are `session-` plus one lowercase UUID. */
+const SESSION_ID_PATTERN = /^session-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u
+
+/** Dependencies purging needs from the plugin. */
+export interface SessionPurgeDeps {
+  /** The dsh sessions root (`dshHomePath('sessions')`). */
+  sessionsRoot: string
+  /** Session ids currently running; purging any of these is refused. */
+  runningSessionIds: ReadonlySet<string>
+}
+
+/**
+ * Validate one session id against the persisted shape. Rejects everything
+ * that could escape the sessions root (separators, dot segments) before any
+ * filesystem call sees it.
+ * @param sessionId - untrusted id from the panel.
+ * @returns the id when well-formed.
+ * @throws SessionPurgeError with code `invalid-id` otherwise.
+ */
+export function assertPurgeableSessionId(sessionId: string): string {
+  if (!SESSION_ID_PATTERN.test(sessionId)) {
+    throw new SessionPurgeError('invalid-id', `session id "${sessionId}" does not match the persisted shape`)
+  }
+  return sessionId
+}
+
+/**
+ * Permanently delete every durable directory of one session. Idempotent over
+ * multiple workspaces: each workspace directory may hold its own copy of the
+ * session, and all of them are removed.
+ * @param deps - root and running-set inputs.
+ * @param sessionId - validated session id.
+ * @returns nothing; throws {@link SessionPurgeError} on refusal or failure.
+ */
+export async function purgeSessionFiles(deps: SessionPurgeDeps, sessionId: string): Promise<void> {
+  assertPurgeableSessionId(sessionId)
+  if (deps.runningSessionIds.has(sessionId)) {
+    throw new SessionPurgeError('running', 'refusing to purge a running session; cancel it first')
+  }
+
+  let workspaces: string[]
+  try {
+    workspaces = await readdir(deps.sessionsRoot, { withFileTypes: true })
+      .then((entries) => entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name))
+  } catch (error: unknown) {
+    throw new SessionPurgeError('internal', `could not read the sessions root "${deps.sessionsRoot}": ${String(error)}`)
+  }
+
+  const targets: string[] = []
+  for (const workspace of workspaces) {
+    // path.join is safe here: the id pattern above excludes separators and
+    // dot segments, so the joined segment cannot escape the workspace dir.
+    const candidate = path.join(deps.sessionsRoot, workspace, sessionId)
+    try {
+      await readdir(candidate)
+      targets.push(candidate)
+    } catch {
+      // Absent in this workspace: nothing to remove there.
+    }
+  }
+
+  if (targets.length === 0) {
+    throw new SessionPurgeError('not-found', `no durable storage found for session "${sessionId}"`)
+  }
+  for (const target of targets) {
+    try {
+      await rm(target, { recursive: true, force: true })
+    } catch (error: unknown) {
+      throw new SessionPurgeError('internal', `could not remove "${target}": ${String(error)}`)
+    }
+  }
+}

--- a/packages/browser/bridge-browser/tests/server.spec.ts
+++ b/packages/browser/bridge-browser/tests/server.spec.ts
@@ -5,7 +5,8 @@ import WebSocket from 'ws'
 import type { MuxFrame, RpcRequest } from '@deepseek-ai/dsh-host-apiproxy/api'
 import { RpcId } from '@deepseek-ai/dsh-host-apiproxy/api'
 import { BridgeServer, BridgeToolError, isLoopbackAddress, messageToText, payloadCode, payloadMessage } from '../src/server.ts'
-import { BRIDGE_INJECT_BROWSER_SNAPSHOT_METHOD, type BridgeFrame } from '../src/protocol.ts'
+import { BRIDGE_INJECT_BROWSER_SNAPSHOT_METHOD, BRIDGE_SESSION_PURGE_METHOD, type BridgeFrame } from '../src/protocol.ts'
+import { SessionPurgeError } from '../src/session-purge.ts'
 
 const TOKEN = 'deadbeefdeadbeefdeadbeefdeadbeef'
 
@@ -41,6 +42,7 @@ async function startBridge(overrides: Partial<ConstructorParameters<typeof Bridg
     toolTimeoutMs: 1_000,
     caps: { textOnly: true, snapshotMaxChars: 12_000, maxInteractiveItems: 60 },
     injectBrowserSnapshot: vi.fn(),
+    purgeSession: vi.fn(async () => {}),
     ...overrides,
   })
   const server = createServer()
@@ -254,6 +256,59 @@ describe('BridgeServer', () => {
       t: 'rpc.result', id: 'snapshot-invalid', ok: false, error: expect.objectContaining({ code: 'bad-request' }),
     }))
     ws.close()
+  })
+
+  it('purges sessions through the internal RPC without forwarding it to the gateway', async () => {
+    const purgeSession = vi.fn(async () => {})
+    const h = await startBridge({ purgeSession })
+    harnesses.push(h)
+    const { ws, frames } = await connect(h.url)
+    send(ws, { t: 'hello', token: TOKEN, caps: CAPS })
+    await waitFor(() => frames.some((frame) => frame.t === 'hello.ok'))
+
+    send(ws, {
+      t: 'rpc',
+      id: 'purge-1',
+      method: BRIDGE_SESSION_PURGE_METHOD,
+      payload: { sessionId: 'session-82222a77-aab5-4c0b-b33e-6376973ec93d' },
+    })
+    await waitFor(() => frames.some((frame) => frame.t === 'rpc.result' && frame.id === 'purge-1'))
+
+    expect(purgeSession).toHaveBeenCalledWith('session-82222a77-aab5-4c0b-b33e-6376973ec93d')
+    expect(h.fetchMock).not.toHaveBeenCalled()
+    expect(frames).toContainEqual({
+      t: 'rpc.result', id: 'purge-1', ok: true, result: { purged: true },
+    })
+
+    send(ws, {
+      t: 'rpc',
+      id: 'purge-invalid',
+      method: BRIDGE_SESSION_PURGE_METHOD,
+      payload: { sessionId: '' },
+    })
+    await waitFor(() => frames.some((frame) => frame.t === 'rpc.result' && frame.id === 'purge-invalid'))
+    expect(frames).toContainEqual(expect.objectContaining({
+      t: 'rpc.result', id: 'purge-invalid', ok: false, error: expect.objectContaining({ code: 'bad-request' }),
+    }))
+
+    const failing = vi.fn(async () => { throw new SessionPurgeError('running', 'cancel it first') })
+    const failureBridge = await startBridge({ purgeSession: failing })
+    harnesses.push(failureBridge)
+    const failure = await connect(failureBridge.url)
+    send(failure.ws, { t: 'hello', token: TOKEN, caps: CAPS })
+    await waitFor(() => failure.frames.some((frame) => frame.t === 'hello.ok'))
+    send(failure.ws, {
+      t: 'rpc',
+      id: 'purge-running',
+      method: BRIDGE_SESSION_PURGE_METHOD,
+      payload: { sessionId: 'session-82222a77-aab5-4c0b-b33e-6376973ec93d' },
+    })
+    await waitFor(() => failure.frames.some((frame) => frame.t === 'rpc.result' && frame.id === 'purge-running'))
+    expect(failure.frames).toContainEqual(expect.objectContaining({
+      t: 'rpc.result', id: 'purge-running', ok: false, error: { code: 'running', message: 'cancel it first' },
+    }))
+    ws.close()
+    failure.ws.close()
   })
 
   it('finishes snapshot injection before forwarding a prompt for the same session', async () => {

--- a/packages/browser/bridge-browser/tests/session-purge.spec.ts
+++ b/packages/browser/bridge-browser/tests/session-purge.spec.ts
@@ -1,0 +1,88 @@
+import { mkdtemp, mkdir, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { SessionPurgeError, assertPurgeableSessionId, purgeSessionFiles } from '../src/session-purge.ts'
+
+const SESSION_A = 'session-82222a77-aab5-4c0b-b33e-6376973ec93d'
+const SESSION_B = 'session-92bad0de-136e-4d1f-a308-d1f5388d608f'
+
+const tempRoots: string[] = []
+
+afterEach(async () => {
+  for (const root of tempRoots.splice(0)) {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+async function makeSessionsRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), 'dsh-session-purge-'))
+  tempRoots.push(root)
+  return root
+}
+
+async function makeSession(root: string, workspace: string, sessionId: string): Promise<string> {
+  const dir = path.join(root, workspace, sessionId)
+  await mkdir(dir, { recursive: true })
+  await writeFile(path.join(dir, 'session.jsonl.zstd'), 'x')
+  return dir
+}
+
+describe('assertPurgeableSessionId', () => {
+  it('accepts the persisted session-id shape', () => {
+    expect(assertPurgeableSessionId(SESSION_A)).toBe(SESSION_A)
+  })
+
+  it.each([
+    ['../escape'],
+    ['workspace/../../escape'],
+    ['not-a-uuid'],
+    ['session-82222a77'],
+    [''],
+  ])('rejects %j', (sessionId) => {
+    expect(() => assertPurgeableSessionId(sessionId)).toThrow(SessionPurgeError)
+    try {
+      assertPurgeableSessionId(sessionId)
+    } catch (error) {
+      expect((error as SessionPurgeError).code).toBe('invalid-id')
+    }
+  })
+})
+
+describe('purgeSessionFiles', () => {
+  it('removes the session directory in every workspace and keeps siblings', async () => {
+    const root = await makeSessionsRoot()
+    const targetA = await makeSession(root, '--Users-apple-browser-sessions--', SESSION_A)
+    const targetB = await makeSession(root, '--other-workspace--', SESSION_A)
+    const sibling = await makeSession(root, '--Users-apple-browser-sessions--', SESSION_B)
+
+    await purgeSessionFiles({ sessionsRoot: root, runningSessionIds: new Set() }, SESSION_A)
+
+    await expect(stat(targetA)).rejects.toThrow()
+    await expect(stat(targetB)).rejects.toThrow()
+    await expect(stat(sibling)).resolves.toBeTruthy()
+  })
+
+  it('refuses running sessions before touching the disk', async () => {
+    const root = await makeSessionsRoot()
+    const target = await makeSession(root, 'ws', SESSION_A)
+
+    await expect(purgeSessionFiles(
+      { sessionsRoot: root, runningSessionIds: new Set([SESSION_A]) },
+      SESSION_A,
+    )).rejects.toMatchObject({ code: 'running' })
+    await expect(stat(target)).resolves.toBeTruthy()
+  })
+
+  it('reports not-found when no durable directory matches', async () => {
+    const root = await makeSessionsRoot()
+    await expect(purgeSessionFiles({ sessionsRoot: root, runningSessionIds: new Set() }, SESSION_A))
+      .rejects.toMatchObject({ code: 'not-found' })
+  })
+
+  it('rejects ids that do not match the persisted shape', async () => {
+    const root = await makeSessionsRoot()
+    await expect(purgeSessionFiles({ sessionsRoot: root, runningSessionIds: new Set() }, '../escape'))
+      .rejects.toMatchObject({ code: 'invalid-id' })
+  })
+})


### PR DESCRIPTION
## 概述 / Summary

为浏览器扩展增加两个能力：**在侧栏选择器中删除历史会话**，以及**在设置页配置自定义 API 中转（base URL + token），支持 Claude / OpenAI / Codex 三种接口格式**。/ Add two capabilities to the side panel: deleting past sessions from the picker, and configuring custom API relays (base URL + token) with Claude / OpenAI / Codex wire formats.

## 动机 / Motivation

- 网关没有 `session.delete`，历史会话无法清理，越积越多。
- 很多用户通过自建或第三方中转站访问模型，但面板只能使用部署时固定的提供方；`llm-pi-ai` 适配器本身已支持任意路由（含 `anthropic-messages`、`openai-codex-responses`），只差一个配置界面。

- The gateway exposes no way to remove old sessions, so durable storage grows forever.
- Many users reach models through relays, but the panel is locked to the composed provider even though the `llm-pi-ai` adapter already supports arbitrary routes — only a UI is missing.

## 改动内容 / Changes

- **会话删除**：桥接插件新增内部 RPC `bridge.session.purge`（协议常量 → server 拦截 → 依赖注入 `purgeSessionFiles`）。删除流程 = 先走官方 `workspace.archiveSession` 更新索引，再文件级清理；严格校验持久化 ID 形态（防路径穿越）、拒绝运行中的会话、跨工作区幂等清理。面板每行新增删除按钮，运行中行隐藏；当前会话被删后自动切换新会话。
- **中转配置**：设置页新增「模型与中转」区块，档案名自由填写（CJK 自动派生安全路由键），写入 `llm-pi-ai` settings 命名空间（热生效）、Token 存入凭据库。获取模型列表：OpenAI 系直接列出并自动补 `/v1`；Claude 协议按上游设计无列表接口，自动回退到站点的 OpenAI 兼容端点拉取（同一 Token 通用）。勾选「设为默认模型」会同时写 `agent-default-model` 并通过 `session.selectModel` 让**当前会话立即切换**。
- **Session deletion**: new internal bridge RPC `bridge.session.purge` (protocol constant → server intercept → injected `purgeSessionFiles`). The panel archives via `workspace.archiveSession` first (index), then purges files; strict persisted-id validation (path-traversal safe), running sessions refused, idempotent across workspaces.
- **Relay profiles**: a settings section edits free-form-named routes into the `llm-pi-ai` namespace (hot reload) with tokens in the credential store. Model listing auto-appends `/v1` on failure and falls back to the relay's OpenAI-compatible endpoint for Claude profiles. "Set as default" writes `agent-default-model` **and** pushes `session.selectModel` so the active session switches immediately.

## 测试 / Testing

- `pnpm run typecheck`：bridge + extension 均 0 错误
- `pnpm run test`：327 通过（bridge 111，其中 11 个为本次新增：ID 校验 / 运行中拒绝 / 跨工作区清理 / RPC 拦截与错误码透传）
- 端到端实测（macOS + Chrome，本地 dsh web 0.1.1-rc.1）：
  - WebSocket 直连桥接发送非法 ID → `invalid-id`
  - 真实会话 归档→清除 → `{"purged":true}`，磁盘目录确认消失
  - 本地 mock 中转站 → 发现请求携带 Bearer 且正确解析模型列表
  - 真实 Anthropic 格式中转站新建会话对话 → 收到完整回复（anthropic-messages 回放状态正常）

- `pnpm run typecheck`: clean for both packages
- `pnpm run test`: 327 passing (111 bridge incl. 11 new)
- E2E on macOS + Chrome: invalid-id rejection, real archive→purge removes files from disk, mock relay listing returns models with bearer auth, and a live anthropic-messages relay completed a full conversation turn.

## 影响范围 / Impact

- Chrome / Edge（MV3 托管安装与源码构建均适用）；Firefox 未单独实测，但改动不触碰 Firefox 特有路径。
- 新 RPC 仅限已认证的桥接通道，特权方法回环限制不变；凭据只进凭据库，不落配置明文。
- Chrome / Edge managed and checkout installs; Firefox untouched paths. New RPC stays inside the authenticated bridge; privileged-method loopback fence unchanged; tokens go to the credential store only.

## Checklist

- [x] 已在相关平台实测通过 / Tested on the relevant platforms (macOS + Chrome)
- [x] 已通过 `pnpm run build` 等基础检查 / Passed basic checks
- [ ] 文档已同步更新（如需要）/ Docs updated if needed
- [x] 不包含无关改动 / No unrelated changes included




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds permanent session cleanup through a bridge-local RPC and introduces side-panel management of custom Claude, OpenAI, and Codex relay profiles.
- Archives sessions before deleting their durable directories and filters archived sessions from the picker.
- Adds relay profile discovery, credential storage, provider configuration, and default-model selection.
- Extends localized panel copy, styling, and bridge/session tests.

<h3>Confidence Score: 3/5</h3>

The PR does not appear safe to merge until active-session deletion fails closed and failed relay-profile removals restore or reload the editor state.

Session purge still proceeds with an empty or stale running-session snapshot and can remove active durable state, while a failed relay removal still hides a profile that remains persisted and leaves no in-place retry path.

**Files Needing Attention:** packages/browser/bridge-browser/src/index.ts, packages/browser/bridge-browser/src/session-purge.ts, extensions/dsh-browser/src/panel/App.tsx

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| extensions/dsh-browser/src/panel/App.tsx | Adds archived-session filtering, session deletion controls, and relay-profile configuration, discovery, persistence, and default-model selection. |
| packages/browser/bridge-browser/src/index.ts | Wires the bridge-local session purge operation to host session state and durable storage. |
| packages/browser/bridge-browser/src/server.ts | Intercepts the new authenticated session-purge RPC and maps purge failures into structured responses. |
| packages/browser/bridge-browser/src/session-purge.ts | Validates persisted session identifiers and removes matching session directories across workspaces. |
| packages/browser/bridge-browser/src/protocol.ts | Defines the shared bridge session-purge method name. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as User
  participant P as Side panel
  participant G as Gateway
  participant B as Bridge
  participant F as Session storage
  U->>P: Delete session
  P->>G: workspace.archiveSession
  G-->>P: Archived
  P->>B: bridge.session.purge
  B->>G: sessions.list
  G-->>B: Session snapshot
  B->>F: Remove matching session directories
  F-->>B: Purge result
  B-->>P: rpc.result
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(panel): exclude archived sessions fr..."](https://github.com/lum1104/dsh-browser/commit/d19fc652ea46f535c15e915e057f499e2ca75af7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56215033)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Browser bridge library](https://app.greptile.com/yuxiang-lin/-/custom-context/knowledge-base/lum1104/dsh-browser/-/docs/browser-bridge-library.md)
- Knowledge Base — [Bridge protocol and server lifecycle](https://app.greptile.com/yuxiang-lin/-/custom-context/knowledge-base/lum1104/dsh-browser/-/docs/bridge-protocol-and-server.md)
- Knowledge Base — [Extension panel experience](https://app.greptile.com/yuxiang-lin/-/custom-context/knowledge-base/lum1104/dsh-browser/-/docs/extension-panel-experience.md)
- Knowledge Base — [Panel conversation and sessions](https://app.greptile.com/yuxiang-lin/-/custom-context/knowledge-base/lum1104/dsh-browser/-/docs/panel-conversation-and-sessions.md)
</details>


<!-- /greptile_comment -->