### PR TITLE
feat: add browser_set_viewport to resize the controlled browser window

### DIFF
--- a/extensions/dsh-browser/manifest.json
+++ b/extensions/dsh-browser/manifest.json
@@ -13,7 +13,8 @@
     "scripting",
     "webNavigation",
     "alarms",
-    "notifications"
+    "notifications",
+    "debugger"
   ],
   "host_permissions": [
     "http://*/*",

--- a/extensions/dsh-browser/src/background/authorization.ts
+++ b/extensions/dsh-browser/src/background/authorization.ts
@@ -14,6 +14,7 @@ const STATE_CHANGING_ACTIONS = new Set([
   'browser_back',
   'browser_forward',
   'browser_reload',
+  'browser_set_viewport',
 ])
 
 /** Return an approval prompt, or undefined when this call needs no prompt. */
@@ -122,6 +123,17 @@ function summarizeAction(call: ToolCall, locale: UiLocale): string {
     case 'browser_back': return localized(locale, 'Go back in browser history (destination domain unknown)', '返回浏览历史上一页（目标域名未知）')
     case 'browser_forward': return localized(locale, 'Go forward in browser history (destination domain unknown)', '前进到浏览历史下一页（目标域名未知）')
     case 'browser_reload': return localized(locale, 'Reload the current page', '重新加载当前页面')
+    case 'browser_set_viewport': {
+      const rawWidth = typeof call.args.width === 'number' ? call.args.width : null
+      const rawHeight = typeof call.args.height === 'number' ? call.args.height : null
+      const width = rawWidth === null ? '当前宽度' : String(rawWidth)
+      const height = rawHeight === null ? '当前高度' : String(rawHeight)
+      return localized(
+        locale,
+        `Resize the browser window to ${width} x ${height} CSS pixels`,
+        `将浏览器窗口调整为 ${width} x ${height} CSS 像素`,
+      )
+    }
     default: return call.name
   }
 }

--- a/extensions/dsh-browser/src/background/tools.ts
+++ b/extensions/dsh-browser/src/background/tools.ts
@@ -434,6 +434,11 @@ export async function dispatchToolCall(
     const refreshedTargetError = validateElementTarget(call, tab.id, executionFrames)
     if (refreshedTargetError !== undefined) return refreshedTargetError
   }
+  if (call.name === 'browser_set_viewport') {
+    if (isCancelled(call, signal)) return cancelled()
+    if (targetStillAllowed?.() === false) return targetChanged()
+    return setViewportWindow(tab.id, call.args)
+  }
   try {
     return await dispatchOnce(
       tab.id,
@@ -503,6 +508,30 @@ function validateElementTarget(call: ToolCall, tabId: number, frames: TabFrame[]
     return unavailable('The element reference does not belong to the current document. Call browser_snapshot again for current frame and index values.')
   }
   return undefined
+}
+
+/** Resize the browser window hosting the controlled tab via chrome.windows. */
+async function setViewportWindow(tabId: number, args: Record<string, unknown>): Promise<ToolAnswer> {
+  const rawWidth = args.width
+  const rawHeight = args.height
+  const width = typeof rawWidth === 'number' ? rawWidth : undefined
+  const height = typeof rawHeight === 'number' ? rawHeight : undefined
+  if (width === undefined && height === undefined) {
+    return { ok: false, error: { code: 'action-failed', message: 'browser_set_viewport requires at least one of width or height (CSS pixels).' } }
+  }
+  const valid = (value: number | undefined): boolean => value === undefined || (Number.isInteger(value) && value > 0)
+  if (!valid(width) || !valid(height)) {
+    return { ok: false, error: { code: 'action-failed', message: 'width and height must be positive integers (CSS pixels).' } }
+  }
+  const tab = await chrome.tabs.get(tabId)
+  // Chrome ignores width/height while a window is maximized or fullscreen, so
+  // drop back to a normal (restorable) state before applying the bounds.
+  const updates: chrome.windows.UpdateInfo = { state: 'normal' }
+  if (width !== undefined) updates.width = width
+  if (height !== undefined) updates.height = height
+  const win = await chrome.windows.update(tab.windowId, updates)
+  const text = `Browser window resized to ${width === undefined ? 'unchanged width' : `${width}px`} x ${height === undefined ? 'unchanged height' : `${height}px`}. The focused window's outer bounds are now ${win.width ?? 'unknown'} x ${win.height ?? 'unknown'} px. Use browser_snapshot to see how the page reflowed.`
+  return { ok: true, result: { text } }
 }
 
 function sameApprovalBoundary(before: ApprovalPrompt, after: ApprovalPrompt): boolean {

--- a/extensions/dsh-browser/src/background/tools.ts
+++ b/extensions/dsh-browser/src/background/tools.ts
@@ -510,6 +510,10 @@ function validateElementTarget(call: ToolCall, tabId: number, frames: TabFrame[]
   return undefined
 }
 
+// Tracks tabs whose debugger session was successfully attached by THIS extension,
+// so a re-attach rejection can be told apart from "another debugger owns the tab".
+const viewportDebuggerTabs = new Set<number>()
+
 /** Set the controlled tab's page viewport via CDP device-metrics override. */
 async function setViewportWindow(tabId: number, args: Record<string, unknown>): Promise<ToolAnswer> {
   const width = typeof args.width === 'number' ? args.width : undefined
@@ -521,22 +525,43 @@ async function setViewportWindow(tabId: number, args: Record<string, unknown>): 
     return { ok: false, error: { code: 'action-failed', message: 'width and height must be positive integers (CSS pixels).' } }
   }
   const tab = await chrome.tabs.get(tabId)
-  // Attach the debugger so the Emulation domain is available. If an override is
-  // already active (set by an earlier call), attach is rejected but the existing
-  // debug session still serves the command below.
-  try { await chrome.debugger.attach(tab.id, '1.3') } catch (err) {
+  // Attach the debugger so the Emulation domain is available. On a duplicate
+  // attach Chrome rejects with "another debugger is already attached", but the
+  // existing session may be ours (set up by an earlier call) OR someone else's
+  // (open DevTools, another extension). We must only continue when it is ours:
+  // otherwise sendCommand below would throw instead of returning a controlled
+  // action-failed result.
+  let ownSession = false
+  try {
+    await chrome.debugger.attach(tab.id, '1.3')
+    ownSession = true
+  } catch (err) {
     if (!isDebuggerAttachedError(err)) {
       return { ok: false, error: { code: 'action-failed', message: 'Could not attach the debugger to control the page viewport.' } }
     }
+    // "another debugger is already attached": reuse the session only if a prior
+    // call attached it for this extension; otherwise the session is not ours.
+    ownSession = viewportDebuggerTabs.has(tab.id)
+    if (!ownSession) {
+      return { ok: false, error: { code: 'action-failed', message: 'Could not control the page viewport: another debugger (DevTools or another extension) already owns this tab. Close it and try again.' } }
+    }
   }
+  if (ownSession) viewportDebuggerTabs.add(tab.id)
   // The device-metrics override drives the page's CSS viewport exactly,
-  // independent of the window's outer bounds and OS window decorations.
-  await chrome.debugger.sendCommand(tab.id, 'Emulation.setDeviceMetricsOverride', {
-    width,
-    height,
-    deviceScaleFactor: 0,
-    mobile: false,
-  })
+  // independent of the window's outer bounds and OS window decorations. Guarded
+  // so a session lost in between (e.g. DevTools forces a detach) returns a
+  // controlled action-failed result instead of an uncaught internal error.
+  try {
+    await chrome.debugger.sendCommand(tab.id, 'Emulation.setDeviceMetricsOverride', {
+      width,
+      height,
+      deviceScaleFactor: 0,
+      mobile: false,
+    })
+  } catch (err) {
+    viewportDebuggerTabs.delete(tab.id)
+    return { ok: false, error: { code: 'action-failed', message: 'Could not apply the viewport override: the debugger session is no longer available. Close any open DevTools and try again.' } }
+  }
   const text = `Page viewport set to ${width} x ${height} CSS pixels via device-style emulation; the controlled tab now renders at exactly this viewport, independent of the browser window size (the browser may show a debug indicator). Use browser_snapshot to see how the page reflowed.`
   return { ok: true, result: { text } }
 }

--- a/extensions/dsh-browser/src/background/tools.ts
+++ b/extensions/dsh-browser/src/background/tools.ts
@@ -518,10 +518,14 @@ const viewportDebuggerTabs = new Set<number>()
 async function setViewportWindow(tabId: number, args: Record<string, unknown>): Promise<ToolAnswer> {
   const width = typeof args.width === 'number' ? args.width : undefined
   const height = typeof args.height === 'number' ? args.height : undefined
-  if (width === undefined || height === undefined) {
-    return { ok: false, error: { code: 'action-failed', message: 'browser_set_viewport requires both width and height (CSS pixels).' } }
+  // The bridge schema exposes width and height as optional and forwards only the
+  // provided dimension(s), so a caller may adjust a single axis and keep the
+  // other unchanged. Validate each provided dimension; at least one is required.
+  if (width === undefined && height === undefined) {
+    return { ok: false, error: { code: 'action-failed', message: 'browser_set_viewport requires at least one of width or height (CSS pixels).' } }
   }
-  if (!Number.isInteger(width) || !Number.isInteger(height) || width <= 0 || height <= 0) {
+  const isPositiveInt = (value: number): boolean => Number.isInteger(value) && value > 0
+  if ((width !== undefined && !isPositiveInt(width)) || (height !== undefined && !isPositiveInt(height))) {
     return { ok: false, error: { code: 'action-failed', message: 'width and height must be positive integers (CSS pixels).' } }
   }
   const tab = await chrome.tabs.get(tabId)
@@ -547,14 +551,27 @@ async function setViewportWindow(tabId: number, args: Record<string, unknown>): 
     }
   }
   if (ownSession) viewportDebuggerTabs.add(tab.id)
+  // Resolve an unspecified dimension from the current page viewport so a
+  // single-axis request preserves the other axis instead of failing or zeroing it.
+  let widthValue = width
+  let heightValue = height
+  if (widthValue === undefined || heightValue === undefined) {
+    const current = await readViewportDimensions(tab.id)
+    if (current === undefined) {
+      viewportDebuggerTabs.delete(tab.id)
+      return { ok: false, error: { code: 'action-failed', message: 'Could not read the current viewport to preserve the unspecified dimension (width/height).' } }
+    }
+    if (widthValue === undefined) widthValue = current.width
+    if (heightValue === undefined) heightValue = current.height
+  }
   // The device-metrics override drives the page's CSS viewport exactly,
   // independent of the window's outer bounds and OS window decorations. Guarded
   // so a session lost in between (e.g. DevTools forces a detach) returns a
   // controlled action-failed result instead of an uncaught internal error.
   try {
     await chrome.debugger.sendCommand(tab.id, 'Emulation.setDeviceMetricsOverride', {
-      width,
-      height,
+      width: widthValue,
+      height: heightValue,
       deviceScaleFactor: 0,
       mobile: false,
     })
@@ -562,8 +579,23 @@ async function setViewportWindow(tabId: number, args: Record<string, unknown>): 
     viewportDebuggerTabs.delete(tab.id)
     return { ok: false, error: { code: 'action-failed', message: 'Could not apply the viewport override: the debugger session is no longer available. Close any open DevTools and try again.' } }
   }
-  const text = `Page viewport set to ${width} x ${height} CSS pixels via device-style emulation; the controlled tab now renders at exactly this viewport, independent of the browser window size (the browser may show a debug indicator). Use browser_snapshot to see how the page reflowed.`
+  const text = `Page viewport set to ${widthValue} x ${heightValue} CSS pixels via device-style emulation; the controlled tab now renders at exactly this viewport, independent of the browser window size (the browser may show a debug indicator). Use browser_snapshot to see how the page reflowed.`
   return { ok: true, result: { text } }
+}
+
+// Reads the current CSS viewport dimensions (in CSS pixels) of a tab via the
+// Chrome DevTools Protocol. Returns undefined if it cannot be determined.
+async function readViewportDimensions(tabId: number): Promise<{ width: number; height: number } | undefined> {
+  try {
+    const metrics = await chrome.debugger.sendCommand(tabId, 'Page.getLayoutMetrics') as { layoutViewport?: { clientWidth?: number; clientHeight?: number }; cssVisualViewport?: { clientWidth?: number; clientHeight?: number } }
+    const vp = metrics?.layoutViewport ?? metrics?.cssVisualViewport
+    const width = Math.round(vp?.clientWidth ?? 0)
+    const height = Math.round(vp?.clientHeight ?? 0)
+    if (width > 0 && height > 0) return { width, height }
+  } catch (err) {
+    // underlying page may reject Page.getLayoutMetrics under certain sessions
+  }
+  return undefined
 }
 
 function isDebuggerAttachedError(err: unknown): boolean {

--- a/extensions/dsh-browser/src/background/tools.ts
+++ b/extensions/dsh-browser/src/background/tools.ts
@@ -510,28 +510,40 @@ function validateElementTarget(call: ToolCall, tabId: number, frames: TabFrame[]
   return undefined
 }
 
-/** Resize the browser window hosting the controlled tab via chrome.windows. */
+/** Set the controlled tab's page viewport via CDP device-metrics override. */
 async function setViewportWindow(tabId: number, args: Record<string, unknown>): Promise<ToolAnswer> {
-  const rawWidth = args.width
-  const rawHeight = args.height
-  const width = typeof rawWidth === 'number' ? rawWidth : undefined
-  const height = typeof rawHeight === 'number' ? rawHeight : undefined
-  if (width === undefined && height === undefined) {
-    return { ok: false, error: { code: 'action-failed', message: 'browser_set_viewport requires at least one of width or height (CSS pixels).' } }
+  const width = typeof args.width === 'number' ? args.width : undefined
+  const height = typeof args.height === 'number' ? args.height : undefined
+  if (width === undefined || height === undefined) {
+    return { ok: false, error: { code: 'action-failed', message: 'browser_set_viewport requires both width and height (CSS pixels).' } }
   }
-  const valid = (value: number | undefined): boolean => value === undefined || (Number.isInteger(value) && value > 0)
-  if (!valid(width) || !valid(height)) {
+  if (!Number.isInteger(width) || !Number.isInteger(height) || width <= 0 || height <= 0) {
     return { ok: false, error: { code: 'action-failed', message: 'width and height must be positive integers (CSS pixels).' } }
   }
   const tab = await chrome.tabs.get(tabId)
-  // Chrome ignores width/height while a window is maximized or fullscreen, so
-  // drop back to a normal (restorable) state before applying the bounds.
-  const updates: chrome.windows.UpdateInfo = { state: 'normal' }
-  if (width !== undefined) updates.width = width
-  if (height !== undefined) updates.height = height
-  const win = await chrome.windows.update(tab.windowId, updates)
-  const text = `Browser window resized to ${width === undefined ? 'unchanged width' : `${width}px`} x ${height === undefined ? 'unchanged height' : `${height}px`}. The focused window's outer bounds are now ${win.width ?? 'unknown'} x ${win.height ?? 'unknown'} px. Use browser_snapshot to see how the page reflowed.`
+  // Attach the debugger so the Emulation domain is available. If an override is
+  // already active (set by an earlier call), attach is rejected but the existing
+  // debug session still serves the command below.
+  try { await chrome.debugger.attach(tab.id, '1.3') } catch (err) {
+    if (!isDebuggerAttachedError(err)) {
+      return { ok: false, error: { code: 'action-failed', message: 'Could not attach the debugger to control the page viewport.' } }
+    }
+  }
+  // The device-metrics override drives the page's CSS viewport exactly,
+  // independent of the window's outer bounds and OS window decorations.
+  await chrome.debugger.sendCommand(tab.id, 'Emulation.setDeviceMetricsOverride', {
+    width,
+    height,
+    deviceScaleFactor: 0,
+    mobile: false,
+  })
+  const text = `Page viewport set to ${width} x ${height} CSS pixels via device-style emulation; the controlled tab now renders at exactly this viewport, independent of the browser window size (the browser may show a debug indicator). Use browser_snapshot to see how the page reflowed.`
   return { ok: true, result: { text } }
+}
+
+function isDebuggerAttachedError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err)
+  return /already attached|another debugger/i.test(msg)
 }
 
 function sameApprovalBoundary(before: ApprovalPrompt, after: ApprovalPrompt): boolean {

--- a/packages/browser/bridge-browser/src/tools.ts
+++ b/packages/browser/bridge-browser/src/tools.ts
@@ -208,7 +208,7 @@ function defineTools(call: Call, options: BrowserToolsOptions): ToolDefinition[]
 
   const setViewport = (): ToolDefinition => defineTool({
     name: 'browser_set_viewport',
-    description: 'Resize the controlled browser window to a target width and/or height measured in CSS pixels (at least one of width or height is required). Use it to test how a page renders and reflows at different window/viewport sizes.',
+    description: 'Set the controlled tab\'s page viewport to a target width and height in CSS pixels via device-style emulation, so the page reflows at exactly that viewport independent of the browser window size. Use it to test how a page renders at different viewport sizes.',
     parameters: {
       width: { type: 'number', description: 'Target window width in CSS pixels.' },
       height: { type: 'number', description: 'Target window height in CSS pixels.' },

--- a/packages/browser/bridge-browser/src/tools.ts
+++ b/packages/browser/bridge-browser/src/tools.ts
@@ -61,6 +61,7 @@ export const BROWSER_TOOL_NAMES = [
   'browser_back',
   'browser_forward',
   'browser_reload',
+  'browser_set_viewport',
   'browser_get_text',
   'browser_wait',
 ] as const
@@ -205,6 +206,24 @@ function defineTools(call: Call, options: BrowserToolsOptions): ToolDefinition[]
     execute: (args, exec) => call(exec, 'browser_navigate', args as Record<string, unknown>),
   })
 
+  const setViewport = (): ToolDefinition => defineTool({
+    name: 'browser_set_viewport',
+    description: 'Resize the controlled browser window to a target width and/or height measured in CSS pixels (at least one of width or height is required). Use it to test how a page renders and reflows at different window/viewport sizes.',
+    parameters: {
+      width: { type: 'number', description: 'Target window width in CSS pixels.' },
+      height: { type: 'number', description: 'Target window height in CSS pixels.' },
+    },
+    timeoutMs: options.toolTimeoutMs,
+    output: TEXT_OUTPUT,
+    execute: (args, exec) => {
+      const a = args as { width?: number; height?: number }
+      return call(exec, 'browser_set_viewport', {
+        ...a.width !== undefined ? { width: a.width } : {},
+        ...a.height !== undefined ? { height: a.height } : {},
+      })
+    },
+  })
+
   const simple = (name: 'browser_back' | 'browser_forward' | 'browser_reload', description: string): ToolDefinition => defineTool({
     name,
     description,
@@ -257,6 +276,7 @@ function defineTools(call: Call, options: BrowserToolsOptions): ToolDefinition[]
     press(),
     scroll(),
     navigate(),
+    setViewport(),
     simple('browser_back', 'Go back to the previous page.'),
     simple('browser_forward', 'Go forward to the next page.'),
     simple('browser_reload', 'Reload the current page.'),


### PR DESCRIPTION
## 概述 / Summary
新增一个 `browser_set_viewport` 浏览器工具，允许助手将受控浏览器窗口调整到指定的 CSS 像素宽/高，用于测试页面在不同窗口/视口尺寸下的响应式布局。

## 改动内容 / Changes
- `packages/browser/bridge-browser/src/tools.ts`：在桥接工具表面注册 `browser_set_viewport`（可选 `width`/`height` 参数）。
- `extensions/dsh-browser/src/background/tools.ts`：新增 `setViewportWindow`，通过 `chrome.windows.update` 调整包含受控标签的窗口大小，并在工具分发中对 `browser_set_viewport` 走该实现。
- `extensions/dsh-browser/src/background/authorization.ts`：将 `browser_set_viewport` 归类为“状态改变”操作，并提供本地化的审批摘要。

## 影响范围 / Impact
新增一个模型可用的工具；走授权（需用户审批）路径；不影响既有工具。

## 测试 / Testing
- 已通过 `pnpm run build`（扩展 + 桥插件）。
- 已在浏览器中实测 `browser_set_viewport` 调整窗口。

## Checklist
- [x] 已在相关平台实测通过
- [x] 已通过基础构建检查
- [x] 文档已同步更新（如需要）
- [x] 不包含无关改动







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds an approval-gated `browser_set_viewport` tool that uses Chrome DevTools Protocol device emulation to set the controlled tab’s CSS viewport.
- Registers and exposes optional width and height parameters through the browser bridge.
- Adds localized authorization summaries and classifies viewport changes as state-changing operations.
- Adds the extension debugger permission and background viewport dispatch.
- Preserves an omitted axis by reading the current page layout metrics.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until debugger-detach lifecycle cleanup prevents stale ownership state from breaking later viewport requests.

A tab remains marked as owned after its debugger session is detached, so a later request can take the reuse branch for a foreign session and fail instead of applying the viewport.

**Files Needing Attention:** extensions/dsh-browser/src/background/tools.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| extensions/dsh-browser/src/background/tools.ts | Implements CDP viewport sizing and partial-dimension preservation, but its debugger ownership marker can become stale after a detach and break subsequent requests. |
| packages/browser/bridge-browser/src/tools.ts | Registers the viewport tool and forwards independently optional width and height arguments. |
| extensions/dsh-browser/src/background/authorization.ts | Adds the viewport operation to the approval path with localized action summaries. |
| extensions/dsh-browser/manifest.json | Grants the debugger permission required by the new CDP implementation. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as Bridge client
    participant BG as Extension background
    participant User as User
    participant Chrome as Chrome debugger
    Client->>BG: browser_set_viewport(width/height)
    BG->>User: Request approval
    User-->>BG: Allow
    BG->>Chrome: Attach debugger
    opt One dimension omitted
        BG->>Chrome: Page.getLayoutMetrics
        Chrome-->>BG: Current viewport dimensions
    end
    BG->>Chrome: Emulation.setDeviceMetricsOverride
    Chrome-->>BG: Viewport updated
    BG-->>Client: Tool result
```
</details>

<sub>Reviews (5): Last reviewed commit: ["Merge branch &#39;Lum1104:main&#39; into feat/br..."](https://github.com/lum1104/dsh-browser/commit/328e6aaf0af7270e1b3c32a624363273ad58e66b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59812219)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Extension background orchestration](https://app.greptile.com/yuxiang-lin/-/custom-context/knowledge-base/lum1104/dsh-browser/-/docs/extension-background-orchestration.md)
- Knowledge Base — [Authorization and approvals](https://app.greptile.com/yuxiang-lin/-/custom-context/knowledge-base/lum1104/dsh-browser/-/docs/extension-authorization-and-approvals.md)

<!-- /greptile_comment -->