### PR TITLE
fix(panel): prevent settings sections from being clipped

### DIFF
--- a/extensions/dsh-browser/src/panel/styles.css
+++ b/extensions/dsh-browser/src/panel/styles.css
@@ -1602,6 +1602,10 @@ textarea:focus-visible {
   scrollbar-gutter: stable;
 }
 
+.settings > * {
+  flex-shrink: 0;
+}
+
 .settings-heading {
   display: flex;
   align-items: center;

--- a/extensions/dsh-browser/tests/panel-styles.spec.ts
+++ b/extensions/dsh-browser/tests/panel-styles.spec.ts
@@ -13,4 +13,12 @@ describe('panel layout styles', () => {
     expect(settingsRule).toMatch(/(?:^|\n)\s*overflow-y:\s*auto;/)
     expect(settingsRule).toMatch(/(?:^|\n)\s*overscroll-behavior:\s*contain;/)
   })
+
+  it('keeps settings sections at their natural height so the view can overflow', () => {
+    const styles = readFileSync(`${process.cwd()}/src/panel/styles.css`, 'utf8')
+    const settingsChildrenRule = styles.match(/\.settings\s*>\s*\*\s*\{([^}]*)\}/)?.[1]
+
+    expect(settingsChildrenRule).toBeDefined()
+    expect(settingsChildrenRule).toMatch(/(?:^|\n)\s*flex-shrink:\s*0;/)
+  })
 })


### PR DESCRIPTION
## Summary

- keep every direct settings section at its natural height so the settings container can overflow and scroll
- add a focused CSS contract test that prevents the sections from becoming shrinkable again

## Root cause

PR #37 correctly constrained `.settings` to the sidebar viewport and made it the scroll container. However, its direct children still used the flexbox default `flex-shrink: 1`. The update card and settings panels also use `overflow: hidden`, so Chrome compressed those cards below their content height and then clipped their contents. Because the cards had already been compressed to fit the viewport, `.settings` had no overflow to scroll.

This PR keeps the existing viewport-height/internal-scroll contract and only disables shrinking for direct settings children. The same flex-shrink failure was first reported and diagnosed in #34 and validated in the broader, closed PR #46; this PR extracts that focused fix for #47.

Fixes #47.

## Validation

- `pnpm test` — 111 bridge tests and 299 extension tests passed
- `pnpm typecheck`
- `pnpm build`
- `pnpm --filter dsh-browser-extension run build:firefox`
- Chrome for Testing 151 layout matrix:
  - 320×300, DPR 1, English, 0 trusted origins
  - 361×960, DPR 2, Simplified Chinese, 5 trusted origins
  - 420×600, DPR 1, Traditional Chinese, 10 trusted origins

For every browser case, the settings container scrolled to its exact maximum position, the update/settings cards retained their complete content height, Save/Cancel and the final hint were reachable, no horizontal overflow appeared, and the chat view kept its existing non-scrolling body contract.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents direct children of the settings flex container from being compressed below their natural content height and adds a focused stylesheet contract test.
- Adds `flex-shrink: 0` to direct settings children so vertical overflow reaches the existing scroll container.
- Verifies the non-shrinking CSS rule remains present.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness, security, or quality issues identified.

The new rule matches the settings container’s column layout and scrolling contract, while the test directly protects the intended non-shrinking behavior.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| extensions/dsh-browser/src/panel/styles.css | Adds a narrowly scoped flex rule that preserves settings-section heights and allows the existing vertical overflow behavior to work. |
| extensions/dsh-browser/tests/panel-styles.spec.ts | Adds a focused contract test asserting that direct settings children cannot shrink. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(panel): guard settings section sizi..."](https://github.com/lum1104/dsh-browser/commit/86fb18d4afc8c466d2451eeba8d076cf4262ed50) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57014644)</sub>

<!-- /greptile_comment -->