### PR TITLE
fix(bridge): keep Desktop ask_user_question on native waterfall

### DIFF
--- a/packages/browser/bridge-browser/package.json
+++ b/packages/browser/bridge-browser/package.json
@@ -40,13 +40,13 @@
   ],
   "peerDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
-    "@deepseek-ai/dsh-agent": "^0.1.1-rc.1",
-    "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1",
-    "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.1",
-    "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1",
-    "@deepseek-ai/dsh-llm": "^0.1.1-rc.1",
-    "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1",
-    "@deepseek-ai/dsh-tools": "^0.1.1-rc.1"
+    "@deepseek-ai/dsh-agent": "^0.1.1-rc.1 || ^0.1.2-alpha.0",
+    "@deepseek-ai/dsh-attachment": "^0.1.1-rc.1 || ^0.1.2-alpha.0",
+    "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.1 || ^0.1.2-alpha.0",
+    "@deepseek-ai/dsh-invariants": "^0.1.1-rc.1 || ^0.1.2-alpha.0",
+    "@deepseek-ai/dsh-llm": "^0.1.1-rc.1 || ^0.1.2-alpha.0",
+    "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.1 || ^0.1.2-alpha.0",
+    "@deepseek-ai/dsh-tools": "^0.1.1-rc.1 || ^0.1.2-alpha.0"
   },
   "dependencies": {
     "@deepseek-ai/schemastery": "^3.18.1",

--- a/packages/browser/bridge-browser/src/extension-sessions.ts
+++ b/packages/browser/bridge-browser/src/extension-sessions.ts
@@ -1,0 +1,40 @@
+/**
+ * Track session ids that the browser extension has driven through the bridge.
+ * Desktop-native sessions must keep the host userQuestions waterfall so the
+ * Desktop UI can render ask_user_question cards.
+ * @module @yuxianglin/dsh-bridge-browser/src/extension-sessions
+ */
+
+/** Mutable registry of extension-owned session ids. */
+export class ExtensionSessionRegistry {
+  private readonly ids = new Set<string>()
+
+  /** Remember a session the extension successfully created or prompted. */
+  note(sessionId: string | undefined): void {
+    if (typeof sessionId === 'string' && sessionId.length > 0) this.ids.add(sessionId)
+  }
+
+  /** Whether the extension has touched this session over the bridge. */
+  has(sessionId: string | undefined): boolean {
+    return typeof sessionId === 'string' && this.ids.has(sessionId)
+  }
+
+  /** Test helper: drop all tracked ids. */
+  clear(): void {
+    this.ids.clear()
+  }
+}
+
+/**
+ * Decide whether the bridge should own ask_user_question for this request.
+ * Desktop sessions must fall through to the native answerer waterfall.
+ */
+export function shouldBridgeOwnQuestion(input: {
+  hasExtensionConnection: boolean
+  sessionId: string | undefined
+  extensionSessions: Pick<ExtensionSessionRegistry, 'has'>
+}): boolean {
+  return input.hasExtensionConnection
+    && input.sessionId !== undefined
+    && input.extensionSessions.has(input.sessionId)
+}

--- a/packages/browser/bridge-browser/src/remote-host-api.ts
+++ b/packages/browser/bridge-browser/src/remote-host-api.ts
@@ -17,6 +17,10 @@ import type {
   HostRpcResult,
 } from './host-api.ts'
 import { hostFailure, isRecord } from './host-api.ts'
+import {
+  ExtensionSessionRegistry,
+  shouldBridgeOwnQuestion,
+} from './extension-sessions.ts'
 import type { RespondResult } from './protocol.ts'
 
 /** Structural subset of dsh 0.1.2's Host TypertGateway service. */
@@ -68,6 +72,7 @@ export function createRemoteHostApi(
 
 class RemoteHostApi implements BrowserHostApi {
   private readonly fetchHandler: ReturnType<HostConnectionLike['createSharedFetchHandler']>
+  private readonly extensionSessions = new ExtensionSessionRegistry()
   private activeEvents: EventGeneration | undefined
 
   constructor(
@@ -98,6 +103,14 @@ class RemoteHostApi implements BrowserHostApi {
         args: target.args,
         signal: call.signal,
       })
+      // Only claim ownership after a successful create/prompt. A failed prompt
+      // against a Desktop session must not steal later ask_user_question away
+      // from the native waterfall.
+      if (call.method === 'session.create' || call.method === 'session.prompt') {
+        this.extensionSessions.note(sessionIdOf(call.payload))
+        this.extensionSessions.note(sessionIdOf(value))
+        if (typeof value === 'string') this.extensionSessions.note(value)
+      }
       return { ok: true, value: target.adapt?.(value) ?? value }
     } catch (error: unknown) {
       return { ok: false, error: this.failure(error) }
@@ -108,6 +121,7 @@ class RemoteHostApi implements BrowserHostApi {
     const generation = new EventGeneration(
       this.gateway,
       this.sendRemoteEventResult.bind(this),
+      this.extensionSessions,
       signal,
     )
     const previous = this.activeEvents
@@ -245,6 +259,7 @@ class EventGeneration {
   constructor(
     private readonly gateway: TypertGatewayLike,
     private readonly sendResult: SendRemoteEventResult,
+    private readonly extensionSessions: ExtensionSessionRegistry,
     outerSignal: AbortSignal,
   ) {
     this.signal = AbortSignal.any([outerSignal, this.lifetime.signal])
@@ -412,6 +427,19 @@ class EventGeneration {
       throw new TypeError('$events emitted an invalid waterfall frame')
     }
     if (value.event !== 'user-questions/request' || !Array.isArray(value.request.questions)) {
+      const clientId = this.clientId
+      if (clientId !== undefined) {
+        await this.sendResult(clientId, value.eventId, { kind: 'next' }, this.signal)
+      }
+      return
+    }
+    // Desktop-owned sessions keep the native waterfall. Only forward questions
+    // for sessions the extension successfully created or prompted.
+    if (!shouldBridgeOwnQuestion({
+      hasExtensionConnection: true,
+      sessionId: value.agentId,
+      extensionSessions: this.extensionSessions,
+    })) {
       const clientId = this.clientId
       if (clientId !== undefined) {
         await this.sendResult(clientId, value.eventId, { kind: 'next' }, this.signal)

--- a/packages/browser/bridge-browser/tests/extension-sessions.spec.ts
+++ b/packages/browser/bridge-browser/tests/extension-sessions.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { ExtensionSessionRegistry, shouldBridgeOwnQuestion } from '../src/extension-sessions.ts'
+
+describe('ExtensionSessionRegistry', () => {
+  it('tracks non-empty session ids only', () => {
+    const registry = new ExtensionSessionRegistry()
+    registry.note(undefined)
+    registry.note('')
+    registry.note('session-1')
+    expect(registry.has(undefined)).toBe(false)
+    expect(registry.has('')).toBe(false)
+    expect(registry.has('session-1')).toBe(true)
+    expect(registry.has('other')).toBe(false)
+  })
+})
+
+describe('shouldBridgeOwnQuestion', () => {
+  it('leaves Desktop sessions to the native waterfall', () => {
+    const extensionSessions = new ExtensionSessionRegistry()
+    expect(shouldBridgeOwnQuestion({
+      hasExtensionConnection: true,
+      sessionId: 'desktop-session',
+      extensionSessions,
+    })).toBe(false)
+  })
+
+  it('owns questions only for extension-driven sessions while connected', () => {
+    const extensionSessions = new ExtensionSessionRegistry()
+    extensionSessions.note('ext-session')
+    expect(shouldBridgeOwnQuestion({
+      hasExtensionConnection: true,
+      sessionId: 'ext-session',
+      extensionSessions,
+    })).toBe(true)
+    expect(shouldBridgeOwnQuestion({
+      hasExtensionConnection: false,
+      sessionId: 'ext-session',
+      extensionSessions,
+    })).toBe(false)
+    expect(shouldBridgeOwnQuestion({
+      hasExtensionConnection: true,
+      sessionId: undefined,
+      extensionSessions,
+    })).toBe(false)
+  })
+})

--- a/packages/browser/bridge-browser/tests/remote-host-api.spec.ts
+++ b/packages/browser/bridge-browser/tests/remote-host-api.spec.ts
@@ -201,6 +201,14 @@ describe('dsh 0.1.2 Remote Host adapter', () => {
     let releaseCancel: (() => void) | undefined
     const { api, fetch } = harness({
       open: async (endpoint, _payload, signal) => {
+        if (endpoint === 'session/follow') {
+          return {
+            async *[Symbol.asyncIterator]() {
+              yield { type: 'snapshot', records: [], hasMore: false }
+              await abortWait(signal)
+            },
+          }
+        }
         if (endpoint !== '$events') throw new Error(endpoint)
         return {
           async *[Symbol.asyncIterator]() {
@@ -219,6 +227,13 @@ describe('dsh 0.1.2 Remote Host adapter', () => {
         }
       },
     })
+    // Extension ownership is claimed only after a successful prompt/create.
+    await expect(api.call(call('session.prompt', {
+      sessionId: 'session-1',
+      mode: 'queue',
+      content: [],
+    }, 'prompt-id'))).resolves.toEqual({ ok: true, value: { accepted: true } })
+
     const abort = new AbortController()
     const events = api.events(abort.signal)[Symbol.asyncIterator]()
 
@@ -269,6 +284,87 @@ describe('dsh 0.1.2 Remote Host adapter', () => {
     })
     abort.abort()
     await events.return?.()
+  })
+
+  it('declines Desktop user-question waterfalls so the native UI can answer', async () => {
+    const { api, fetch } = harness({
+      open: async (endpoint, _payload, signal) => {
+        if (endpoint !== '$events') throw new Error(endpoint)
+        return {
+          async *[Symbol.asyncIterator]() {
+            yield { type: 'ready', clientId: 'client-desktop', host: { home: '/home/test' } }
+            yield {
+              type: 'waterfall',
+              event: 'user-questions/request',
+              eventId: 'question-desktop',
+              agentId: 'desktop-session',
+              request: { questions: [{ id: 'db', question: 'Database?' }] },
+            }
+            await abortWait(signal)
+          },
+        }
+      },
+    })
+
+    const abort = new AbortController()
+    const iterator = api.events(abort.signal)[Symbol.asyncIterator]()
+    const pending = iterator.next()
+    await vi.waitFor(() => { expect(fetch).toHaveBeenCalledOnce() })
+    expect(await (fetch.mock.calls[0]?.[0] as Request).clone().json()).toMatchObject({
+      payload: { args: { eventId: 'question-desktop', outcome: { kind: 'next' } } },
+    })
+    abort.abort()
+    await expect(pending).resolves.toEqual({ done: true, value: undefined })
+  })
+
+  it('does not claim session ownership when prompt fails', async () => {
+    const error = Object.assign(new Error('rejected'), { code: 'bad-request', details: {} })
+    const { api, fetch } = harness({
+      invoke: async () => { throw error },
+      open: async (endpoint, _payload, signal) => {
+        if (endpoint === 'session/follow') {
+          return {
+            async *[Symbol.asyncIterator]() {
+              yield { type: 'snapshot', records: [], hasMore: false }
+              await abortWait(signal)
+            },
+          }
+        }
+        if (endpoint !== '$events') throw new Error(endpoint)
+        return {
+          async *[Symbol.asyncIterator]() {
+            yield { type: 'ready', clientId: 'client-fail', host: { home: '/home/test' } }
+            yield {
+              type: 'waterfall',
+              event: 'user-questions/request',
+              eventId: 'question-fail',
+              agentId: 'session-fail',
+              request: { questions: [{ id: 'db', question: 'Database?' }] },
+            }
+            await abortWait(signal)
+          },
+        }
+      },
+    })
+
+    await expect(api.call(call('session.prompt', {
+      sessionId: 'session-fail',
+      mode: 'queue',
+      content: [],
+    }))).resolves.toEqual({
+      ok: false,
+      error: { code: 'bad-request', message: 'rejected', details: {} },
+    })
+
+    const abort = new AbortController()
+    const iterator = api.events(abort.signal)[Symbol.asyncIterator]()
+    const pending = iterator.next()
+    await vi.waitFor(() => { expect(fetch).toHaveBeenCalledOnce() })
+    expect(await (fetch.mock.calls[0]?.[0] as Request).clone().json()).toMatchObject({
+      payload: { args: { eventId: 'question-fail', outcome: { kind: 'next' } } },
+    })
+    abort.abort()
+    await expect(pending).resolves.toEqual({ done: true, value: undefined })
   })
 
   it('delegates unhandled waterfalls and preserves Gateway failure fields', async () => {


### PR DESCRIPTION
## Summary
- On the 0.1.2 remotes migration, every `user-questions` waterfall was forwarded to the connected extension, which stole Desktop-owned sessions away from the native option UI whenever the bridge was online.
- Claim session ownership only after a successful extension `create`/`prompt`, and decline unrelated waterfalls with `next` so Desktop can answer them.
- Widen peer ranges to accept `0.1.2-alpha` Desktop hosts.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents the browser bridge from claiming Desktop-owned user-question waterfalls while retaining extension ownership after successful session creation or prompting.
- Adds a registry of extension-driven session IDs.
- Delegates unrelated user-question waterfalls to the Desktop native handler with a `next` outcome.
- Adds ownership and failed-prompt coverage.
- Expands peer dependency ranges for 0.1.2 alpha hosts.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issues established.

The ownership registry is updated only after successful extension RPCs, and the new waterfall branch preserves Desktop handling for sessions absent from that registry; the added tests cover the principal success and failure paths.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/browser/bridge-browser/src/extension-sessions.ts | Adds a focused in-memory registry and ownership predicate for distinguishing extension-driven sessions. |
| packages/browser/bridge-browser/src/remote-host-api.ts | Records session ownership after successful create or prompt calls and delegates unowned user-question waterfalls to Desktop. |
| packages/browser/bridge-browser/tests/remote-host-api.spec.ts | Covers extension ownership, Desktop delegation, and the failed-prompt path. |
| packages/browser/bridge-browser/package.json | Broadens DSH peer dependency compatibility to include the 0.1.2 alpha line. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Ext as Browser extension
    participant Bridge as RemoteHostApi
    participant Host as Desktop host
    participant UI as Desktop native UI
    Ext->>Bridge: session.create / session.prompt
    Bridge->>Host: invoke RPC
    Host-->>Bridge: successful result
    Bridge->>Bridge: record session ID
    Host->>Bridge: user-questions/request
    alt Recorded extension session
        Bridge-->>Ext: question/requested
    else Unrecorded Desktop session
        Bridge->>Host: event result: next
        Host-->>UI: continue native waterfall
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(bridge): keep Desktop ask\_user\_quest..."](https://github.com/lum1104/dsh-browser/commit/fa9d7e1967a16ca69bde4ab5abce48c924912b8a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59588961)</sub>

<!-- /greptile_comment -->