### PR TITLE
feat(tab-affinity): let a handoff choice stop asking on later tab switches

### DIFF
--- a/extensions/dsh-browser/src/background/index.ts
+++ b/extensions/dsh-browser/src/background/index.ts
@@ -57,6 +57,7 @@ import {
 import { TransientEventCache } from './transient-events.ts'
 import {
   TabAffinityController,
+  isTabAffinityDecision,
   type AffinityTab,
   type TabAffinityDecision,
 } from './tab-affinity.ts'
@@ -144,7 +145,7 @@ const STORAGE_KEY = 'dshSettings'
 const TAB_AFFINITY_STORAGE_KEY = 'dshTabAffinity'
 
 type StoredTabAffinity =
-  | { controlledTabId: number; keptActiveTabId?: number; sessionTabs?: Record<string, AffinityTab>; focusedSessionId?: string }
+  | { controlledTabId: number; keptActiveTabId?: number; pinned?: true; sessionTabs?: Record<string, AffinityTab>; focusedSessionId?: string }
   | { lost: true; sessionTabs?: Record<string, AffinityTab>; focusedSessionId?: string }
 
 let settings: Settings = { ...SETTINGS_DEFAULTS }
@@ -491,6 +492,7 @@ function storedAffinity(): StoredTabAffinity | null {
       ...(state.status === 'background' && state.active !== null
         ? { keptActiveTabId: state.active.tabId }
         : {}),
+      ...(state.pinned ? { pinned: true as const } : {}),
       ...(hasSessionTabs ? { sessionTabs } : {}),
       ...focus,
     }
@@ -570,6 +572,7 @@ async function restoreTabAffinity(): Promise<void> {
         ...(typeof keptActiveTabId === 'number' && Number.isInteger(keptActiveTabId) && keptActiveTabId >= 0
           ? { keptActiveTabId }
           : {}),
+        ...((candidate as { pinned?: unknown }).pinned === true ? { pinned: true as const } : {}),
         ...(typeof sessionTabs === 'object' && sessionTabs !== null ? { sessionTabs } : {}),
         ...focus,
       }
@@ -615,6 +618,9 @@ async function restoreTabAffinity(): Promise<void> {
     tabAffinity.restoreLost()
   }
 
+  // Restore the pin before syncing the active tab: otherwise the sync would
+  // surface a handoff prompt for a switch the user already said not to ask about.
+  if (record !== null && 'pinned' in record && record.pinned === true) tabAffinity.restorePinned()
   await syncActiveTab()
   if (record !== null && 'keptActiveTabId' in record) {
     const state = tabAffinity.snapshot()
@@ -1181,8 +1187,7 @@ chrome.runtime.onConnect.addListener((port) => {
       }
       case 'tab-affinity.response': {
         const response = message as { revision?: unknown; decision?: unknown; sessionId?: unknown }
-        if (typeof response.revision !== 'number'
-          || (response.decision !== 'keep' && response.decision !== 'follow')) break
+        if (typeof response.revision !== 'number' || !isTabAffinityDecision(response.decision)) break
         const sid = typeof response.sessionId === 'string' ? response.sessionId : undefined
         const decision = resolveTabAffinityResponse({
           revision: response.revision,

--- a/extensions/dsh-browser/src/background/tab-affinity.ts
+++ b/extensions/dsh-browser/src/background/tab-affinity.ts
@@ -5,6 +5,11 @@
  * affinity rules so transitions can be tested without a browser runtime.
  * A manual tab switch never silently changes the tool target: it creates a
  * handoff decision, and tool dispatch remains blocked until the user chooses.
+ * `keep-always` is the one way out of that per-switch prompt: it pins the
+ * controlled tab so later switches resolve straight to `background` instead of
+ * asking again, and `ask-again` reverses it without disturbing the binding.
+ * Pinning never widens what the tools may touch — the target is still exactly
+ * the tab the user already approved — and any change of binding clears it.
  *
  * @module
  */
@@ -18,7 +23,13 @@ export interface AffinityTab {
 }
 
 export type TabAffinityStatus = 'unbound' | 'following' | 'handoff' | 'background' | 'lost'
-export type TabAffinityDecision = 'keep' | 'follow'
+export type TabAffinityDecision = 'keep' | 'follow' | 'keep-always' | 'ask-again'
+
+/** Narrow an untrusted panel message field to a decision. */
+export function isTabAffinityDecision(value: unknown): value is TabAffinityDecision {
+  return value === 'keep' || value === 'follow'
+    || value === 'keep-always' || value === 'ask-again'
+}
 
 /** Serializable state sent from the service worker to every side panel. */
 export interface TabAffinityState {
@@ -26,6 +37,8 @@ export interface TabAffinityState {
   status: TabAffinityStatus
   controlled: AffinityTab | null
   active: AffinityTab | null
+  /** True once the user chose `keep-always`; tab switches stop prompting. */
+  pinned: boolean
 }
 
 export type TabTargetResolution =
@@ -46,6 +59,7 @@ export class TabAffinityController {
   private controlled: AffinityTab | null = null
   private active: AffinityTab | null = null
   private keptActiveTabId: number | null = null
+  private pinned = false
   private hasBound = false
   private lost = false
   private revision = 0
@@ -58,6 +72,7 @@ export class TabAffinityController {
       status: this.status(),
       controlled: this.controlled === null ? null : { ...this.controlled },
       active: this.active === null ? null : { ...this.active },
+      pinned: this.pinned,
     }
   }
 
@@ -99,6 +114,7 @@ export class TabAffinityController {
     const previousKept = this.keptActiveTabId
     const previousLost = this.lost
     this.focusedSessionId = sessionId
+    this.pinned = false
     const tab = this.sessionTabs.get(sessionId)
     if (tab === undefined) {
       this.controlled = null
@@ -162,6 +178,7 @@ export class TabAffinityController {
         this.hasBound = true
         this.lost = false
         this.keptActiveTabId = null
+        this.pinned = false
       }
       this.revision += 1
       return true
@@ -171,6 +188,7 @@ export class TabAffinityController {
     this.controlled = { ...tab }
     this.hasBound = true
     this.keptActiveTabId = null
+    this.pinned = false
     this.revision += 1
     return true
   }
@@ -185,6 +203,7 @@ export class TabAffinityController {
     this.active = { ...tab }
     this.controlled = { ...tab }
     this.keptActiveTabId = null
+    this.pinned = false
     this.hasBound = true
     this.lost = false
     if (!sameTab(previous ?? null, tab)) this.revision += 1
@@ -197,6 +216,7 @@ export class TabAffinityController {
     this.active = { ...tab }
     this.controlled = { ...tab }
     this.keptActiveTabId = null
+    this.pinned = false
     this.hasBound = true
     this.lost = false
     if (sid !== undefined && sid !== '') {
@@ -212,6 +232,19 @@ export class TabAffinityController {
     if (this.controlled !== null || this.hasBound || this.lost) return false
     this.controlled = { ...tab }
     this.hasBound = true
+    this.revision += 1
+    return true
+  }
+
+  /**
+   * Rehydrate a `keep-always` choice after an MV3 worker restart.
+   *
+   * Only valid once a controlled tab exists, so a stale pin can never suppress
+   * the handoff prompt for a binding the user has not approved.
+   */
+  restorePinned(): boolean {
+    if (this.controlled === null || this.pinned) return false
+    this.pinned = true
     this.revision += 1
     return true
   }
@@ -253,6 +286,7 @@ export class TabAffinityController {
     if (this.controlled?.tabId === tabId) {
       this.controlled = null
       this.keptActiveTabId = null
+      this.pinned = false
       this.hasBound = true
       this.lost = true
     }
@@ -293,9 +327,19 @@ export class TabAffinityController {
   decide(decision: TabAffinityDecision, revision: number, sessionId?: string): boolean {
     if (revision !== this.revision) return false
     const currentStatus = this.status()
-    if (decision === 'keep') {
+    if (decision === 'ask-again') {
+      // Undo a pin in place. Dropping keptActiveTabId re-raises the prompt for
+      // the switch the pin was suppressing, so control stays user-confirmed.
+      if (!this.pinned) return false
+      this.pinned = false
+      this.keptActiveTabId = null
+      this.revision += 1
+      return true
+    }
+    if (decision === 'keep' || decision === 'keep-always') {
       if (currentStatus !== 'handoff' || this.active === null) return false
       this.keptActiveTabId = this.active.tabId
+      if (decision === 'keep-always') this.pinned = true
       this.revision += 1
       return true
     }
@@ -304,6 +348,7 @@ export class TabAffinityController {
     }
     this.controlled = { ...this.active }
     this.keptActiveTabId = null
+    this.pinned = false
     this.hasBound = true
     this.lost = false
     if (sessionId !== undefined && sessionId.trim() !== '') {
@@ -349,7 +394,7 @@ export class TabAffinityController {
   private status(): TabAffinityStatus {
     if (this.controlled === null) return this.lost ? 'lost' : 'unbound'
     if (this.active?.tabId === this.controlled.tabId) return 'following'
-    if (this.active !== null && this.keptActiveTabId !== this.active.tabId) return 'handoff'
+    if (this.active !== null && !this.pinned && this.keptActiveTabId !== this.active.tabId) return 'handoff'
     return 'background'
   }
 

--- a/extensions/dsh-browser/src/background/tab-affinity.ts
+++ b/extensions/dsh-browser/src/background/tab-affinity.ts
@@ -131,8 +131,11 @@ export class TabAffinityController {
         : null
       // A pin belongs to the tab it was made for, so it survives re-focusing the
       // same binding (session resume replays the focused session) and is dropped
-      // only when focus actually moves the controlled tab.
-      if (!sameTab(previousControlled, this.controlled)) this.pinned = false
+      // only when focus actually moves the controlled tab. Identity here is the
+      // tab id alone, not sameTab(): that compares title and url for change
+      // detection, and a restored session snapshot routinely disagrees with the
+      // live tab on both after the page has navigated.
+      if (previousControlled?.tabId !== this.controlled.tabId) this.pinned = false
     }
     const changed = previousFocusedSessionId !== sessionId
       || !sameTab(previousControlled, this.controlled)

--- a/extensions/dsh-browser/src/background/tab-affinity.ts
+++ b/extensions/dsh-browser/src/background/tab-affinity.ts
@@ -113,12 +113,13 @@ export class TabAffinityController {
     const previousControlled = this.controlled
     const previousKept = this.keptActiveTabId
     const previousLost = this.lost
+    const previousPinned = this.pinned
     this.focusedSessionId = sessionId
-    this.pinned = false
     const tab = this.sessionTabs.get(sessionId)
     if (tab === undefined) {
       this.controlled = null
       this.keptActiveTabId = null
+      this.pinned = false
       this.hasBound = true
       this.lost = true
     } else {
@@ -128,11 +129,16 @@ export class TabAffinityController {
       this.keptActiveTabId = this.active !== null && this.active.tabId !== tab.tabId
         ? this.active.tabId
         : null
+      // A pin belongs to the tab it was made for, so it survives re-focusing the
+      // same binding (session resume replays the focused session) and is dropped
+      // only when focus actually moves the controlled tab.
+      if (!sameTab(previousControlled, this.controlled)) this.pinned = false
     }
     const changed = previousFocusedSessionId !== sessionId
       || !sameTab(previousControlled, this.controlled)
       || previousKept !== this.keptActiveTabId
       || previousLost !== this.lost
+      || previousPinned !== this.pinned
     if (changed) this.revision += 1
     return changed
   }

--- a/extensions/dsh-browser/src/panel/App.tsx
+++ b/extensions/dsh-browser/src/panel/App.tsx
@@ -332,7 +332,9 @@ function TabAffinityBanner({
     ? copy.tabHandoff.lostBody
     : handoff
       ? copy.tabHandoff.questionBody(controlled, active)
-      : copy.tabHandoff.backgroundBody(active)
+      : state.pinned
+        ? copy.tabHandoff.pinnedBody(active)
+        : copy.tabHandoff.backgroundBody(active)
 
   return (
     <section className={`tab-affinity ${state.status}`} role={handoff || lost ? 'alert' : 'status'}>
@@ -357,6 +359,16 @@ function TabAffinityBanner({
         {state.active !== null && (
           <button className="follow" onClick={() => onDecision('follow')}>
             {lost ? copy.tabHandoff.useCurrent : handoff ? copy.tabHandoff.follow : copy.tabHandoff.followCurrent}
+          </button>
+        )}
+        {handoff && (
+          <button className="keep-always" onClick={() => onDecision('keep-always')}>
+            {copy.tabHandoff.keepAlways}
+          </button>
+        )}
+        {!handoff && !lost && state.pinned && (
+          <button className="keep-always" onClick={() => onDecision('ask-again')}>
+            {copy.tabHandoff.askAgain}
           </button>
         )}
       </div>

--- a/extensions/dsh-browser/src/panel/strings.ts
+++ b/extensions/dsh-browser/src/panel/strings.ts
@@ -36,9 +36,12 @@ export interface PanelCopy {
     questionTitle: string
     questionBody: (controlled: string, active: string) => string
     keep: string
+    keepAlways: string
     follow: string
     backgroundTitle: (controlled: string) => string
     backgroundBody: (active: string) => string
+    pinnedBody: (active: string) => string
+    askAgain: string
     followCurrent: string
     lostTitle: string
     lostBody: string
@@ -249,9 +252,12 @@ const EN: PanelCopy = {
     questionTitle: 'Follow your current page?',
     questionBody: (controlled, active) => `It is still bound to “${controlled}”, while you moved to “${active}”. Browser actions are paused until you choose.`,
     keep: 'Stay on original',
+    keepAlways: 'Stay & stop asking',
     follow: 'Follow current page',
     backgroundTitle: () => 'Assistant stays on the original page',
     backgroundBody: (active) => `You are viewing “${active}”. Future browser actions still run on the original page.`,
+    pinnedBody: (active) => `You are viewing “${active}”. Future browser actions still run on the original page, and switching tabs will not ask again.`,
+    askAgain: 'Ask on tab switch',
     followCurrent: 'Follow current page',
     lostTitle: 'The controlled tab was closed',
     lostBody: 'Browser actions are paused to avoid operating the wrong page.',
@@ -462,9 +468,12 @@ const ZH: PanelCopy = {
     questionTitle: '助手要跟随当前页面吗？',
     questionBody: (controlled, active) => `助手仍绑定“${controlled}”，你刚切到“${active}”。选择前，浏览器操作会暂停。`,
     keep: '留在原页面',
+    keepAlways: '留在原页面并不再询问',
     follow: '跟随当前页面',
     backgroundTitle: () => '助手仍在原页面',
     backgroundBody: (active) => `你正在查看“${active}”，后续浏览器操作仍会在原页面执行。`,
+    pinnedBody: (active) => `你正在查看“${active}”，后续浏览器操作仍会在原页面执行；切换标签页时不会再询问。`,
+    askAgain: '切换标签页时重新询问',
     followCurrent: '改为跟随当前页',
     lostTitle: '受控标签页已关闭',
     lostBody: '为避免操作错页，浏览器操作已暂停。',

--- a/extensions/dsh-browser/src/panel/styles.css
+++ b/extensions/dsh-browser/src/panel/styles.css
@@ -271,7 +271,9 @@ textarea:focus-visible {
 
 .tab-affinity-actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
+  row-gap: 6px;
   margin-top: 10px;
 }
 
@@ -310,6 +312,21 @@ textarea:focus-visible {
 .tab-affinity-actions .follow:hover {
   border-color: var(--blue-hover);
   background: var(--blue-hover);
+}
+
+/* The pin controls ("stay and stop asking" / "ask on tab switch") take their
+   own full-width row so the primary answers above keep equal weight. */
+.tab-affinity-actions .keep-always {
+  flex: 1 0 100%;
+  border: 1px dashed var(--line-strong);
+  background: transparent;
+  color: var(--muted);
+}
+
+.tab-affinity-actions .keep-always:hover {
+  border-color: #b6c0d0;
+  background: var(--surface);
+  color: var(--ink);
 }
 
 .tab-affinity.background .tab-affinity-actions {

--- a/extensions/dsh-browser/tests/panel-api.spec.ts
+++ b/extensions/dsh-browser/tests/panel-api.spec.ts
@@ -114,6 +114,7 @@ describe('panel protocol', () => {
       status: 'handoff',
       controlled: { tabId: 1, windowId: 2, title: 'Original', url: 'https://original.example/' },
       active: { tabId: 3, windowId: 2, title: 'Current', url: 'https://current.example/' },
+      pinned: false,
     }
 
     receive?.({ type: 'tab-affinity', state })

--- a/extensions/dsh-browser/tests/tab-affinity.spec.ts
+++ b/extensions/dsh-browser/tests/tab-affinity.spec.ts
@@ -148,6 +148,23 @@ describe('TabAffinityController', () => {
     expect(affinity.snapshot().revision).toBeGreaterThan(before.revision)
   })
 
+  it('keeps a restored pin when the tab navigated while the worker was down', () => {
+    // Restart shape: the stored session snapshot carries the metadata from when
+    // the session was bound, while the live tab has since navigated.
+    const affinity = new TabAffinityController()
+    affinity.restoreSessionTabs({ s1: tab(1, 'Title at bind time') })
+    affinity.restoreControlled(tab(1, 'Title after navigating'))
+    affinity.restoreFocusedSession('s1')
+    expect(affinity.restorePinned()).toBe(true)
+    affinity.observeActive(tab(2))
+    expect(affinity.snapshot()).toMatchObject({ status: 'background', pinned: true })
+
+    // Same tab id, different title/url: still the binding the user pinned.
+    affinity.focusSession('s1')
+    expect(affinity.snapshot()).toMatchObject({ pinned: true, controlled: { tabId: 1 } })
+    expect(affinity.resolveTarget()).toMatchObject({ kind: 'target', tab: { tabId: 1 } })
+  })
+
   it('rejects a keep-always pin that has no controlled tab behind it', () => {
     const unbound = new TabAffinityController()
     unbound.observeActive(tab(1))

--- a/extensions/dsh-browser/tests/tab-affinity.spec.ts
+++ b/extensions/dsh-browser/tests/tab-affinity.spec.ts
@@ -125,6 +125,29 @@ describe('TabAffinityController', () => {
     expect(affinity.decide('ask-again', affinity.snapshot().revision)).toBe(false)
   })
 
+  it('keeps a pin when focus replays the same session, drops it when the tab moves', () => {
+    const affinity = new TabAffinityController()
+    affinity.observeActive(tab(1))
+    affinity.bindNewSession('s1', tab(1))
+    affinity.bindNewSession('s2', tab(2))
+    affinity.focusSession('s1')
+    affinity.observeActive(tab(3))
+    affinity.decide('keep-always', affinity.snapshot().revision)
+    expect(affinity.snapshot()).toMatchObject({ status: 'background', pinned: true, controlled: { tabId: 1 } })
+
+    // Session resume replays the focused session: the binding is unchanged, so
+    // the pin must survive and no revision is burned.
+    const before = affinity.snapshot()
+    expect(affinity.focusSession('s1')).toBe(false)
+    expect(affinity.snapshot()).toMatchObject({ revision: before.revision, pinned: true, status: 'background' })
+
+    // Moving focus to a session on a different tab drops the pin, and the
+    // change is reported so the panel and the persisted record follow.
+    expect(affinity.focusSession('s2')).toBe(true)
+    expect(affinity.snapshot()).toMatchObject({ pinned: false, controlled: { tabId: 2 } })
+    expect(affinity.snapshot().revision).toBeGreaterThan(before.revision)
+  })
+
   it('rejects a keep-always pin that has no controlled tab behind it', () => {
     const unbound = new TabAffinityController()
     unbound.observeActive(tab(1))

--- a/extensions/dsh-browser/tests/tab-affinity.spec.ts
+++ b/extensions/dsh-browser/tests/tab-affinity.spec.ts
@@ -53,6 +53,92 @@ describe('TabAffinityController', () => {
     expect(affinity.snapshot().status).toBe('handoff')
   })
 
+  it('stops prompting on later tab switches after keep-always', () => {
+    const affinity = new TabAffinityController()
+    affinity.observeActive(tab(1))
+    affinity.bindInitial(tab(1))
+    affinity.observeActive(tab(2))
+
+    expect(affinity.decide('keep-always', affinity.snapshot().revision)).toBe(true)
+    expect(affinity.snapshot()).toMatchObject({ status: 'background', pinned: true, controlled: { tabId: 1 } })
+
+    affinity.observeActive(tab(3))
+    expect(affinity.snapshot()).toMatchObject({ status: 'background', pinned: true, controlled: { tabId: 1 } })
+    expect(affinity.resolveTarget()).toMatchObject({ kind: 'target', tab: { tabId: 1 } })
+
+    // Returning to the controlled tab and leaving again must still not prompt.
+    affinity.observeActive(tab(1))
+    expect(affinity.snapshot()).toMatchObject({ status: 'following', pinned: true })
+    affinity.observeActive(tab(4))
+    expect(affinity.snapshot().status).toBe('background')
+  })
+
+  it('drops the keep-always pin whenever the binding changes', () => {
+    const followed = new TabAffinityController()
+    followed.observeActive(tab(1))
+    followed.bindInitial(tab(1))
+    followed.observeActive(tab(2))
+    followed.decide('keep-always', followed.snapshot().revision)
+    followed.observeActive(tab(3))
+    expect(followed.decide('follow', followed.snapshot().revision)).toBe(true)
+    expect(followed.snapshot()).toMatchObject({ status: 'following', pinned: false, controlled: { tabId: 3 } })
+    followed.observeActive(tab(5))
+    expect(followed.snapshot().status).toBe('handoff')
+
+    const rebound = new TabAffinityController()
+    rebound.observeActive(tab(1))
+    rebound.bindInitial(tab(1))
+    rebound.observeActive(tab(2))
+    rebound.decide('keep-always', rebound.snapshot().revision)
+    rebound.rebindActive(tab(2))
+    expect(rebound.snapshot().pinned).toBe(false)
+
+    const closed = new TabAffinityController()
+    closed.observeActive(tab(1))
+    closed.bindInitial(tab(1))
+    closed.observeActive(tab(2))
+    closed.decide('keep-always', closed.snapshot().revision)
+    closed.removeTab(1)
+    expect(closed.snapshot()).toMatchObject({ status: 'lost', pinned: false })
+  })
+
+  it('re-raises the prompt when the pin is undone, without rebinding', () => {
+    const affinity = new TabAffinityController()
+    affinity.observeActive(tab(1))
+    affinity.bindInitial(tab(1))
+    affinity.observeActive(tab(2))
+    affinity.decide('keep-always', affinity.snapshot().revision)
+    affinity.observeActive(tab(3))
+
+    const pinned = affinity.snapshot()
+    expect(affinity.decide('ask-again', pinned.revision - 1)).toBe(false)
+    expect(affinity.decide('ask-again', pinned.revision)).toBe(true)
+    expect(affinity.snapshot()).toMatchObject({
+      status: 'handoff',
+      pinned: false,
+      controlled: { tabId: 1 },
+      active: { tabId: 3 },
+    })
+    expect(affinity.resolveTarget()).toEqual({ kind: 'handoff' })
+
+    // Undoing a pin that is not set is a no-op rather than a state change.
+    expect(affinity.decide('ask-again', affinity.snapshot().revision)).toBe(false)
+  })
+
+  it('rejects a keep-always pin that has no controlled tab behind it', () => {
+    const unbound = new TabAffinityController()
+    unbound.observeActive(tab(1))
+    expect(unbound.restorePinned()).toBe(false)
+    expect(unbound.snapshot().pinned).toBe(false)
+
+    const restored = new TabAffinityController()
+    restored.restoreControlled(tab(1))
+    expect(restored.restorePinned()).toBe(true)
+    restored.observeActive(tab(2))
+    expect(restored.snapshot()).toMatchObject({ status: 'background', pinned: true })
+    expect(restored.restorePinned()).toBe(false)
+  })
+
   it('supports explicit rebindActive when starting new chat', () => {
     const affinity = new TabAffinityController()
     affinity.observeActive(tab(1))


### PR DESCRIPTION
## Problem

"Stay on original" is scoped to the one tab the user switched to: `keptActiveTabId` records that tab, so moving to a *third* tab raises the prompt again. Someone who works across several tabs while the assistant holds one page is asked on every switch, with browser actions paused each time until they answer.

## What this adds

A third handoff answer, **"Stay & stop asking"** (`keep-always`), which pins the controlled tab: later switches resolve straight to `background` rather than `handoff`.

The prompt's two primary answers keep equal weight on the first row; the pin option wraps onto its own full-width row beneath them.

## Safety

Pinning never widens what the tools may touch — the target is still exactly the tab the user already approved. The pin is cleared by anything that changes the binding: `follow`, `rebindActive`, `bindInitial`, `bindNewSession`, `focusSession`, or the controlled tab being closed.

It survives an MV3 worker restart through `chrome.storage.session`. `restorePinned()` refuses to apply when no controlled tab was restored, so a stale record can never suppress the prompt for a binding the user has not approved, and it runs *before* `syncActiveTab()` so the sync does not surface a prompt the user already dismissed.

## Reversing a pin

A pin needs a way out that does not move the binding, so `ask-again` reverses it in place and is offered on the pinned banner as **"Ask on tab switch"**. Without it, the only routes back to prompting would be "Follow current page" — which rebinds to a different tab — or starting a new chat.

Dropping `keptActiveTabId` as part of the undo re-raises the prompt for the switch the pin was suppressing, so control stays user-confirmed.

## Other notes

Panel message validation moves to an `isTabAffinityDecision` type guard so the widened union has one place to stay in sync. Copy added in English and Chinese.

## Testing

- `pnpm typecheck` clean; `pnpm test` passes (306 tests), including 4 new controller cases: pinning stops later prompts, every binding change drops the pin, `ask-again` re-raises the prompt without rebinding, and a pin with no controlled tab behind it is rejected.
- Rendered the built panel in Chrome at 400px wide and exercised both the three-option handoff prompt and the pinned banner: no horizontal overflow, and the actions wrap as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013p3bM6qigAEnF51xpEXz2z





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a persistent “Stay & stop asking” tab-affinity choice and an in-place option to resume prompting.
- Persists and restores the pin across service-worker restarts.
- Clears the pin when the controlled-tab binding genuinely changes or is lost.
- Extends panel validation, localized copy, layout, and state-machine tests.
- Preserves the pin when session focus is replayed for the same tab, including after title or URL changes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| extensions/dsh-browser/src/background/tab-affinity.ts | Adds pinned affinity state and correctly preserves it across same-tab session focus while clearing it on actual binding changes. |
| extensions/dsh-browser/src/background/index.ts | Persists, validates, and restores pinned affinity before active-tab synchronization. |
| extensions/dsh-browser/src/panel/App.tsx | Exposes the new pin and undo decisions in the appropriate affinity banner states. |
| extensions/dsh-browser/tests/tab-affinity.spec.ts | Covers pin persistence, reversal, binding changes, restart restoration, and the previously reported session-focus cases. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(tab-affinity): identify the pinned b..."](https://github.com/lum1104/dsh-browser/commit/ea258ae7cd3ef2f8c58522dade4842cd221a671a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58810632)</sub>

**Context used:**

- Knowledge Base — [Navigation, frames, and tab affinity](https://app.greptile.com/yuxiang-lin/-/custom-context/knowledge-base/lum1104/dsh-browser/-/docs/extension-navigation-and-tab-affinity.md)
- Knowledge Base — [Extension background orchestration](https://app.greptile.com/yuxiang-lin/-/custom-context/knowledge-base/lum1104/dsh-browser/-/docs/extension-background-orchestration.md)

<!-- /greptile_comment -->