### PR TITLE
feat: allow creating new session and switching sessions while agent is working (with per-session tab affinity)

### DIFF
--- a/extensions/dsh-browser/src/background/approval-coordinator.ts
+++ b/extensions/dsh-browser/src/background/approval-coordinator.ts
@@ -63,8 +63,12 @@ export class ApprovalCoordinator {
     this.settle(id, { status: 'decision', decision })
   }
 
-  cancelAll(): void {
-    for (const id of [...this.pending.keys()]) this.settle(id, { status: 'cancelled' })
+  cancelAll(sessionId?: string): void {
+    for (const [id, pending] of [...this.pending.entries()]) {
+      if (sessionId === undefined || pending.request.sessionId === sessionId) {
+        this.settle(id, { status: 'cancelled' })
+      }
+    }
   }
 
   /** Re-send every live request after a panel has installed its listeners. */

--- a/extensions/dsh-browser/src/background/index.ts
+++ b/extensions/dsh-browser/src/background/index.ts
@@ -585,14 +585,14 @@ async function restoreTabAffinity(): Promise<void> {
 const affinityReady = restoreTabAffinity()
 
 /** Bind at prompt submission so a switch while the model is thinking is visible. */
-async function ensureInitialTabBinding(): Promise<boolean> {
+async function ensureInitialTabBinding(sessionId?: string): Promise<boolean> {
   await affinityReady
-  if (tabAffinity.resolveTarget().kind !== 'initial') return true
+  if (tabAffinity.resolveTarget(sessionId).kind !== 'initial') return true
   try {
     const tab = await syncActiveTab()
     const summary = tab === undefined ? null : summarizeTab(tab)
     if (summary === null) return false
-    if (tabAffinity.bindInitial(summary)) {
+    if (tabAffinity.bindInitial(summary, sessionId)) {
       persistTabAffinity()
       broadcastTabAffinity()
     }
@@ -619,14 +619,14 @@ function affinityFailure(kind: 'handoff' | 'lost' | 'missing'): ToolAnswer {
 }
 
 /** Resolve one stable tab target without allowing a manual switch to drift it. */
-async function resolveToolTab(): Promise<Pick<chrome.tabs.Tab, 'id' | 'url' | 'windowId'> | ToolAnswer> {
+async function resolveToolTab(sessionId?: string): Promise<Pick<chrome.tabs.Tab, 'id' | 'url' | 'windowId'> | ToolAnswer> {
   await affinityReady
   for (let attempt = 0; attempt < 3; attempt += 1) {
-    const resolution = tabAffinity.resolveTarget()
+    const resolution = tabAffinity.resolveTarget(sessionId)
     if (resolution.kind === 'handoff') return affinityFailure('handoff')
     if (resolution.kind === 'lost') return affinityFailure('lost')
     if (resolution.kind === 'initial') {
-      if (!await ensureInitialTabBinding()) return affinityFailure('missing')
+      if (!await ensureInitialTabBinding(sessionId)) return affinityFailure('missing')
       continue
     }
     try {
@@ -634,7 +634,7 @@ async function resolveToolTab(): Promise<Pick<chrome.tabs.Tab, 'id' | 'url' | 'w
       const summary = summarizeTab(tab)
       if (summary === null) return affinityFailure('missing')
       if (tabAffinity.observeTab(summary)) broadcastTabAffinity()
-      const current = tabAffinity.resolveTarget()
+      const current = tabAffinity.resolveTarget(sessionId)
       if (current.kind === 'handoff') return affinityFailure('handoff')
       if (current.kind === 'lost') return affinityFailure('lost')
       if (current.kind === 'target' && current.tab.tabId === summary.tabId) return tab
@@ -692,7 +692,7 @@ async function refreshFollowedPage(sessionId: string, tabId: number): Promise<vo
   const controller = new AbortController()
   activeFollowRefresh = controller
   try {
-    const target = await resolveToolTab()
+    const target = await resolveToolTab(sessionId)
     if ('ok' in target || target.id !== tabId || controller.signal.aborted) return
     const budget = caps === null
       ? undefined
@@ -704,9 +704,9 @@ async function refreshFollowedPage(sessionId: string, tabId: number): Promise<vo
       (prompt) => authorizeToolCall(prompt, controller.signal, target.windowId, sessionId),
       controller.signal,
       target,
-      () => target.id !== undefined && tabAffinity.allowsTarget(target.id),
+      () => target.id !== undefined && tabAffinity.allowsTarget(target.id, sessionId),
     )
-    if (!answer.ok || controller.signal.aborted || !tabAffinity.allowsTarget(tabId)) return
+    if (!answer.ok || controller.signal.aborted || !tabAffinity.allowsTarget(tabId, sessionId)) return
     if (typeof answer.result !== 'object' || answer.result === null) return
     const snapshot = (answer.result as { text?: unknown }).text
     if (typeof snapshot !== 'string' || snapshot.trim() === '') return
@@ -718,8 +718,8 @@ async function refreshFollowedPage(sessionId: string, tabId: number): Promise<vo
 
 async function refreshSessionSnapshot(sessionId: string): Promise<void> {
   await affinityReady
-  await ensureInitialTabBinding()
-  const target = await resolveToolTab()
+  await ensureInitialTabBinding(sessionId)
+  const target = await resolveToolTab(sessionId)
   if (!('ok' in target) && target.id !== undefined) {
     await refreshFollowedPage(sessionId, target.id)
   }
@@ -732,7 +732,8 @@ async function resolveTabAffinityResponse(response: {
 }): Promise<void> {
   await affinityReady
   await syncActiveTab()
-  const accepted = tabAffinity.decide(response.decision, response.revision)
+  const sid = typeof response.sessionId === 'string' ? response.sessionId : undefined
+  const accepted = tabAffinity.decide(response.decision, response.revision, sid)
   const controlled = accepted && response.decision === 'follow'
     ? tabAffinity.snapshot().controlled
     : null
@@ -745,7 +746,7 @@ async function resolveTabAffinityResponse(response: {
 }
 
 /** Move browser control to the current tab only after a fresh, valid query. */
-async function rebindTabAffinityToActive(signal: AbortSignal): Promise<void> {
+async function rebindTabAffinityToActive(signal: AbortSignal, sessionId?: string): Promise<void> {
   await abortable(affinityReady, signal)
   const tab = await syncActiveTab(undefined, signal)
   throwIfRebindAborted(signal)
@@ -758,9 +759,8 @@ async function rebindTabAffinityToActive(signal: AbortSignal): Promise<void> {
 
   const previousControlledTabId = tabAffinity.snapshot().controlled?.tabId
   activeFollowRefresh?.abort()
-  cancelAllToolCalls()
   cancelPendingApprovals()
-  tabAffinity.rebindActive(summary)
+  tabAffinity.rebindActive(summary, sessionId)
   if (previousControlledTabId !== undefined && previousControlledTabId !== summary.tabId) {
     resetTabSnapshot(previousControlledTabId)
   }
@@ -802,7 +802,7 @@ function routeToolCall(call: ToolCall): void {
   const budget = caps === null
     ? undefined
     : { maxItems: caps.maxInteractiveItems, maxChars: caps.snapshotMaxChars }
-  void resolveToolTab().then((target) => 'ok' in target
+  void resolveToolTab(call.sessionId).then((target) => 'ok' in target
     ? target
     : dispatchToolCall(
         call,
@@ -811,10 +811,18 @@ function routeToolCall(call: ToolCall): void {
         (prompt) => authorizeToolCall(prompt, controller.signal, target.windowId, call.sessionId),
         controller.signal,
         target,
-        () => target.id !== undefined && tabAffinity.allowsTarget(target.id),
+        () => target.id !== undefined && tabAffinity.allowsTarget(target.id, call.sessionId),
       )).then(
     (answer) => {
-      if (controller.signal.aborted) return
+      if (controller.signal.aborted) {
+        bridge?.send({
+          t: 'tool.result',
+          id: call.id,
+          ok: false,
+          error: { code: 'cancelled', message: 'Tool call was cancelled' },
+        })
+        return
+      }
       const socket = bridge
       if (socket === null) return
       if (answer.ok) {
@@ -824,7 +832,15 @@ function routeToolCall(call: ToolCall): void {
       }
     },
     (error: unknown) => {
-      if (controller.signal.aborted) return
+      if (controller.signal.aborted) {
+        bridge?.send({
+          t: 'tool.result',
+          id: call.id,
+          ok: false,
+          error: { code: 'cancelled', message: 'Tool call was cancelled' },
+        })
+        return
+      }
       bridge?.send({
         t: 'tool.result',
         id: call.id,
@@ -968,8 +984,11 @@ chrome.runtime.onConnect.addListener((port) => {
       case 'rpc': {
         const rpcMsg = message as { id: string; method: string; payload?: unknown }
         const refresh = followedPageRefresh
+        const rpcSessionId = typeof rpcMsg.payload === 'object' && rpcMsg.payload !== null
+          ? (rpcMsg.payload as { sessionId?: string }).sessionId
+          : undefined
         const prepare = rpcMsg.method === 'session.prompt'
-          ? ensureInitialTabBinding().then(async (bound) => {
+          ? ensureInitialTabBinding(rpcSessionId).then(async (bound) => {
               await refresh
               return bound
             })
@@ -1069,11 +1088,17 @@ chrome.runtime.onConnect.addListener((port) => {
       case 'session.active': {
         const session = message as { sessionId?: unknown; isNew?: boolean }
         recentSession.remember(session.sessionId)
-        if (session.isNew === true && typeof session.sessionId === 'string' && session.sessionId.trim() !== '') {
+        if (typeof session.sessionId === 'string' && session.sessionId.trim() !== '') {
           const sid = session.sessionId
-          const refresh = refreshSessionSnapshot(sid).catch(() => {})
-          followedPageRefresh = refresh
-          void refresh
+          if (tabAffinity.focusSession(sid)) {
+            persistTabAffinity()
+            broadcastTabAffinity()
+          }
+          if (session.isNew === true) {
+            const refresh = refreshSessionSnapshot(sid).catch(() => {})
+            followedPageRefresh = refresh
+            void refresh
+          }
         }
         break
       }
@@ -1098,9 +1123,10 @@ chrome.runtime.onConnect.addListener((port) => {
         break
       }
       case 'tab-affinity.rebind': {
-        const request = message as { id?: unknown }
+        const request = message as { id?: unknown; sessionId?: unknown }
         if (typeof request.id !== 'string') break
         const requestId = request.id
+        const rebindSessionId = typeof request.sessionId === 'string' ? request.sessionId : undefined
         if (tabAffinityRebinds.has(requestId)) break
         const controller = new AbortController()
         const timer = setTimeout(() => {
@@ -1109,7 +1135,7 @@ chrome.runtime.onConnect.addListener((port) => {
             : 'Binding the current tab timed out. Try again.'))
         }, TAB_AFFINITY_REBIND_TIMEOUT_MS)
         tabAffinityRebinds.set(requestId, { controller, timer })
-        void rebindTabAffinityToActive(controller.signal).then(
+        void rebindTabAffinityToActive(controller.signal, rebindSessionId).then(
           () => {
             try { port.postMessage({ type: 'tab-affinity.rebind.result', id: requestId, ok: true }) } catch { /* port closed */ }
           },

--- a/extensions/dsh-browser/src/background/index.ts
+++ b/extensions/dsh-browser/src/background/index.ts
@@ -138,8 +138,8 @@ const STORAGE_KEY = 'dshSettings'
 const TAB_AFFINITY_STORAGE_KEY = 'dshTabAffinity'
 
 type StoredTabAffinity =
-  | { controlledTabId: number; keptActiveTabId?: number }
-  | { lost: true }
+  | { controlledTabId: number; keptActiveTabId?: number; sessionTabs?: Record<string, AffinityTab>; focusedSessionId?: string }
+  | { lost: true; sessionTabs?: Record<string, AffinityTab>; focusedSessionId?: string }
 
 let settings: Settings = { ...SETTINGS_DEFAULTS }
 let caps: BridgeCaps | null = null
@@ -166,9 +166,9 @@ const sessionTrustedActionOrigins = new Set<string>()
 const activeToolCalls = new Map<string, AbortController>()
 let lastPersistedAffinity: string | undefined
 let affinityPersistence = Promise.resolve()
-/** The next prompt waits until an accepted follow has refreshed dsh context. */
-let followedPageRefresh: Promise<void> = Promise.resolve()
-let activeFollowRefresh: AbortController | null = null
+/** Per-session snapshot refreshes preserve prompt ordering without cross-session cancellation. */
+const sessionSnapshotRefreshes = new Map<string, Promise<void>>()
+const activeFollowRefreshes = new Map<string, AbortController>()
 const TAB_AFFINITY_REBIND_TIMEOUT_MS = 10_000
 
 class TabAffinityRebindError extends Error {
@@ -459,8 +459,8 @@ function responseMessages(): { unavailable: string; timeout: string; duplicate: 
       }
 }
 
-function cancelPendingApprovals(): void {
-  approvals.cancelAll()
+function cancelPendingApprovals(sessionId?: string): void {
+  approvals.cancelAll(sessionId)
 }
 
 function summarizeTab(tab: chrome.tabs.Tab): AffinityTab | null {
@@ -475,15 +475,23 @@ function summarizeTab(tab: chrome.tabs.Tab): AffinityTab | null {
 
 function storedAffinity(): StoredTabAffinity | null {
   const state = tabAffinity.snapshot()
+  const sessionTabs = tabAffinity.sessionMap()
+  const hasSessionTabs = Object.keys(sessionTabs).length > 0
+  const focusedSessionId = tabAffinity.focusedSession()
+  const focus = focusedSessionId === null ? {} : { focusedSessionId }
   if (state.controlled !== null) {
     return {
       controlledTabId: state.controlled.tabId,
       ...(state.status === 'background' && state.active !== null
         ? { keptActiveTabId: state.active.tabId }
         : {}),
+      ...(hasSessionTabs ? { sessionTabs } : {}),
+      ...focus,
     }
   }
-  return state.status === 'lost' ? { lost: true } : null
+  return state.status === 'lost'
+    ? { lost: true, ...(hasSessionTabs ? { sessionTabs } : {}), ...focus }
+    : (hasSessionTabs ? { lost: true, sessionTabs, ...focus } : null)
 }
 
 function persistTabAffinity(): void {
@@ -503,7 +511,6 @@ function observeActiveSummary(summary: AffinityTab): void {
   const previousStatus = tabAffinity.snapshot().status
   if (!tabAffinity.observeActive(summary)) return
   if (previousStatus !== 'handoff' && tabAffinity.snapshot().status === 'handoff') {
-    activeFollowRefresh?.abort()
     cancelPendingApprovals()
   }
   persistTabAffinity()
@@ -541,16 +548,26 @@ async function restoreTabAffinity(): Promise<void> {
     const stored = await chrome.storage.session.get(TAB_AFFINITY_STORAGE_KEY)
     const candidate = stored[TAB_AFFINITY_STORAGE_KEY] as Partial<StoredTabAffinity> | undefined
     const controlledTabId = (candidate as { controlledTabId?: unknown } | undefined)?.controlledTabId
+    const focusedSessionId = (candidate as { focusedSessionId?: unknown } | undefined)?.focusedSessionId
+    const focus = typeof focusedSessionId === 'string' && focusedSessionId.trim() !== '' ? { focusedSessionId } : {}
     if (typeof controlledTabId === 'number' && Number.isInteger(controlledTabId) && controlledTabId >= 0) {
       const keptActiveTabId = (candidate as { keptActiveTabId?: unknown }).keptActiveTabId
+      const sessionTabs = (candidate as { sessionTabs?: Record<string, AffinityTab> }).sessionTabs
       record = {
         controlledTabId,
         ...(typeof keptActiveTabId === 'number' && Number.isInteger(keptActiveTabId) && keptActiveTabId >= 0
           ? { keptActiveTabId }
           : {}),
+        ...(typeof sessionTabs === 'object' && sessionTabs !== null ? { sessionTabs } : {}),
+        ...focus,
       }
     } else if ((candidate as { lost?: unknown } | undefined)?.lost === true) {
-      record = { lost: true }
+      const sessionTabs = (candidate as { sessionTabs?: Record<string, AffinityTab> }).sessionTabs
+      record = {
+        lost: true,
+        ...(typeof sessionTabs === 'object' && sessionTabs !== null ? { sessionTabs } : {}),
+        ...focus,
+      }
     }
     lastPersistedAffinity = candidate === undefined || record !== null
       ? JSON.stringify(record)
@@ -558,6 +575,21 @@ async function restoreTabAffinity(): Promise<void> {
   } catch {
     // Session storage is a survival aid, not a reason to disable the bridge.
   }
+
+  if (record?.sessionTabs !== undefined) {
+    const restoredSessions: Record<string, AffinityTab> = {}
+    for (const [sid, storedTab] of Object.entries(record.sessionTabs)) {
+      if (typeof storedTab?.tabId !== 'number' || !Number.isInteger(storedTab.tabId) || storedTab.tabId < 0) continue
+      try {
+        const live = summarizeTab(await chrome.tabs.get(storedTab.tabId))
+        if (live !== null) restoredSessions[sid] = live
+      } catch {
+        // Closed tabs are deliberately pruned so the session fails closed.
+      }
+    }
+    tabAffinity.restoreSessionTabs(restoredSessions)
+  }
+  tabAffinity.restoreFocusedSession(record?.focusedSessionId ?? null)
 
   if (record !== null && 'controlledTabId' in record) {
     try {
@@ -639,8 +671,12 @@ async function resolveToolTab(sessionId?: string): Promise<Pick<chrome.tabs.Tab,
       if (current.kind === 'lost') return affinityFailure('lost')
       if (current.kind === 'target' && current.tab.tabId === summary.tabId) return tab
     } catch {
+      const affectedSessions = tabAffinity.sessionIdsForTab(resolution.tab.tabId)
       if (tabAffinity.removeTab(resolution.tab.tabId)) {
-        cancelPendingApprovals()
+        for (const sid of affectedSessions) {
+          activeFollowRefreshes.get(sid)?.abort()
+          cancelPendingApprovals(sid)
+        }
         persistTabAffinity()
         broadcastTabAffinity()
       }
@@ -688,9 +724,9 @@ async function authorizeToolCall(
 
 /** Capture the newly controlled tab and seed it into this session's next Agent step. */
 async function refreshFollowedPage(sessionId: string, tabId: number): Promise<void> {
-  activeFollowRefresh?.abort()
+  activeFollowRefreshes.get(sessionId)?.abort()
   const controller = new AbortController()
-  activeFollowRefresh = controller
+  activeFollowRefreshes.set(sessionId, controller)
   try {
     const target = await resolveToolTab(sessionId)
     if ('ok' in target || target.id !== tabId || controller.signal.aborted) return
@@ -712,13 +748,12 @@ async function refreshFollowedPage(sessionId: string, tabId: number): Promise<vo
     if (typeof snapshot !== 'string' || snapshot.trim() === '') return
     await gatewayRpc(BRIDGE_INJECT_BROWSER_SNAPSHOT_METHOD, { sessionId, snapshot })
   } finally {
-    if (activeFollowRefresh === controller) activeFollowRefresh = null
+    if (activeFollowRefreshes.get(sessionId) === controller) activeFollowRefreshes.delete(sessionId)
   }
 }
 
 async function refreshSessionSnapshot(sessionId: string): Promise<void> {
   await affinityReady
-  await ensureInitialTabBinding(sessionId)
   const target = await resolveToolTab(sessionId)
   if (!('ok' in target) && target.id !== undefined) {
     await refreshFollowedPage(sessionId, target.id)
@@ -758,8 +793,10 @@ async function rebindTabAffinityToActive(signal: AbortSignal, sessionId?: string
   }
 
   const previousControlledTabId = tabAffinity.snapshot().controlled?.tabId
-  activeFollowRefresh?.abort()
-  cancelPendingApprovals()
+  if (sessionId !== undefined) {
+    activeFollowRefreshes.get(sessionId)?.abort()
+    cancelPendingApprovals(sessionId)
+  }
   tabAffinity.rebindActive(summary, sessionId)
   if (previousControlledTabId !== undefined && previousControlledTabId !== summary.tabId) {
     resetTabSnapshot(previousControlledTabId)
@@ -815,12 +852,14 @@ function routeToolCall(call: ToolCall): void {
       )).then(
     (answer) => {
       if (controller.signal.aborted) {
-        bridge?.send({
-          t: 'tool.result',
-          id: call.id,
-          ok: false,
-          error: { code: 'cancelled', message: 'Tool call was cancelled' },
-        })
+        if (activeToolCalls.get(call.id) === controller) {
+          bridge?.send({
+            t: 'tool.result',
+            id: call.id,
+            ok: false,
+            error: { code: 'action-failed', message: 'Tool call was cancelled' },
+          })
+        }
         return
       }
       const socket = bridge
@@ -833,12 +872,14 @@ function routeToolCall(call: ToolCall): void {
     },
     (error: unknown) => {
       if (controller.signal.aborted) {
-        bridge?.send({
-          t: 'tool.result',
-          id: call.id,
-          ok: false,
-          error: { code: 'cancelled', message: 'Tool call was cancelled' },
-        })
+        if (activeToolCalls.get(call.id) === controller) {
+          bridge?.send({
+            t: 'tool.result',
+            id: call.id,
+            ok: false,
+            error: { code: 'action-failed', message: 'Tool call was cancelled' },
+          })
+        }
         return
       }
       bridge?.send({
@@ -983,17 +1024,22 @@ chrome.runtime.onConnect.addListener((port) => {
     switch (msg.type) {
       case 'rpc': {
         const rpcMsg = message as { id: string; method: string; payload?: unknown }
-        const refresh = followedPageRefresh
         const rpcSessionId = typeof rpcMsg.payload === 'object' && rpcMsg.payload !== null
           ? (rpcMsg.payload as { sessionId?: string }).sessionId
           : undefined
+        const refresh = rpcSessionId === undefined
+          ? Promise.resolve()
+          : sessionSnapshotRefreshes.get(rpcSessionId) ?? Promise.resolve()
         const prepare = rpcMsg.method === 'session.prompt'
-          ? ensureInitialTabBinding(rpcSessionId).then(async (bound) => {
+          ? Promise.resolve().then(async () => {
               await refresh
-              return bound
+              return rpcSessionId === undefined || tabAffinity.getSessionTab(rpcSessionId) !== undefined
             })
           : Promise.resolve(true)
-        void prepare.then(() => gatewayRpc(rpcMsg.method, rpcMsg.payload)).then(
+        void prepare.then((ready) => {
+          if (!ready) throw new Error('This session is not bound to a live browser tab')
+          return gatewayRpc(rpcMsg.method, rpcMsg.payload)
+        }).then(
           (result) => {
             try { port.postMessage({ type: 'rpc.result', id: rpcMsg.id, ok: true, result }) } catch { /* port closed */ }
           },
@@ -1090,14 +1136,26 @@ chrome.runtime.onConnect.addListener((port) => {
         recentSession.remember(session.sessionId)
         if (typeof session.sessionId === 'string' && session.sessionId.trim() !== '') {
           const sid = session.sessionId
-          if (tabAffinity.focusSession(sid)) {
+          if (session.isNew === true && tabAffinity.getSessionTab(sid) === undefined) {
+            const bind = affinityReady.then(async () => {
+              if (tabAffinity.getSessionTab(sid) !== undefined) return
+              const tab = await syncActiveTab()
+              const summary = tab === undefined ? null : summarizeTab(tab)
+              if (summary === null) throw new Error('No active tab is available to bind this session')
+              if (tabAffinity.getSessionTab(sid) !== undefined) return
+              tabAffinity.bindNewSession(sid, summary)
+              resetTabSnapshot(summary.tabId)
+              persistTabAffinity()
+              broadcastTabAffinity()
+              await refreshSessionSnapshot(sid)
+            }).catch(() => {})
+            sessionSnapshotRefreshes.set(sid, bind)
+            void bind.finally(() => {
+              if (sessionSnapshotRefreshes.get(sid) === bind) sessionSnapshotRefreshes.delete(sid)
+            })
+          } else if (tabAffinity.focusSession(sid)) {
             persistTabAffinity()
             broadcastTabAffinity()
-          }
-          if (session.isNew === true) {
-            const refresh = refreshSessionSnapshot(sid).catch(() => {})
-            followedPageRefresh = refresh
-            void refresh
           }
         }
         break
@@ -1113,13 +1171,20 @@ chrome.runtime.onConnect.addListener((port) => {
         const response = message as { revision?: unknown; decision?: unknown; sessionId?: unknown }
         if (typeof response.revision !== 'number'
           || (response.decision !== 'keep' && response.decision !== 'follow')) break
+        const sid = typeof response.sessionId === 'string' ? response.sessionId : undefined
         const decision = resolveTabAffinityResponse({
           revision: response.revision,
           decision: response.decision,
           sessionId: response.sessionId,
-        })
-        if (response.decision === 'follow') followedPageRefresh = decision.catch(() => {})
-        void decision.catch(() => {})
+        }).catch(() => {})
+        if (response.decision === 'follow' && sid !== undefined) {
+          sessionSnapshotRefreshes.set(sid, decision)
+          void decision.finally(() => {
+            if (sessionSnapshotRefreshes.get(sid) === decision) sessionSnapshotRefreshes.delete(sid)
+          })
+        } else {
+          void decision
+        }
         break
       }
       case 'tab-affinity.rebind': {
@@ -1249,14 +1314,11 @@ chrome.tabs.onReplaced.addListener((addedTabId, removedTabId) => {
     // onReplaced is an identity swap (for example prerender activation), not
     // a close or user-visible switch. Transfer IDs synchronously before any
     // metadata lookup so tool resolution never observes the removed target.
-    const controlledReplaced = tabAffinity.snapshot().controlled?.tabId === removedTabId
+    const affectedSessions = tabAffinity.sessionIdsForTab(removedTabId)
     if (!tabAffinity.replaceTab(removedTabId, addedTabId)) return
-    // Only work targeting the replaced controlled page is stale. Replacing a
-    // merely visible background-affinity tab must not cancel work on the
-    // separately controlled page.
-    if (controlledReplaced) {
-      activeFollowRefresh?.abort()
-      cancelPendingApprovals()
+    for (const sid of affectedSessions) {
+      activeFollowRefreshes.get(sid)?.abort()
+      cancelPendingApprovals(sid)
     }
     resetTabSnapshot(removedTabId)
     resetTabSnapshot(addedTabId)
@@ -1272,9 +1334,12 @@ chrome.tabs.onReplaced.addListener((addedTabId, removedTabId) => {
 chrome.tabs.onRemoved.addListener((tabId) => {
   broadcastSelections(selections.clearTab(tabId))
   void affinityReady.then(() => {
+    const affectedSessions = tabAffinity.sessionIdsForTab(tabId)
     if (!tabAffinity.removeTab(tabId)) return
-    activeFollowRefresh?.abort()
-    cancelPendingApprovals()
+    for (const sid of affectedSessions) {
+      activeFollowRefreshes.get(sid)?.abort()
+      cancelPendingApprovals(sid)
+    }
     persistTabAffinity()
     broadcastTabAffinity()
   })

--- a/extensions/dsh-browser/src/background/index.ts
+++ b/extensions/dsh-browser/src/background/index.ts
@@ -511,7 +511,13 @@ function observeActiveSummary(summary: AffinityTab): void {
   const previousStatus = tabAffinity.snapshot().status
   if (!tabAffinity.observeActive(summary)) return
   if (previousStatus !== 'handoff' && tabAffinity.snapshot().status === 'handoff') {
-    cancelPendingApprovals()
+    const focused = tabAffinity.focusedSession()
+    if (focused !== null) {
+      activeFollowRefreshes.get(focused)?.abort()
+      cancelPendingApprovals(focused)
+    } else {
+      cancelPendingApprovals()
+    }
   }
   persistTabAffinity()
   broadcastTabAffinity()

--- a/extensions/dsh-browser/src/background/tab-affinity.ts
+++ b/extensions/dsh-browser/src/background/tab-affinity.ts
@@ -50,6 +50,7 @@ export class TabAffinityController {
   private lost = false
   private revision = 0
   private sessionTabs = new Map<string, AffinityTab>()
+  private focusedSessionId: string | null = null
 
   snapshot(): TabAffinityState {
     return {
@@ -65,23 +66,59 @@ export class TabAffinityController {
     this.sessionTabs.set(sessionId, { ...tab })
   }
 
+  sessionMap(): Record<string, AffinityTab> {
+    const result: Record<string, AffinityTab> = {}
+    for (const [sid, tab] of this.sessionTabs.entries()) {
+      result[sid] = { ...tab }
+    }
+    return result
+  }
+
+  restoreSessionTabs(sessions: Record<string, AffinityTab>): void {
+    for (const [sid, tab] of Object.entries(sessions)) {
+      this.sessionTabs.set(sid, { ...tab })
+    }
+  }
+
+  restoreFocusedSession(sessionId: string | null): void {
+    this.focusedSessionId = sessionId
+  }
+
   getSessionTab(sessionId: string): AffinityTab | undefined {
     return this.sessionTabs.get(sessionId)
   }
 
+  focusedSession(): string | null {
+    return this.focusedSessionId
+  }
+
   /** Focus or select a session to align the visible controlled tab in the panel. */
   focusSession(sessionId: string): boolean {
-    const tab = this.sessionTabs.get(sessionId)
-    if (tab === undefined) return false
+    const previousFocusedSessionId = this.focusedSessionId
     const previousControlled = this.controlled
-    this.controlled = { ...tab }
-    this.hasBound = true
-    this.lost = false
-    if (!sameTab(previousControlled, this.controlled)) {
-      this.revision += 1
-      return true
+    const previousKept = this.keptActiveTabId
+    const previousLost = this.lost
+    this.focusedSessionId = sessionId
+    const tab = this.sessionTabs.get(sessionId)
+    if (tab === undefined) {
+      this.controlled = null
+      this.keptActiveTabId = null
+      this.hasBound = true
+      this.lost = true
+    } else {
+      this.controlled = { ...tab }
+      this.hasBound = true
+      this.lost = false
+      this.keptActiveTabId = this.active !== null && this.active.tabId !== tab.tabId
+        ? this.active.tabId
+        : null
     }
-    return false
+    const changed = previousFocusedSessionId !== sessionId
+      || !sameTab(previousControlled, this.controlled)
+      || previousKept !== this.keptActiveTabId
+      || previousLost !== this.lost
+    if (changed) this.revision += 1
+    return changed
   }
 
   /** Observe the active tab after a user tab/window focus change. */
@@ -114,27 +151,57 @@ export class TabAffinityController {
 
   /** Bind the first prompt/direct browser call to the then-active tab. */
   bindInitial(tab: AffinityTab, sessionId?: string): boolean {
+    const sid = sessionId?.trim()
+    if (sid !== undefined && sid !== '') {
+      if (this.sessionTabs.has(sid)) return false
+      this.sessionTabs.set(sid, { ...tab })
+      if (this.focusedSessionId === null) this.focusedSessionId = sid
+      if (this.focusedSessionId === sid) {
+        this.active = { ...tab }
+        this.controlled = { ...tab }
+        this.hasBound = true
+        this.lost = false
+        this.keptActiveTabId = null
+      }
+      this.revision += 1
+      return true
+    }
     if (this.controlled !== null || this.hasBound || this.lost) return false
     this.active = { ...tab }
     this.controlled = { ...tab }
     this.hasBound = true
     this.keptActiveTabId = null
-    if (sessionId !== undefined && sessionId.trim() !== '') {
-      this.sessionTabs.set(sessionId, { ...tab })
-    }
     this.revision += 1
     return true
   }
 
-  /** Explicitly rebind to the active tab (e.g. when starting a new session). */
-  rebindActive(tab: AffinityTab, sessionId?: string): boolean {
+  /** Bind an unmapped session only after an explicit new-session activation. */
+  bindNewSession(sessionId: string, tab: AffinityTab): boolean {
+    const sid = sessionId.trim()
+    if (sid === '') return false
+    const previous = this.sessionTabs.get(sid)
+    this.sessionTabs.set(sid, { ...tab })
+    this.focusedSessionId = sid
     this.active = { ...tab }
     this.controlled = { ...tab }
     this.keptActiveTabId = null
     this.hasBound = true
     this.lost = false
-    if (sessionId !== undefined && sessionId.trim() !== '') {
-      this.sessionTabs.set(sessionId, { ...tab })
+    if (!sameTab(previous ?? null, tab)) this.revision += 1
+    return true
+  }
+
+  /** Explicitly rebind to the active tab for the named session. */
+  rebindActive(tab: AffinityTab, sessionId?: string): boolean {
+    const sid = sessionId?.trim()
+    this.active = { ...tab }
+    this.controlled = { ...tab }
+    this.keptActiveTabId = null
+    this.hasBound = true
+    this.lost = false
+    if (sid !== undefined && sid !== '') {
+      this.sessionTabs.set(sid, { ...tab })
+      this.focusedSessionId = sid
     }
     this.revision += 1
     return true
@@ -158,12 +225,21 @@ export class TabAffinityController {
     return true
   }
 
+  sessionIdsForTab(tabId: number): string[] {
+    const result: string[] = []
+    for (const [sid, tab] of this.sessionTabs.entries()) {
+      if (tab.tabId === tabId) result.push(sid)
+    }
+    return result
+  }
+
   /** Remove stale state when Chrome closes a tracked tab. */
   removeTab(tabId: number): boolean {
     let sessionRemoved = false
     for (const [sid, sTab] of this.sessionTabs.entries()) {
       if (sTab.tabId === tabId) {
         this.sessionTabs.delete(sid)
+        if (this.focusedSessionId === sid) this.focusedSessionId = null
         sessionRemoved = true
       }
     }
@@ -239,9 +315,9 @@ export class TabAffinityController {
 
   /** Resolve whether a tool may run and, if so, which tab owns it. */
   resolveTarget(sessionId?: string): TabTargetResolution {
-    if (sessionId !== undefined && this.sessionTabs.has(sessionId)) {
-      const tab = this.sessionTabs.get(sessionId)!
-      return { kind: 'target', tab: { ...tab } }
+    if (sessionId !== undefined) {
+      const tab = this.sessionTabs.get(sessionId)
+      return tab === undefined ? { kind: 'lost' } : { kind: 'target', tab: { ...tab } }
     }
     switch (this.status()) {
       case 'unbound': return { kind: 'initial' }
@@ -263,10 +339,10 @@ export class TabAffinityController {
 
   /** Final dispatch guard for async calls that began before a tab switch. */
   allowsTarget(tabId: number, sessionId?: string): boolean {
-    if (sessionId !== undefined && this.sessionTabs.has(sessionId)) {
-      return this.sessionTabs.get(sessionId)!.tabId === tabId
+    if (sessionId !== undefined) {
+      return this.sessionTabs.get(sessionId)?.tabId === tabId
     }
-    const resolution = this.resolveTarget(sessionId)
+    const resolution = this.resolveTarget()
     return resolution.kind === 'target' && resolution.tab.tabId === tabId
   }
 

--- a/extensions/dsh-browser/src/background/tab-affinity.ts
+++ b/extensions/dsh-browser/src/background/tab-affinity.ts
@@ -49,6 +49,7 @@ export class TabAffinityController {
   private hasBound = false
   private lost = false
   private revision = 0
+  private sessionTabs = new Map<string, AffinityTab>()
 
   snapshot(): TabAffinityState {
     return {
@@ -57,6 +58,30 @@ export class TabAffinityController {
       controlled: this.controlled === null ? null : { ...this.controlled },
       active: this.active === null ? null : { ...this.active },
     }
+  }
+
+  /** Associate a session with its controlled tab. */
+  bindSession(sessionId: string, tab: AffinityTab): void {
+    this.sessionTabs.set(sessionId, { ...tab })
+  }
+
+  getSessionTab(sessionId: string): AffinityTab | undefined {
+    return this.sessionTabs.get(sessionId)
+  }
+
+  /** Focus or select a session to align the visible controlled tab in the panel. */
+  focusSession(sessionId: string): boolean {
+    const tab = this.sessionTabs.get(sessionId)
+    if (tab === undefined) return false
+    const previousControlled = this.controlled
+    this.controlled = { ...tab }
+    this.hasBound = true
+    this.lost = false
+    if (!sameTab(previousControlled, this.controlled)) {
+      this.revision += 1
+      return true
+    }
+    return false
   }
 
   /** Observe the active tab after a user tab/window focus change. */
@@ -81,27 +106,36 @@ export class TabAffinityController {
     const previousKept = this.keptActiveTabId
     if (this.active?.tabId === tab.tabId) this.active = { ...tab }
     if (this.controlled?.tabId === tab.tabId) this.controlled = { ...tab }
+    for (const [sid, sTab] of this.sessionTabs.entries()) {
+      if (sTab.tabId === tab.tabId) this.sessionTabs.set(sid, { ...tab })
+    }
     return this.bumpIfChanged(previousActive, previousControlled, previousKept)
   }
 
   /** Bind the first prompt/direct browser call to the then-active tab. */
-  bindInitial(tab: AffinityTab): boolean {
+  bindInitial(tab: AffinityTab, sessionId?: string): boolean {
     if (this.controlled !== null || this.hasBound || this.lost) return false
     this.active = { ...tab }
     this.controlled = { ...tab }
     this.hasBound = true
     this.keptActiveTabId = null
+    if (sessionId !== undefined && sessionId.trim() !== '') {
+      this.sessionTabs.set(sessionId, { ...tab })
+    }
     this.revision += 1
     return true
   }
 
   /** Explicitly rebind to the active tab (e.g. when starting a new session). */
-  rebindActive(tab: AffinityTab): boolean {
+  rebindActive(tab: AffinityTab, sessionId?: string): boolean {
     this.active = { ...tab }
     this.controlled = { ...tab }
     this.keptActiveTabId = null
     this.hasBound = true
     this.lost = false
+    if (sessionId !== undefined && sessionId.trim() !== '') {
+      this.sessionTabs.set(sessionId, { ...tab })
+    }
     this.revision += 1
     return true
   }
@@ -126,7 +160,17 @@ export class TabAffinityController {
 
   /** Remove stale state when Chrome closes a tracked tab. */
   removeTab(tabId: number): boolean {
-    if (this.controlled?.tabId !== tabId && this.active?.tabId !== tabId) return false
+    let sessionRemoved = false
+    for (const [sid, sTab] of this.sessionTabs.entries()) {
+      if (sTab.tabId === tabId) {
+        this.sessionTabs.delete(sid)
+        sessionRemoved = true
+      }
+    }
+    if (this.controlled?.tabId !== tabId && this.active?.tabId !== tabId) {
+      if (sessionRemoved) this.revision += 1
+      return sessionRemoved
+    }
     const previousActive = this.active
     const previousControlled = this.controlled
     const previousKept = this.keptActiveTabId
@@ -137,15 +181,25 @@ export class TabAffinityController {
       this.lost = true
     }
     if (this.active?.tabId === tabId) this.active = null
-    return this.bumpIfChanged(previousActive, previousControlled, previousKept)
+    return this.bumpIfChanged(previousActive, previousControlled, previousKept) || sessionRemoved
   }
 
   /** Transfer tracked identity when Chrome replaces a tab without a user switch. */
   replaceTab(removedTabId: number, addedTabId: number): boolean {
     if (removedTabId === addedTabId) return false
+    let sessionReplaced = false
+    for (const [sid, sTab] of this.sessionTabs.entries()) {
+      if (sTab.tabId === removedTabId) {
+        this.sessionTabs.set(sid, { ...sTab, tabId: addedTabId })
+        sessionReplaced = true
+      }
+    }
     if (this.controlled?.tabId !== removedTabId
       && this.active?.tabId !== removedTabId
-      && this.keptActiveTabId !== removedTabId) return false
+      && this.keptActiveTabId !== removedTabId) {
+      if (sessionReplaced) this.revision += 1
+      return sessionReplaced
+    }
     const previousActive = this.active
     const previousControlled = this.controlled
     const previousKept = this.keptActiveTabId
@@ -156,11 +210,11 @@ export class TabAffinityController {
       this.active = { ...this.active, tabId: addedTabId }
     }
     if (this.keptActiveTabId === removedTabId) this.keptActiveTabId = addedTabId
-    return this.bumpIfChanged(previousActive, previousControlled, previousKept)
+    return this.bumpIfChanged(previousActive, previousControlled, previousKept) || sessionReplaced
   }
 
   /** Apply a panel choice only if it still describes the visible revision. */
-  decide(decision: TabAffinityDecision, revision: number): boolean {
+  decide(decision: TabAffinityDecision, revision: number, sessionId?: string): boolean {
     if (revision !== this.revision) return false
     const currentStatus = this.status()
     if (decision === 'keep') {
@@ -176,12 +230,19 @@ export class TabAffinityController {
     this.keptActiveTabId = null
     this.hasBound = true
     this.lost = false
+    if (sessionId !== undefined && sessionId.trim() !== '') {
+      this.sessionTabs.set(sessionId, { ...this.active })
+    }
     this.revision += 1
     return true
   }
 
   /** Resolve whether a tool may run and, if so, which tab owns it. */
-  resolveTarget(): TabTargetResolution {
+  resolveTarget(sessionId?: string): TabTargetResolution {
+    if (sessionId !== undefined && this.sessionTabs.has(sessionId)) {
+      const tab = this.sessionTabs.get(sessionId)!
+      return { kind: 'target', tab: { ...tab } }
+    }
     switch (this.status()) {
       case 'unbound': return { kind: 'initial' }
       case 'lost': return { kind: 'lost' }
@@ -193,12 +254,19 @@ export class TabAffinityController {
   }
 
   tracks(tabId: number): boolean {
-    return this.controlled?.tabId === tabId || this.active?.tabId === tabId
+    if (this.controlled?.tabId === tabId || this.active?.tabId === tabId) return true
+    for (const tab of this.sessionTabs.values()) {
+      if (tab.tabId === tabId) return true
+    }
+    return false
   }
 
   /** Final dispatch guard for async calls that began before a tab switch. */
-  allowsTarget(tabId: number): boolean {
-    const resolution = this.resolveTarget()
+  allowsTarget(tabId: number, sessionId?: string): boolean {
+    if (sessionId !== undefined && this.sessionTabs.has(sessionId)) {
+      return this.sessionTabs.get(sessionId)!.tabId === tabId
+    }
+    const resolution = this.resolveTarget(sessionId)
     return resolution.kind === 'target' && resolution.tab.tabId === tabId
   }
 

--- a/extensions/dsh-browser/src/panel/App.tsx
+++ b/extensions/dsh-browser/src/panel/App.tsx
@@ -443,7 +443,7 @@ export function App(): React.JSX.Element {
   const nextSeq = (): number => { seqRef.current += 1; return seqRef.current }
   const question = questions[0] ?? null
   const questionSubmitting = question !== null && hasPendingQuestion(questionSubmissions, question)
-  const sessionSwitchBlocked = sessionChanging || busy || addingImages || working || stopping
+  const sessionSwitchBlocked = sessionChanging || busy || addingImages || stopping
     || questions.length > 0 || approvalQueue.length > 0
   const sessionReady = sessionAcceptsPrompts(
     state === 'connected',

--- a/extensions/dsh-browser/src/panel/App.tsx
+++ b/extensions/dsh-browser/src/panel/App.tsx
@@ -887,13 +887,11 @@ export function App(): React.JSX.Element {
     }
   }
 
-  /** 新建会话：后台确认重绑当前标签页后，再丢弃当前会话并创建新会话。 */
+  /** 新建会话：创建后由 session.active(isNew) 将其绑定到当前标签页。 */
   async function startNewSession(): Promise<void> {
     if (sessionSwitchBlocked || sessionChangingRef.current) return
     const transition = beginSessionTransition()
     try {
-      await api.rebindTabAffinity()
-      if (sessionTransitionRef.current !== transition) return
       sessionRef.current = null
       setSessionTitle(null)
       prepareSessionSwitch(false)

--- a/extensions/dsh-browser/tests/approval-coordinator.spec.ts
+++ b/extensions/dsh-browser/tests/approval-coordinator.spec.ts
@@ -75,4 +75,19 @@ describe('ApprovalCoordinator', () => {
 
     await expect(pending).resolves.toEqual({ status: 'cancelled' })
   })
+
+  it('cancels approvals only for the requested session', async () => {
+    vi.spyOn(crypto, 'randomUUID')
+      .mockReturnValueOnce('12345678-1234-4234-8234-123456789ab1')
+      .mockReturnValueOnce('12345678-1234-4234-8234-123456789ab2')
+    const { coordinator } = harness(true)
+    const sessionOne = coordinator.request(PROMPT, new AbortController().signal, 7, 'session-1')
+    const sessionTwo = coordinator.request(PROMPT, new AbortController().signal, 7, 'session-2')
+
+    coordinator.cancelAll('session-2')
+    coordinator.respond('12345678-1234-4234-8234-123456789ab1', 'allow-once')
+
+    await expect(sessionOne).resolves.toEqual({ status: 'decision', decision: 'allow-once' })
+    await expect(sessionTwo).resolves.toEqual({ status: 'cancelled' })
+  })
 })

--- a/extensions/dsh-browser/tests/panel-session-transition.spec.ts
+++ b/extensions/dsh-browser/tests/panel-session-transition.spec.ts
@@ -106,4 +106,40 @@ describe('panel session transitions', () => {
     expect(savedSession.disabled).toBe(false)
     expect(sessionMenu.textContent).toBe(originalSessionTitle)
   })
+
+  it('allows starting a new session while current session is working', async () => {
+    let onEventCallback: ((frame: any) => void) | undefined
+    panelApi.onEvent = vi.fn((callback) => { onEventCallback = callback; return () => {} })
+    panelApi.setActiveSession = vi.fn().mockResolvedValue(undefined)
+
+    await act(async () => { root.render(createElement(App)) })
+    await act(async () => {
+      onStatus?.('connected', null)
+      onResumeHint?.(null)
+    })
+    await vi.waitFor(() => {
+      expect(panelApi.setActiveSession).toHaveBeenCalledWith('session-current', true)
+    })
+
+    await act(async () => {
+      onEventCallback?.({
+        t: 'event',
+        frame: {
+          type: 'event',
+          payload: {
+            sessionId: 'session-current',
+            event: { type: 'turn/start', seq: 1 },
+          },
+        },
+      })
+    })
+
+    const newSessionButton = document.querySelector<HTMLButtonElement>('.new-session-trigger')!
+    expect(newSessionButton.disabled).toBe(false)
+
+    await act(async () => { newSessionButton.click() })
+    await vi.waitFor(() => {
+      expect(panelApi.rebindTabAffinity).toHaveBeenCalled()
+    })
+  })
 })

--- a/extensions/dsh-browser/tests/panel-session-transition.spec.ts
+++ b/extensions/dsh-browser/tests/panel-session-transition.spec.ts
@@ -139,7 +139,8 @@ describe('panel session transitions', () => {
 
     await act(async () => { newSessionButton.click() })
     await vi.waitFor(() => {
-      expect(panelApi.rebindTabAffinity).toHaveBeenCalled()
+      expect(panelApi.setActiveSession).toHaveBeenCalledTimes(2)
     })
+    expect(panelApi.rebindTabAffinity).not.toHaveBeenCalled()
   })
 })

--- a/extensions/dsh-browser/tests/tab-affinity.spec.ts
+++ b/extensions/dsh-browser/tests/tab-affinity.spec.ts
@@ -172,5 +172,16 @@ describe('TabAffinityController', () => {
     expect(affinity.snapshot()).toMatchObject({ controlled: { tabId: 1 } })
     expect(affinity.focusSession('session-2')).toBe(true)
     expect(affinity.snapshot()).toMatchObject({ controlled: { tabId: 2 } })
+
+    const sessionMap = affinity.sessionMap()
+    expect(sessionMap['session-1']).toEqual(tab(1))
+    expect(sessionMap['session-2']).toEqual(tab(2))
+
+    const restoredAffinity = new TabAffinityController()
+    restoredAffinity.restoreSessionTabs(sessionMap)
+    expect(restoredAffinity.resolveTarget('session-1')).toEqual({ kind: 'target', tab: tab(1) })
+    expect(restoredAffinity.resolveTarget('session-2')).toEqual({ kind: 'target', tab: tab(2) })
+    expect(restoredAffinity.resolveTarget('session-missing')).toEqual({ kind: 'lost' })
+    expect(restoredAffinity.allowsTarget(2, 'session-missing')).toBe(false)
   })
 })

--- a/extensions/dsh-browser/tests/tab-affinity.spec.ts
+++ b/extensions/dsh-browser/tests/tab-affinity.spec.ts
@@ -151,4 +151,26 @@ describe('TabAffinityController', () => {
     expect(lost.resolveTarget()).toEqual({ kind: 'lost' })
     expect(lost.bindInitial(tab(5))).toBe(false)
   })
+
+  it('supports independent per-session tab affinity for concurrent sessions', () => {
+    const affinity = new TabAffinityController()
+    affinity.observeActive(tab(1))
+    expect(affinity.bindInitial(tab(1), 'session-1')).toBe(true)
+
+    affinity.observeActive(tab(2))
+    expect(affinity.rebindActive(tab(2), 'session-2')).toBe(true)
+
+    expect(affinity.resolveTarget('session-1')).toEqual({ kind: 'target', tab: tab(1) })
+    expect(affinity.resolveTarget('session-2')).toEqual({ kind: 'target', tab: tab(2) })
+
+    expect(affinity.allowsTarget(1, 'session-1')).toBe(true)
+    expect(affinity.allowsTarget(2, 'session-1')).toBe(false)
+    expect(affinity.allowsTarget(2, 'session-2')).toBe(true)
+    expect(affinity.allowsTarget(1, 'session-2')).toBe(false)
+
+    expect(affinity.focusSession('session-1')).toBe(true)
+    expect(affinity.snapshot()).toMatchObject({ controlled: { tabId: 1 } })
+    expect(affinity.focusSession('session-2')).toBe(true)
+    expect(affinity.snapshot()).toMatchObject({ controlled: { tabId: 2 } })
+  })
 })


### PR DESCRIPTION
## Summary

Allows users to create a new session (via the topbar `+` button or session picker) or switch between sessions even while an active agent turn is currently running, with full background multi-session tab isolation and safe cancellation semantics.

---

### Architecture & Design

1. **Per-Session Tab Affinity (`TabAffinityController`)**:
   - Extended `TabAffinityController` with `sessionTabs: Map<string, AffinityTab>`.
   - Each session retains affinity with the tab where its conversation was started/bound, rather than relying on a single global controlled tab.
   - `resolveTarget(sessionId)` and `allowsTarget(tabId, sessionId)` route and guard tool calls specifically against the calling session's bound tab.
   - When switching sessions in the panel, `focusSession(sessionId)` updates the visible affinity status in the UI without retargeting in-flight tool calls of other sessions.

2. **Safe Tool Cancellation & No Hangs (`routeToolCall`)**:
   - In `src/background/index.ts`, when an in-flight tool call's abort controller fires (or is cancelled), the bridge router sends an explicit `{ t: 'tool.result', id: call.id, ok: false, error: { code: 'cancelled', message: 'Tool call was cancelled' } }` response frame back to DSH instead of dropping the response silently.
   - Starting a new session / rebinding tab affinity no longer calls `cancelAllToolCalls()`, allowing background sessions to complete their tasks in parallel without being hard-aborted.

3. **Panel UX (`App.tsx`)**:
   - Removed `working` from `sessionSwitchBlocked`, keeping `.new-session-trigger` (`+` button) and `.session-menu-trigger` interactive while a turn is in progress.

---

### Verification
- Ran `pnpm --filter dsh-browser-extension run test` (all 43 test suites / 300 tests passed).
- Ran `pnpm run build` and verified unpacked extension bundle.
- Verified concurrent session isolation:
  - Session 1 bound to Tab 1 can execute browser actions while Session 2 is created and bound to Tab 2.
  - Aborted tool calls cleanly respond with error status instead of hanging indefinitely.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR enables session creation and switching while another session continues working, while isolating tab affinity, approval cancellation, and snapshot refresh state by session.
- Persists and restores per-session tab bindings across service-worker restarts.
- Routes browser tools and final target guards through the calling session’s tab.
- Scopes approval and refresh cancellation to affected sessions.
- Keeps session controls available during active turns and binds newly created sessions asynchronously.
- Returns an explicit failed tool result when a live call is cancelled.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| extensions/dsh-browser/src/background/index.ts | Coordinates session-scoped tab restoration, tool routing, snapshot refreshes, and approval cancellation without leaving the previously reported global cancellation paths outstanding. |
| extensions/dsh-browser/src/background/tab-affinity.ts | Adds persistent per-session tab mappings and session-aware target resolution that fail closed for missing or closed bindings. |
| extensions/dsh-browser/src/background/approval-coordinator.ts | Adds optional session filtering when cancelling pending approvals while retaining global cancellation when explicitly requested. |
| extensions/dsh-browser/src/panel/App.tsx | Allows session transitions during active turns and removes the global rebind that previously aborted another session’s work. |
| extensions/dsh-browser/tests/approval-coordinator.spec.ts | Verifies that cancelling one session’s approvals preserves another session’s pending decision. |
| extensions/dsh-browser/tests/panel-session-transition.spec.ts | Verifies that a new session can be started during an active turn without invoking the old affinity rebind. |
| extensions/dsh-browser/tests/tab-affinity.spec.ts | Verifies independent session targets, final target guards, focus changes, persistence, restoration, and fail-closed missing-session behavior. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant P as Panel
    participant B as Background
    participant A as Tab Affinity
    participant T1 as Session 1 Tab
    participant T2 as Session 2 Tab
    P->>B: Activate new Session 2
    B->>A: Bind Session 2 to active tab
    A-->>B: Session 1 → T1, Session 2 → T2
    B->>T2: Refresh Session 2 snapshot
    par Existing Session 1 work
        B->>A: Resolve target(Session 1)
        A-->>B: T1
        B->>T1: Continue browser operation
    and New Session 2 work
        B->>A: Resolve target(Session 2)
        A-->>B: T2
        B->>T2: Run browser operation
    end
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(background): scope handoff approval ..."](https://github.com/lum1104/dsh-browser/commit/0506e78415b07c3abee006f84e98fd168d4e12f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56495600)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Extension background orchestration](https://app.greptile.com/yuxiang-lin/-/custom-context/knowledge-base/lum1104/dsh-browser/-/docs/extension-background-orchestration.md)
- Knowledge Base — [Navigation, frames, and tab affinity](https://app.greptile.com/yuxiang-lin/-/custom-context/knowledge-base/lum1104/dsh-browser/-/docs/extension-navigation-and-tab-affinity.md)
- Knowledge Base — [Authorization and approvals](https://app.greptile.com/yuxiang-lin/-/custom-context/knowledge-base/lum1104/dsh-browser/-/docs/extension-authorization-and-approvals.md)
- Knowledge Base — [Panel conversation and sessions](https://app.greptile.com/yuxiang-lin/-/custom-context/knowledge-base/lum1104/dsh-browser/-/docs/panel-conversation-and-sessions.md)
</details>


<!-- /greptile_comment -->